### PR TITLE
Implement idle based sleep transitions

### DIFF
--- a/config/config.sample.toml
+++ b/config/config.sample.toml
@@ -58,10 +58,17 @@ hotkey = "Super+V"
 type = "sway"
 
 [sleep]
-# Idle timeout in seconds before the sleep action fires. Must be > 0.
-idle_timeout_secs = 300
 # Whether to suspend the machine (true) or just deactivate (false).
 suspend = false
+
+# ---- Idle-based auto-sleep ----
+# Minutes of no user interaction after which the daemon drops Active → Drowsy
+# (model weights unloaded, server stays alive). 0 disables this transition.
+# idle_to_drowsy_mins = 30
+# Minutes of no user interaction after which the daemon drops to Sleeping
+# (llama-server stopped, all VRAM freed). Must be greater than
+# idle_to_drowsy_mins when both are non-zero. 0 disables this transition.
+# idle_to_sleep_mins = 120
 
 # ---- GPU contention monitor ----
 # Background NVML poller that transitions the daemon to Sleeping when another

--- a/crates/assistd-core/src/config.rs
+++ b/crates/assistd-core/src/config.rs
@@ -104,8 +104,17 @@ pub struct CompositorConfig {
 /// Sleep/idle policy settings.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct SleepConfig {
-    /// Idle timeout in seconds before the sleep action fires.
-    pub idle_timeout_secs: u64,
+    /// Minutes of no user interaction after which the daemon drops
+    /// `Active → Drowsy` (model weights unloaded, server stays alive).
+    /// `0` disables this transition. Independent of `idle_to_sleep_mins`.
+    #[serde(default = "default_idle_to_drowsy_mins")]
+    pub idle_to_drowsy_mins: u64,
+    /// Minutes of no user interaction after which the daemon drops to
+    /// `Sleeping` (llama-server stopped, all VRAM freed). Must be greater
+    /// than `idle_to_drowsy_mins` when both are non-zero. `0` disables
+    /// this transition.
+    #[serde(default = "default_idle_to_sleep_mins")]
+    pub idle_to_sleep_mins: u64,
     /// Whether to suspend the machine (true) or just deactivate (false).
     pub suspend: bool,
 
@@ -176,6 +185,14 @@ fn default_ready_timeout_secs() -> u64 {
     300
 }
 
+fn default_idle_to_drowsy_mins() -> u64 {
+    30
+}
+
+fn default_idle_to_sleep_mins() -> u64 {
+    120
+}
+
 fn default_gpu_monitor_enabled() -> bool {
     true
 }
@@ -241,7 +258,8 @@ impl Default for Config {
                 compositor_type: CompositorType::Sway,
             },
             sleep: SleepConfig {
-                idle_timeout_secs: 300,
+                idle_to_drowsy_mins: default_idle_to_drowsy_mins(),
+                idle_to_sleep_mins: default_idle_to_sleep_mins(),
                 suspend: false,
                 gpu_monitor_enabled: default_gpu_monitor_enabled(),
                 gpu_poll_secs: default_gpu_poll_secs(),
@@ -394,8 +412,15 @@ impl Config {
             errors.push("voice.hotkey must not be empty when voice is enabled".into());
         }
 
-        if self.sleep.idle_timeout_secs == 0 {
-            errors.push("sleep.idle_timeout_secs must be greater than 0".into());
+        if self.sleep.idle_to_drowsy_mins > 0
+            && self.sleep.idle_to_sleep_mins > 0
+            && self.sleep.idle_to_sleep_mins <= self.sleep.idle_to_drowsy_mins
+        {
+            errors.push(
+                "sleep.idle_to_sleep_mins must be greater than sleep.idle_to_drowsy_mins \
+                 (set either to 0 to disable that transition)"
+                    .into(),
+            );
         }
 
         if self.sleep.gpu_monitor_enabled {
@@ -580,7 +605,7 @@ mod tests {
         let mut config = Config::default();
         config.model.name = String::new();
         config.model.context_length = 0;
-        config.sleep.idle_timeout_secs = 0;
+        config.chat.max_response_tokens = 0;
         let errs = validation_errors(config.validate().unwrap_err());
         assert_eq!(errs.len(), 3);
     }
@@ -615,7 +640,6 @@ hotkey = "Super+V"
 type = "kde"
 
 [sleep]
-idle_timeout_secs = 300
 suspend = false
 
 [remote]
@@ -683,7 +707,6 @@ hotkey = "Super+V"
 type = "sway"
 
 [sleep]
-idle_timeout_secs = 300
 suspend = false
 
 [remote]
@@ -777,7 +800,6 @@ hotkey = "Super+V"
 type = "sway"
 
 [sleep]
-idle_timeout_secs = 300
 suspend = false
 
 [remote]
@@ -836,7 +858,6 @@ hotkey = "Super+V"
 type = "sway"
 
 [sleep]
-idle_timeout_secs = 300
 suspend = false
 
 [remote]
@@ -884,5 +905,94 @@ port = 8384
         config
             .validate()
             .expect("zero poll/threshold is allowed when monitor disabled");
+    }
+
+    #[test]
+    fn idle_timeouts_default_from_missing_keys() {
+        let toml_str = r#"
+[model]
+name = "test/model-GGUF:Q4_K_M"
+context_length = 8192
+
+[llama_server]
+binary_path = "llama-server"
+host = "127.0.0.1"
+port = 8385
+
+[chat]
+system_prompt = "hi"
+max_history_tokens = 4000
+summary_target_tokens = 500
+preserve_recent_turns = 2
+temperature = 0.5
+max_response_tokens = 1024
+max_summary_tokens = 800
+request_timeout_secs = 60
+
+[voice]
+enabled = false
+hotkey = "Super+V"
+
+[compositor]
+type = "sway"
+
+[sleep]
+suspend = false
+
+[remote]
+enabled = false
+bind_address = "127.0.0.1"
+port = 8384
+"#;
+        let cfg: Config = toml::from_str(toml_str).expect("parse without idle keys");
+        assert_eq!(cfg.sleep.idle_to_drowsy_mins, 30);
+        assert_eq!(cfg.sleep.idle_to_sleep_mins, 120);
+    }
+
+    #[test]
+    fn validation_catches_idle_sleep_lte_drowsy() {
+        let mut config = Config::default();
+        config.sleep.idle_to_drowsy_mins = 60;
+        config.sleep.idle_to_sleep_mins = 30;
+        let errs = validation_errors(config.validate().unwrap_err());
+        assert!(
+            errs.iter()
+                .any(|e| e.contains("idle_to_sleep_mins") && e.contains("idle_to_drowsy_mins"))
+        );
+    }
+
+    #[test]
+    fn validation_catches_idle_sleep_eq_drowsy() {
+        let mut config = Config::default();
+        config.sleep.idle_to_drowsy_mins = 60;
+        config.sleep.idle_to_sleep_mins = 60;
+        let errs = validation_errors(config.validate().unwrap_err());
+        assert!(errs.iter().any(|e| e.contains("idle_to_sleep_mins")));
+    }
+
+    #[test]
+    fn idle_both_zero_is_valid() {
+        let mut config = Config::default();
+        config.sleep.idle_to_drowsy_mins = 0;
+        config.sleep.idle_to_sleep_mins = 0;
+        config
+            .validate()
+            .expect("both zero disables idle monitoring");
+    }
+
+    #[test]
+    fn idle_only_drowsy_set_is_valid() {
+        let mut config = Config::default();
+        config.sleep.idle_to_drowsy_mins = 30;
+        config.sleep.idle_to_sleep_mins = 0;
+        config.validate().expect("only drowsy configured is valid");
+    }
+
+    #[test]
+    fn idle_only_sleep_set_is_valid() {
+        let mut config = Config::default();
+        config.sleep.idle_to_drowsy_mins = 0;
+        config.sleep.idle_to_sleep_mins = 120;
+        config.validate().expect("only sleep configured is valid");
     }
 }

--- a/crates/assistd-core/src/presence.rs
+++ b/crates/assistd-core/src/presence.rs
@@ -28,7 +28,7 @@
 //! before dispatching work to the LLM backend.
 
 use std::sync::{Arc, Mutex as StdMutex};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result, anyhow, bail};
 use assistd_ipc::PresenceState;
@@ -62,6 +62,12 @@ pub struct PresenceManager {
     // Holds the daemon shutdown receiver alive so the forwarder task
     // keeps a valid subscription.
     _daemon_shutdown: watch::Receiver<bool>,
+    // Monotonic timestamp of the last user-initiated interaction
+    // (query, manual presence command, hotkey, cycle). The idle monitor
+    // reads this to decide when to drowse or sleep; automatic monitors
+    // (GPU, idle) deliberately do not update it so their own
+    // transitions don't defer further idle progress.
+    last_activity: StdMutex<Instant>,
 }
 
 impl PresenceManager {
@@ -114,6 +120,7 @@ impl PresenceManager {
             current_inner_shutdown,
             state_tx,
             _daemon_shutdown: daemon_shutdown,
+            last_activity: StdMutex::new(Instant::now()),
         });
 
         manager
@@ -126,6 +133,55 @@ impl PresenceManager {
     /// Current presence state. Cheap, lock-protected snapshot.
     pub fn state(&self) -> PresenceState {
         *self.state.lock().expect("presence state mutex poisoned")
+    }
+
+    /// Record that the user just interacted with the daemon. Called at
+    /// the top of every user-facing wrapper (`ensure_active`,
+    /// `set_presence`, `cycle`). Deliberately NOT called by the
+    /// low-level transition methods (`wake`/`drowse`/`sleep`) so that
+    /// automatic monitors (GPU, idle) don't defer their own progress.
+    fn mark_activity(&self) {
+        *self
+            .last_activity
+            .lock()
+            .expect("last_activity mutex poisoned") = Instant::now();
+    }
+
+    /// Time since the last recorded user interaction. Read by the idle
+    /// monitor to decide when to drowse/sleep, and by the TUI status
+    /// bar for its countdown display.
+    pub fn idle_duration(&self) -> Duration {
+        self.last_activity
+            .lock()
+            .expect("last_activity mutex poisoned")
+            .elapsed()
+    }
+
+    /// Time until the next idle-based transition given the current
+    /// state and config. Returns `None` when idle monitoring is
+    /// disabled for the relevant transition or when the daemon is
+    /// already `Sleeping`.
+    pub fn time_until_next_transition(&self, cfg: &crate::SleepConfig) -> Option<Duration> {
+        let idle = self.idle_duration();
+        let threshold_mins = match self.state() {
+            PresenceState::Active => {
+                if cfg.idle_to_drowsy_mins > 0 {
+                    cfg.idle_to_drowsy_mins
+                } else if cfg.idle_to_sleep_mins > 0 {
+                    cfg.idle_to_sleep_mins
+                } else {
+                    return None;
+                }
+            }
+            PresenceState::Drowsy => {
+                if cfg.idle_to_sleep_mins == 0 {
+                    return None;
+                }
+                cfg.idle_to_sleep_mins
+            }
+            PresenceState::Sleeping => return None,
+        };
+        Some(Duration::from_secs(threshold_mins * 60).saturating_sub(idle))
     }
 
     /// Subscribe to presence-state changes. The returned receiver starts at
@@ -145,6 +201,7 @@ impl PresenceManager {
     /// concurrent queries — racing callers serialise on the transition
     /// lock and only one wake actually runs.
     pub async fn ensure_active(&self) -> Result<()> {
+        self.mark_activity();
         if self.state() == PresenceState::Active {
             return Ok(());
         }
@@ -154,6 +211,7 @@ impl PresenceManager {
     /// Drive the manager to `target`. Convenience wrapper used by the IPC
     /// `SetPresence` handler.
     pub async fn set_presence(&self, target: PresenceState) -> Result<()> {
+        self.mark_activity();
         match target {
             PresenceState::Active => self.wake().await,
             PresenceState::Drowsy => self.drowse().await,
@@ -170,6 +228,7 @@ impl PresenceManager {
     /// transition mutex still serialises the actual state change, so we
     /// never skip or split a step.
     pub async fn cycle(&self) -> Result<PresenceState> {
+        self.mark_activity();
         let target = self.state().next();
         self.set_presence(target).await?;
         Ok(target)
@@ -354,6 +413,7 @@ impl PresenceManager {
             current_inner_shutdown: Arc::new(StdMutex::new(None)),
             state_tx,
             _daemon_shutdown: rx,
+            last_activity: StdMutex::new(Instant::now()),
         })
     }
 
@@ -439,5 +499,102 @@ mod tests {
         // exercised by integration with a live daemon.
         let start = PresenceState::Sleeping;
         assert_eq!(start.next(), PresenceState::Active);
+    }
+
+    fn sleep_cfg(drowsy: u64, sleep: u64) -> crate::SleepConfig {
+        let mut cfg = crate::Config::default().sleep;
+        cfg.idle_to_drowsy_mins = drowsy;
+        cfg.idle_to_sleep_mins = sleep;
+        cfg
+    }
+
+    #[tokio::test]
+    async fn ensure_active_resets_activity_timer() {
+        let m = PresenceManager::stub(PresenceState::Active);
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        let before = m.idle_duration();
+        assert!(before >= Duration::from_millis(40));
+        m.ensure_active().await.unwrap();
+        let after = m.idle_duration();
+        assert!(after < before);
+        assert!(after < Duration::from_millis(20));
+    }
+
+    #[tokio::test]
+    async fn set_presence_resets_activity_timer() {
+        let m = PresenceManager::stub(PresenceState::Active);
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(m.idle_duration() >= Duration::from_millis(40));
+        // set_presence(Active) from Active short-circuits in wake() but
+        // mark_activity still runs as the first line of set_presence.
+        m.set_presence(PresenceState::Active).await.unwrap();
+        assert!(m.idle_duration() < Duration::from_millis(20));
+    }
+
+    #[tokio::test]
+    async fn cycle_resets_activity_timer() {
+        // Stub starts in Drowsy; cycle() computes target=Sleeping and
+        // calls set_presence(Sleeping) → sleep(), which is a pure
+        // local-state transition with no network I/O in the stub.
+        let m = PresenceManager::stub(PresenceState::Drowsy);
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(m.idle_duration() >= Duration::from_millis(40));
+        m.cycle().await.unwrap();
+        assert!(m.idle_duration() < Duration::from_millis(20));
+    }
+
+    #[tokio::test]
+    async fn wake_from_active_does_not_reset_activity_timer() {
+        // Low-level transition methods are called directly by automatic
+        // monitors (GPU, idle). They must NOT reset last_activity, or
+        // those automatic transitions would indefinitely defer their
+        // own forward progress.
+        let m = PresenceManager::stub(PresenceState::Active);
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        let before = m.idle_duration();
+        m.wake().await.unwrap();
+        let after = m.idle_duration();
+        assert!(after >= before);
+    }
+
+    #[test]
+    fn time_until_next_transition_active_counts_down_to_drowsy() {
+        let m = PresenceManager::stub(PresenceState::Active);
+        let cfg = sleep_cfg(30, 120);
+        let d = m.time_until_next_transition(&cfg).unwrap();
+        assert!(d <= Duration::from_secs(30 * 60));
+        assert!(d >= Duration::from_secs(30 * 60).saturating_sub(Duration::from_secs(5)));
+    }
+
+    #[test]
+    fn time_until_next_transition_sleeping_returns_none() {
+        let m = PresenceManager::stub(PresenceState::Sleeping);
+        assert!(m.time_until_next_transition(&sleep_cfg(30, 120)).is_none());
+    }
+
+    #[test]
+    fn time_until_next_transition_active_with_drowsy_disabled_uses_sleep() {
+        let m = PresenceManager::stub(PresenceState::Active);
+        let d = m.time_until_next_transition(&sleep_cfg(0, 120)).unwrap();
+        assert!(d <= Duration::from_secs(120 * 60));
+    }
+
+    #[test]
+    fn time_until_next_transition_active_with_both_disabled_returns_none() {
+        let m = PresenceManager::stub(PresenceState::Active);
+        assert!(m.time_until_next_transition(&sleep_cfg(0, 0)).is_none());
+    }
+
+    #[test]
+    fn time_until_next_transition_drowsy_with_sleep_disabled_returns_none() {
+        let m = PresenceManager::stub(PresenceState::Drowsy);
+        assert!(m.time_until_next_transition(&sleep_cfg(30, 0)).is_none());
+    }
+
+    #[test]
+    fn time_until_next_transition_drowsy_counts_down_to_sleep() {
+        let m = PresenceManager::stub(PresenceState::Drowsy);
+        let d = m.time_until_next_transition(&sleep_cfg(30, 120)).unwrap();
+        assert!(d <= Duration::from_secs(120 * 60));
     }
 }

--- a/crates/assistd/src/chat/app.rs
+++ b/crates/assistd/src/chat/app.rs
@@ -7,7 +7,7 @@
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use assistd_core::{PresenceManager, PresenceState};
+use assistd_core::{PresenceManager, PresenceState, SleepConfig};
 use assistd_llm::{LlmBackend, LlmEvent};
 use crossterm::event::{KeyCode, KeyEvent};
 use tokio::sync::mpsc;
@@ -38,9 +38,10 @@ pub struct App {
     pub notice: Option<(String, Instant)>,
     pub last_output_height: u16,
     pub presence_state: Option<PresenceState>,
+    pub sleep_cfg: SleepConfig,
+    pub presence: Option<Arc<PresenceManager>>,
     client: Arc<dyn LlmBackend>,
     chat_tx: mpsc::Sender<ChatEvent>,
-    presence: Option<Arc<PresenceManager>>,
 }
 
 impl App {
@@ -48,6 +49,7 @@ impl App {
         client: Arc<dyn LlmBackend>,
         chat_tx: mpsc::Sender<ChatEvent>,
         model_name: String,
+        sleep_cfg: SleepConfig,
         presence: Option<Arc<PresenceManager>>,
     ) -> Self {
         let presence_state = presence.as_ref().map(|p| p.state());
@@ -63,9 +65,10 @@ impl App {
             notice: None,
             last_output_height: 10,
             presence_state,
+            sleep_cfg,
+            presence,
             client,
             chat_tx,
-            presence,
         }
     }
 
@@ -235,10 +238,17 @@ mod tests {
     use assistd_llm::{EchoBackend, FailedBackend};
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
+    fn test_sleep_cfg() -> SleepConfig {
+        let mut cfg = assistd_core::Config::default().sleep;
+        cfg.idle_to_drowsy_mins = 0;
+        cfg.idle_to_sleep_mins = 0;
+        cfg
+    }
+
     fn test_app() -> (App, mpsc::Receiver<ChatEvent>) {
         let (tx, rx) = mpsc::channel::<ChatEvent>(16);
         let client: Arc<dyn LlmBackend> = Arc::new(EchoBackend);
-        let app = App::new(client, tx, "test-model".into(), None);
+        let app = App::new(client, tx, "test-model".into(), test_sleep_cfg(), None);
         (app, rx)
     }
 
@@ -350,7 +360,7 @@ mod tests {
     async fn failed_backend_spawn_yields_llm_error() {
         let (tx, mut rx) = mpsc::channel::<ChatEvent>(16);
         let client: Arc<dyn LlmBackend> = Arc::new(FailedBackend::new("server down".into()));
-        let app = App::new(client, tx, "test-model".into(), None);
+        let app = App::new(client, tx, "test-model".into(), test_sleep_cfg(), None);
         app.spawn_generation("hello".into());
         let ev = rx.recv().await.expect("error event");
         match ev {

--- a/crates/assistd/src/chat/mod.rs
+++ b/crates/assistd/src/chat/mod.rs
@@ -17,8 +17,10 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
-use assistd_core::{Config, PresenceManager};
+use assistd_core::{Config, PresenceManager, SleepConfig};
 use assistd_llm::{FailedBackend, LlamaChatClient, LlmBackend};
+
+use crate::idle_monitor;
 use clap::Args;
 use crossterm::event::{self, Event, EventStream};
 use crossterm::{cursor, execute, terminal};
@@ -45,6 +47,7 @@ pub async fn run(args: ChatArgs) -> Result<()> {
     };
     let config = Config::load_from_file(&config_path)?;
     config.validate()?;
+    idle_monitor::validate(&config.sleep)?;
 
     let _log_guard = init_file_tracing()?;
 
@@ -83,6 +86,10 @@ pub async fn run(args: ChatArgs) -> Result<()> {
 
     let mut resource_rx = vram::spawn_probe(shutdown_tx.subscribe());
 
+    let idle_monitor_handle = presence.as_ref().and_then(|p| {
+        idle_monitor::spawn_monitor(&config.sleep, p.clone(), shutdown_tx.subscribe())
+    });
+
     let model_name = config
         .model
         .name
@@ -93,6 +100,7 @@ pub async fn run(args: ChatArgs) -> Result<()> {
     let run_result = run_tui(
         client,
         model_name,
+        config.sleep.clone(),
         presence.clone(),
         &mut resource_rx,
         shutdown_tx.clone(),
@@ -101,6 +109,9 @@ pub async fn run(args: ChatArgs) -> Result<()> {
     .await;
 
     let _ = shutdown_tx.send(true);
+    if let Some(h) = idle_monitor_handle {
+        let _ = h.await;
+    }
     if let Some(p) = presence {
         if let Err(e) = p.sleep().await {
             tracing::error!("presence shutdown error: {e:#}");
@@ -113,6 +124,7 @@ pub async fn run(args: ChatArgs) -> Result<()> {
 async fn run_tui(
     client: Arc<dyn LlmBackend>,
     model_name: String,
+    sleep_cfg: SleepConfig,
     presence: Option<Arc<PresenceManager>>,
     resource_rx: &mut watch::Receiver<vram::ResourceState>,
     shutdown_tx: watch::Sender<bool>,
@@ -139,7 +151,7 @@ async fn run_tui(
     let mut terminal = Terminal::new(backend).context("Terminal::new")?;
 
     let (chat_tx, mut chat_rx) = mpsc::channel::<ChatEvent>(64);
-    let mut app = App::new(client, chat_tx, model_name, presence.clone());
+    let mut app = App::new(client, chat_tx, model_name, sleep_cfg, presence.clone());
 
     if let Some(err) = startup_error {
         app.output

--- a/crates/assistd/src/chat/ui.rs
+++ b/crates/assistd/src/chat/ui.rs
@@ -2,7 +2,7 @@
 //! output pane's wrap cache and the app's last-viewport-height sink, both
 //! of which must be updated during layout.
 
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use assistd_core::PresenceState;
 use ratatui::Frame;
@@ -90,6 +90,16 @@ fn render_status(frame: &mut Frame, area: Rect, app: &App) {
         ));
         left_spans.push(Span::styled(format!(" {label}"), reversed));
     }
+    if let Some(remaining) = app
+        .presence
+        .as_ref()
+        .and_then(|p| p.time_until_next_transition(&app.sleep_cfg))
+    {
+        left_spans.push(Span::styled(
+            format!(" ({})", format_countdown(remaining)),
+            reversed,
+        ));
+    }
     left_spans.push(Span::styled(format!(" │ {state}"), reversed));
     if let Some(r) = rate {
         left_spans.push(Span::styled(format!(" │ {r}"), reversed));
@@ -136,6 +146,17 @@ fn presence_dot(s: Option<PresenceState>) -> Option<(Color, &'static str)> {
         PresenceState::Active => Some((Color::Green, "active")),
         PresenceState::Drowsy => Some((Color::Yellow, "drowsy")),
         PresenceState::Sleeping => Some((Color::Red, "sleeping")),
+    }
+}
+
+fn format_countdown(d: Duration) -> String {
+    let total = d.as_secs();
+    if total >= 3600 {
+        format!("{}h{:02}m", total / 3600, (total % 3600) / 60)
+    } else if total >= 60 {
+        format!("{}m", total / 60)
+    } else {
+        format!("{total}s")
     }
 }
 

--- a/crates/assistd/src/daemon.rs
+++ b/crates/assistd/src/daemon.rs
@@ -8,7 +8,7 @@ use tokio::signal::unix::{SignalKind, signal};
 use tokio::sync::watch;
 use tracing::info;
 
-use crate::{gpu_monitor, hotkey};
+use crate::{gpu_monitor, hotkey, idle_monitor};
 
 #[derive(Args)]
 pub struct DaemonArgs {
@@ -28,6 +28,7 @@ pub async fn run(args: DaemonArgs) -> Result<()> {
     config.validate()?;
     hotkey::validate(&config.presence)?;
     gpu_monitor::validate(&config.sleep)?;
+    idle_monitor::validate(&config.sleep)?;
 
     info!(
         "assistd v{} — local model agent OS assistant daemon",
@@ -82,6 +83,8 @@ pub async fn run(args: DaemonArgs) -> Result<()> {
         hotkey::spawn_listener(&config.presence, presence.clone(), shutdown_tx.subscribe());
     let gpu_monitor_handle =
         gpu_monitor::spawn_monitor(&config.sleep, presence.clone(), shutdown_tx.subscribe());
+    let idle_monitor_handle =
+        idle_monitor::spawn_monitor(&config.sleep, presence.clone(), shutdown_tx.subscribe());
     let state = Arc::new(AppState::new(config, Arc::new(chat), presence.clone()));
 
     let mut socket_shutdown_rx = shutdown_tx.subscribe();
@@ -100,6 +103,9 @@ pub async fn run(args: DaemonArgs) -> Result<()> {
         let _ = h.await;
     }
     if let Some(h) = gpu_monitor_handle {
+        let _ = h.await;
+    }
+    if let Some(h) = idle_monitor_handle {
         let _ = h.await;
     }
 

--- a/crates/assistd/src/gpu_monitor.rs
+++ b/crates/assistd/src/gpu_monitor.rs
@@ -307,7 +307,8 @@ mod tests {
 
     fn cfg() -> SleepConfig {
         SleepConfig {
-            idle_timeout_secs: 300,
+            idle_to_drowsy_mins: 30,
+            idle_to_sleep_mins: 120,
             suspend: false,
             gpu_monitor_enabled: true,
             gpu_poll_secs: 5,

--- a/crates/assistd/src/idle_monitor.rs
+++ b/crates/assistd/src/idle_monitor.rs
@@ -1,0 +1,340 @@
+//! Automatic idle-based sleep monitor.
+//!
+//! Polls `PresenceManager::idle_duration()` on a fixed interval and
+//! drives `drowse()` / `sleep()` when the configured thresholds are
+//! crossed. Any user interaction (query, TUI submit, CLI presence
+//! command, hotkey) resets `PresenceManager::last_activity` and
+//! naturally defers the next transition.
+//!
+//! Like `gpu_monitor`, this module is a *driver* of `PresenceManager`.
+//! It calls `presence.drowse()` / `presence.sleep()` directly rather
+//! than going through `set_presence`, which means automatic transitions
+//! do not themselves reset the idle timer — a crucial invariant so that
+//! the monitor can make forward progress through Active → Drowsy →
+//! Sleeping.
+//!
+//! Disabled when both `sleep.idle_to_drowsy_mins` and
+//! `sleep.idle_to_sleep_mins` are 0; returns `None` from
+//! [`spawn_monitor`] with an info log.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Result, bail};
+use assistd_core::{PresenceManager, PresenceState, SleepConfig};
+use tokio::sync::watch;
+use tokio::task::JoinHandle;
+use tracing::{info, warn};
+
+/// How often to re-check idle duration against thresholds. The
+/// thresholds themselves are in minutes, so sub-minute granularity is
+/// irrelevant — 10 s keeps the TUI countdown feeling live while
+/// imposing near-zero cost at idle (one std-mutex read + compare).
+const POLL_INTERVAL_SECS: u64 = 10;
+
+/// Decision output for one poll cycle. Pure and trivially unit-testable.
+#[derive(Debug, PartialEq, Eq)]
+enum Action {
+    None,
+    Drowse,
+    Sleep,
+}
+
+/// Pre-flight check called from daemon startup, mirroring
+/// [`crate::gpu_monitor::validate`]. `Config::validate` already catches
+/// this; we duplicate the rule here so the daemon's fail-fast path
+/// stays symmetric across subsystems.
+pub fn validate(cfg: &SleepConfig) -> Result<()> {
+    if cfg.idle_to_drowsy_mins > 0
+        && cfg.idle_to_sleep_mins > 0
+        && cfg.idle_to_sleep_mins <= cfg.idle_to_drowsy_mins
+    {
+        bail!(
+            "sleep.idle_to_sleep_mins must be greater than sleep.idle_to_drowsy_mins \
+             (set either to 0 to disable that transition)"
+        );
+    }
+    Ok(())
+}
+
+/// Spawn the idle monitor. Returns `None` when both thresholds are 0
+/// (feature fully disabled).
+pub fn spawn_monitor(
+    cfg: &SleepConfig,
+    presence: Arc<PresenceManager>,
+    shutdown: watch::Receiver<bool>,
+) -> Option<JoinHandle<()>> {
+    if cfg.idle_to_drowsy_mins == 0 && cfg.idle_to_sleep_mins == 0 {
+        info!(
+            target: "assistd::idle_monitor",
+            "sleep.idle_to_drowsy_mins = sleep.idle_to_sleep_mins = 0; idle monitor disabled"
+        );
+        return None;
+    }
+    info!(
+        target: "assistd::idle_monitor",
+        drowsy_mins = cfg.idle_to_drowsy_mins,
+        sleep_mins = cfg.idle_to_sleep_mins,
+        poll_secs = POLL_INTERVAL_SECS,
+        "idle monitor enabled"
+    );
+    let cfg = cfg.clone();
+    Some(tokio::spawn(async move {
+        run_monitor(cfg, presence, shutdown).await
+    }))
+}
+
+async fn run_monitor(
+    cfg: SleepConfig,
+    presence: Arc<PresenceManager>,
+    mut shutdown: watch::Receiver<bool>,
+) {
+    let mut tick = tokio::time::interval(Duration::from_secs(POLL_INTERVAL_SECS));
+    tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    let mut sub = presence.subscribe();
+
+    loop {
+        tokio::select! {
+            _ = tick.tick() => {
+                let action = decide(presence.state(), presence.idle_duration(), &cfg);
+                apply(action, &presence).await;
+            }
+            _ = sub.changed() => {
+                // External transition (hotkey, query auto-wake, CLI
+                // command, GPU monitor). Drop the old reading; the next
+                // tick will re-evaluate against the new state.
+                let _ = *sub.borrow_and_update();
+            }
+            _ = shutdown.changed() => {
+                if *shutdown.borrow() {
+                    return;
+                }
+            }
+        }
+    }
+}
+
+async fn apply(action: Action, presence: &PresenceManager) {
+    match action {
+        Action::None => {}
+        Action::Drowse => {
+            info!(target: "assistd::idle_monitor", "idle threshold reached; drowsing");
+            if let Err(e) = presence.drowse().await {
+                warn!(target: "assistd::idle_monitor", "drowse failed: {e:#}");
+            }
+        }
+        Action::Sleep => {
+            info!(target: "assistd::idle_monitor", "idle threshold reached; sleeping");
+            if let Err(e) = presence.sleep().await {
+                warn!(target: "assistd::idle_monitor", "sleep failed: {e:#}");
+            }
+        }
+    }
+}
+
+fn decide(state: PresenceState, idle: Duration, cfg: &SleepConfig) -> Action {
+    let drowsy_threshold = Duration::from_secs(cfg.idle_to_drowsy_mins * 60);
+    let sleep_threshold = Duration::from_secs(cfg.idle_to_sleep_mins * 60);
+    match state {
+        PresenceState::Active => {
+            if cfg.idle_to_drowsy_mins > 0 && idle >= drowsy_threshold {
+                // Cascade: even if idle already exceeds the sleep
+                // threshold, step through Drowsy on this tick so the
+                // model weights are unloaded cleanly before the server
+                // is torn down on the next tick.
+                Action::Drowse
+            } else if cfg.idle_to_drowsy_mins == 0
+                && cfg.idle_to_sleep_mins > 0
+                && idle >= sleep_threshold
+            {
+                // Drowsy step explicitly disabled — skip directly to Sleep.
+                Action::Sleep
+            } else {
+                Action::None
+            }
+        }
+        PresenceState::Drowsy => {
+            if cfg.idle_to_sleep_mins > 0 && idle >= sleep_threshold {
+                Action::Sleep
+            } else {
+                Action::None
+            }
+        }
+        PresenceState::Sleeping => Action::None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg(drowsy: u64, sleep: u64) -> SleepConfig {
+        let mut c = assistd_core::Config::default().sleep;
+        c.idle_to_drowsy_mins = drowsy;
+        c.idle_to_sleep_mins = sleep;
+        c
+    }
+
+    // --- validate -----------------------------------------------------
+
+    #[test]
+    fn validate_both_zero_is_ok() {
+        validate(&cfg(0, 0)).expect("both zero disables the monitor");
+    }
+
+    #[test]
+    fn validate_one_zero_is_ok() {
+        validate(&cfg(0, 120)).expect("only sleep configured is valid");
+        validate(&cfg(30, 0)).expect("only drowsy configured is valid");
+    }
+
+    #[test]
+    fn validate_sleep_gt_drowsy_is_ok() {
+        validate(&cfg(30, 120)).expect("standard ordering is valid");
+    }
+
+    #[test]
+    fn validate_sleep_lt_drowsy_errors() {
+        let err = validate(&cfg(60, 30)).unwrap_err();
+        assert!(err.to_string().contains("idle_to_sleep_mins"));
+    }
+
+    #[test]
+    fn validate_sleep_eq_drowsy_errors() {
+        let err = validate(&cfg(60, 60)).unwrap_err();
+        assert!(err.to_string().contains("idle_to_sleep_mins"));
+    }
+
+    // --- decide: Active ----------------------------------------------
+
+    #[test]
+    fn active_before_drowsy_threshold_no_action() {
+        let a = decide(
+            PresenceState::Active,
+            Duration::from_secs(10 * 60),
+            &cfg(30, 120),
+        );
+        assert_eq!(a, Action::None);
+    }
+
+    #[test]
+    fn active_at_drowsy_threshold_drowses() {
+        let a = decide(
+            PresenceState::Active,
+            Duration::from_secs(30 * 60),
+            &cfg(30, 120),
+        );
+        assert_eq!(a, Action::Drowse);
+    }
+
+    #[test]
+    fn active_past_drowsy_but_below_sleep_still_drowses() {
+        let a = decide(
+            PresenceState::Active,
+            Duration::from_secs(90 * 60),
+            &cfg(30, 120),
+        );
+        assert_eq!(a, Action::Drowse);
+    }
+
+    #[test]
+    fn active_past_sleep_threshold_still_drowses_first_cascade() {
+        // Cascade semantics: emit Drowse here, next tick will see
+        // Drowsy + idle >= sleep and emit Sleep. This preserves the
+        // ordered teardown (weights unload → server stop) even when
+        // idle had already exceeded both thresholds at startup.
+        let a = decide(
+            PresenceState::Active,
+            Duration::from_secs(200 * 60),
+            &cfg(30, 120),
+        );
+        assert_eq!(a, Action::Drowse);
+    }
+
+    #[test]
+    fn active_with_drowsy_disabled_before_sleep_no_action() {
+        let a = decide(
+            PresenceState::Active,
+            Duration::from_secs(60 * 60),
+            &cfg(0, 120),
+        );
+        assert_eq!(a, Action::None);
+    }
+
+    #[test]
+    fn active_with_drowsy_disabled_past_sleep_sleeps_directly() {
+        let a = decide(
+            PresenceState::Active,
+            Duration::from_secs(130 * 60),
+            &cfg(0, 120),
+        );
+        assert_eq!(a, Action::Sleep);
+    }
+
+    #[test]
+    fn active_with_sleep_disabled_still_drowses() {
+        let a = decide(
+            PresenceState::Active,
+            Duration::from_secs(30 * 60),
+            &cfg(30, 0),
+        );
+        assert_eq!(a, Action::Drowse);
+    }
+
+    // --- decide: Drowsy ----------------------------------------------
+
+    #[test]
+    fn drowsy_before_sleep_threshold_no_action() {
+        let a = decide(
+            PresenceState::Drowsy,
+            Duration::from_secs(60 * 60),
+            &cfg(30, 120),
+        );
+        assert_eq!(a, Action::None);
+    }
+
+    #[test]
+    fn drowsy_at_sleep_threshold_sleeps() {
+        let a = decide(
+            PresenceState::Drowsy,
+            Duration::from_secs(120 * 60),
+            &cfg(30, 120),
+        );
+        assert_eq!(a, Action::Sleep);
+    }
+
+    #[test]
+    fn drowsy_with_sleep_disabled_no_action() {
+        let a = decide(
+            PresenceState::Drowsy,
+            Duration::from_secs(200 * 60),
+            &cfg(30, 0),
+        );
+        assert_eq!(a, Action::None);
+    }
+
+    // --- decide: Sleeping --------------------------------------------
+
+    #[test]
+    fn sleeping_never_acts() {
+        let a = decide(
+            PresenceState::Sleeping,
+            Duration::from_secs(500 * 60),
+            &cfg(30, 120),
+        );
+        assert_eq!(a, Action::None);
+    }
+
+    #[test]
+    fn both_disabled_returns_none_from_any_state() {
+        let disabled = cfg(0, 0);
+        for state in [
+            PresenceState::Active,
+            PresenceState::Drowsy,
+            PresenceState::Sleeping,
+        ] {
+            let a = decide(state, Duration::from_secs(10_000 * 60), &disabled);
+            assert_eq!(a, Action::None);
+        }
+    }
+}

--- a/crates/assistd/src/main.rs
+++ b/crates/assistd/src/main.rs
@@ -9,6 +9,8 @@ mod daemon;
 mod gpu_monitor;
 #[cfg(feature = "daemon")]
 mod hotkey;
+#[cfg(any(feature = "daemon", feature = "chat"))]
+mod idle_monitor;
 #[cfg(feature = "client")]
 mod presence;
 #[cfg(feature = "client")]


### PR DESCRIPTION
Implementation of idle based sleep transitions that impact both the deamon and tui controls. (temporary) countdown to change of state in tui status bar.