### PR TITLE
Handle in-flight requests during state transitions

### DIFF
--- a/crates/assistd-core/src/lib.rs
+++ b/crates/assistd-core/src/lib.rs
@@ -6,7 +6,7 @@ pub mod state;
 pub use assistd_ipc as ipc;
 pub use assistd_ipc::PresenceState;
 pub use config::{Config, PresenceConfig, SleepConfig};
-pub use presence::PresenceManager;
+pub use presence::{PresenceManager, RequestGuard};
 pub use state::AppState;
 
 /// Returns the version string of the assistd-core crate.

--- a/crates/assistd-core/src/presence.rs
+++ b/crates/assistd-core/src/presence.rs
@@ -33,7 +33,7 @@ use std::time::{Duration, Instant};
 use anyhow::{Context, Result, anyhow, bail};
 use assistd_ipc::PresenceState;
 use assistd_llm::{LlamaServerControl, LlamaService, ModelSpec, ServerSpec};
-use tokio::sync::{Mutex as AsyncMutex, watch};
+use tokio::sync::{Mutex as AsyncMutex, OwnedRwLockReadGuard, RwLock, watch};
 use tracing::{debug, info, warn};
 
 /// Owner of the llama-server handle and the daemon-wide presence state.
@@ -68,6 +68,52 @@ pub struct PresenceManager {
     // (GPU, idle) deliberately do not update it so their own
     // transitions don't defer further idle progress.
     last_activity: StdMutex<Instant>,
+    // Shared lock over in-flight request tracking. Request handlers take
+    // an owned read guard (`RequestGuard`) for the duration of the
+    // generation; `sleep`/`drowse` take the write side to block until
+    // all outstanding requests drain. `tokio::sync::RwLock` is
+    // writer-preferring, so new requests queued after a pending
+    // transition wait for that transition plus the subsequent wake
+    // rather than starving the writer.
+    inflight: Arc<RwLock<()>>,
+    // `Some(started_at)` while a `wake` transition is executing — set
+    // after the transition mutex is taken and the short-circuit check
+    // passes, cleared by RAII when `wake` returns (success or error).
+    // The TUI polls this each render tick to drive the "waking up"
+    // indicator.
+    wake_started: Arc<StdMutex<Option<Instant>>>,
+}
+
+/// Held by request handlers for the duration of a query (or other
+/// in-flight work). While any guard is alive, [`PresenceManager::sleep`]
+/// and [`PresenceManager::drowse`] block — sleep cannot tear down the
+/// llama-server while a response is still streaming.
+///
+/// Created via [`PresenceManager::acquire_request_guard`]; released on
+/// drop.
+pub struct RequestGuard {
+    _guard: OwnedRwLockReadGuard<()>,
+}
+
+/// RAII marker for "a wake transition is in progress". Constructed at
+/// the top of [`PresenceManager::wake`] after the short-circuit check;
+/// cleared on drop so every return path — `?`-propagated error, panic,
+/// success — leaves `wake_started` back at `None`.
+struct WakeMarker {
+    slot: Arc<StdMutex<Option<Instant>>>,
+}
+
+impl WakeMarker {
+    fn new(slot: Arc<StdMutex<Option<Instant>>>) -> Self {
+        *slot.lock().expect("wake_started mutex poisoned") = Some(Instant::now());
+        Self { slot }
+    }
+}
+
+impl Drop for WakeMarker {
+    fn drop(&mut self) {
+        *self.slot.lock().expect("wake_started mutex poisoned") = None;
+    }
 }
 
 impl PresenceManager {
@@ -121,6 +167,8 @@ impl PresenceManager {
             state_tx,
             _daemon_shutdown: daemon_shutdown,
             last_activity: StdMutex::new(Instant::now()),
+            inflight: Arc::new(RwLock::new(())),
+            wake_started: Arc::new(StdMutex::new(None)),
         });
 
         manager
@@ -208,6 +256,47 @@ impl PresenceManager {
         self.wake().await
     }
 
+    /// Request a guard that keeps the daemon `Active` for as long as
+    /// the returned [`RequestGuard`] is alive. While any guard exists,
+    /// [`Self::sleep`] and [`Self::drowse`] block — this is the
+    /// mechanism that prevents a concurrent sleep from tearing down
+    /// llama-server mid-generation.
+    ///
+    /// The guard is acquired *before* the state check, so `state ==
+    /// Active` observed under the guard is a stable invariant for the
+    /// guard's lifetime (a sleep that wants to flip the state first
+    /// needs the write side of the same lock, which this guard blocks).
+    ///
+    /// If the state is not `Active` when the read guard is taken, the
+    /// guard is dropped and [`Self::ensure_active`] runs to wake the
+    /// daemon, then a new read guard is acquired and the state
+    /// re-checked. A bounded retry guards against pathological
+    /// sleep/wake churn.
+    pub async fn acquire_request_guard(self: &Arc<Self>) -> Result<RequestGuard> {
+        self.mark_activity();
+        const MAX_RETRIES: usize = 3;
+        for _ in 0..MAX_RETRIES {
+            let guard = self.inflight.clone().read_owned().await;
+            if self.state() == PresenceState::Active {
+                return Ok(RequestGuard { _guard: guard });
+            }
+            drop(guard);
+            self.ensure_active().await?;
+        }
+        bail!("failed to acquire active request guard after {MAX_RETRIES} retries")
+    }
+
+    /// `Some(started_at)` if a wake transition is currently running;
+    /// `None` otherwise. Used by the TUI to drive a "waking up"
+    /// indicator during cold-start wakes (which can take tens of
+    /// seconds to minutes).
+    pub fn wake_in_progress(&self) -> Option<Instant> {
+        *self
+            .wake_started
+            .lock()
+            .expect("wake_started mutex poisoned")
+    }
+
     /// Drive the manager to `target`. Convenience wrapper used by the IPC
     /// `SetPresence` handler.
     pub async fn set_presence(&self, target: PresenceState) -> Result<()> {
@@ -235,6 +324,9 @@ impl PresenceManager {
     }
 
     /// `Active|Drowsy → Sleeping`. Idempotent from `Sleeping`.
+    ///
+    /// Blocks until every outstanding [`RequestGuard`] has been dropped,
+    /// so an in-flight generation is never killed mid-stream.
     pub async fn sleep(&self) -> Result<()> {
         let _guard = self.transition.lock().await;
         let prior = self.state();
@@ -242,6 +334,11 @@ impl PresenceManager {
             debug!(target: "assistd::presence", "sleep: already Sleeping, no-op");
             return Ok(());
         }
+
+        // Wait for all in-flight requests to drop their read guards.
+        // Writer-preferring: new requests acquiring read guards after
+        // this point will block until the write guard is released.
+        let _inflight = self.inflight.write().await;
 
         let started = Instant::now();
         // Flip inner-shutdown to trigger supervisor teardown.
@@ -276,6 +373,10 @@ impl PresenceManager {
     }
 
     /// `Active → Drowsy`. Idempotent from `Drowsy`. Errors from `Sleeping`.
+    ///
+    /// Blocks until every outstanding [`RequestGuard`] has been dropped,
+    /// so an in-flight generation completes before the model weights
+    /// are unloaded.
     pub async fn drowse(&self) -> Result<()> {
         let _guard = self.transition.lock().await;
         let prior = self.state();
@@ -286,6 +387,10 @@ impl PresenceManager {
             }
             PresenceState::Active => {}
         }
+
+        // Wait for all in-flight requests to drop their read guards
+        // before unloading model weights.
+        let _inflight = self.inflight.write().await;
 
         let started = Instant::now();
         self.control
@@ -311,12 +416,22 @@ impl PresenceManager {
     }
 
     /// `Sleeping|Drowsy → Active`. Idempotent from `Active`.
+    ///
+    /// While this is running, [`Self::wake_in_progress`] returns
+    /// `Some(started_at)` so the TUI can display a "waking up"
+    /// indicator. The marker is installed via RAII after the
+    /// short-circuit check and cleared on every return path.
     pub async fn wake(&self) -> Result<()> {
         let _guard = self.transition.lock().await;
         let prior = self.state();
         if prior == PresenceState::Active {
             return Ok(());
         }
+
+        // Mark wake-in-progress for TUI. Placed *after* the short-circuit
+        // so idempotent wakes from Active don't briefly flicker the
+        // indicator.
+        let _wake_marker = WakeMarker::new(Arc::clone(&self.wake_started));
 
         let started = Instant::now();
         match prior {
@@ -414,6 +529,8 @@ impl PresenceManager {
             state_tx,
             _daemon_shutdown: rx,
             last_activity: StdMutex::new(Instant::now()),
+            inflight: Arc::new(RwLock::new(())),
+            wake_started: Arc::new(StdMutex::new(None)),
         })
     }
 
@@ -596,5 +713,137 @@ mod tests {
         let m = PresenceManager::stub(PresenceState::Drowsy);
         let d = m.time_until_next_transition(&sleep_cfg(30, 120)).unwrap();
         assert!(d <= Duration::from_secs(120 * 60));
+    }
+
+    #[tokio::test]
+    async fn acquire_request_guard_fast_path_when_active() {
+        let m = PresenceManager::stub(PresenceState::Active);
+        let g = tokio::time::timeout(Duration::from_millis(100), m.acquire_request_guard())
+            .await
+            .expect("acquire did not complete in time")
+            .expect("acquire returned Err");
+        drop(g);
+        assert_eq!(m.state(), PresenceState::Active);
+    }
+
+    #[tokio::test]
+    async fn sleep_defers_for_inflight_request() {
+        let m = PresenceManager::stub(PresenceState::Active);
+        let guard = m.acquire_request_guard().await.unwrap();
+
+        let m2 = Arc::clone(&m);
+        let sleep_task = tokio::spawn(async move { m2.sleep().await });
+
+        // Sleep must block while the request guard is alive.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert!(
+            !sleep_task.is_finished(),
+            "sleep completed while request guard held"
+        );
+
+        // Drop guard — sleep should now proceed.
+        drop(guard);
+        let res = tokio::time::timeout(Duration::from_secs(2), sleep_task)
+            .await
+            .expect("sleep did not complete after guard dropped")
+            .expect("sleep task panicked");
+        res.expect("sleep returned Err");
+        assert_eq!(m.state(), PresenceState::Sleeping);
+    }
+
+    #[tokio::test]
+    async fn drowse_defers_for_inflight_request() {
+        // Same mechanism as sleep: the inflight write lock blocks
+        // drowse until all read guards drop. We only verify the block
+        // behaviour; the drowse itself will error on the dummy control
+        // client once it gets past the inflight wait, which is fine.
+        let m = PresenceManager::stub(PresenceState::Active);
+        let guard = m.acquire_request_guard().await.unwrap();
+
+        let m2 = Arc::clone(&m);
+        let drowse_task = tokio::spawn(async move { m2.drowse().await });
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert!(
+            !drowse_task.is_finished(),
+            "drowse must block while request guard is held"
+        );
+
+        drop(guard);
+        // After drop, drowse completes (with Err from the dummy
+        // control client, since load/unload hit an unreachable port).
+        let _ = tokio::time::timeout(Duration::from_secs(2), drowse_task)
+            .await
+            .expect("drowse did not unblock after guard dropped");
+    }
+
+    #[tokio::test]
+    async fn wake_marker_cleared_on_error_path() {
+        // Wake from Drowsy calls `control.load_model`, which hits an
+        // unreachable port in the stub and returns Err. The RAII
+        // marker must still clear on the error path.
+        let m = PresenceManager::stub(PresenceState::Drowsy);
+        assert!(m.wake_in_progress().is_none());
+        let err = m.wake().await;
+        assert!(err.is_err(), "wake must fail against dummy control");
+        assert!(
+            m.wake_in_progress().is_none(),
+            "wake_in_progress must be cleared after wake returns, even on error"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn rapid_sleep_guard_loop_no_crash() {
+        // Stress the inflight RwLock + transition mutex interaction:
+        // many tasks take/release read guards while another loop calls
+        // sleep() and restores state via set_state_for_test. The stub
+        // can't cold-start wake, so the writer forces state back to
+        // Active after each sleep, which lets the retry loop in
+        // acquire_request_guard make progress. The point of the test
+        // is to confirm no deadlock or state corruption under churn —
+        // not to measure throughput. A generous wall-clock timeout
+        // wraps the whole workload.
+        let m = PresenceManager::stub(PresenceState::Active);
+
+        let mut readers = Vec::new();
+        for _ in 0..4 {
+            let m = Arc::clone(&m);
+            readers.push(tokio::spawn(async move {
+                for _ in 0..20 {
+                    match m.acquire_request_guard().await {
+                        Ok(g) => {
+                            tokio::task::yield_now().await;
+                            drop(g);
+                        }
+                        // Reader may observe Sleeping between writer's
+                        // sleep() completing and set_state_for_test(Active)
+                        // running; ensure_active() then fails in the
+                        // stub. Retry exhaustion is fine — just keep
+                        // going.
+                        Err(_) => tokio::task::yield_now().await,
+                    }
+                }
+            }));
+        }
+
+        let m2 = Arc::clone(&m);
+        let writer = tokio::spawn(async move {
+            for _ in 0..10 {
+                m2.sleep().await.expect("sleep errored");
+                m2.set_state_for_test(PresenceState::Active);
+                tokio::task::yield_now().await;
+            }
+        });
+
+        // Overall workload cap: if anything deadlocks, this trips and
+        // the test fails with a clear message rather than hanging.
+        tokio::time::timeout(Duration::from_secs(30), async move {
+            writer.await.expect("writer panicked");
+            for r in readers {
+                r.await.expect("reader panicked");
+            }
+        })
+        .await
+        .expect("rapid toggle workload deadlocked");
     }
 }

--- a/crates/assistd-core/src/state.rs
+++ b/crates/assistd-core/src/state.rs
@@ -48,18 +48,25 @@ impl AppState {
         text: String,
         tx: mpsc::Sender<Event>,
     ) -> Result<()> {
-        // Auto-wake: a query in any non-Active state blocks here until the
-        // daemon is ready to serve. Failures surface to the client as an
-        // Error event so the client doesn't hang.
-        if let Err(e) = self.presence.ensure_active().await {
-            let _ = tx
-                .send(Event::Error {
-                    id: id.clone(),
-                    message: format!("wake failed: {e:#}"),
-                })
-                .await;
-            return Err(e);
-        }
+        // Auto-wake and take an in-flight guard: a query in any
+        // non-Active state blocks here until the daemon is ready to
+        // serve. The returned guard keeps the daemon `Active` for the
+        // lifetime of the generation — a concurrent `sleep()` will
+        // wait until this guard (and the generator that follows) has
+        // finished. Failures surface to the client as an Error event
+        // so the client doesn't hang.
+        let _request_guard = match self.presence.acquire_request_guard().await {
+            Ok(g) => g,
+            Err(e) => {
+                let _ = tx
+                    .send(Event::Error {
+                        id: id.clone(),
+                        message: format!("wake failed: {e:#}"),
+                    })
+                    .await;
+                return Err(e);
+            }
+        };
 
         let (llm_tx, mut llm_rx) = mpsc::channel::<LlmEvent>(32);
         let llm = self.llm.clone();

--- a/crates/assistd-llm/tests/presence.rs
+++ b/crates/assistd-llm/tests/presence.rs
@@ -13,10 +13,11 @@ use std::time::Duration;
 
 use assistd_core::{AppState, Config, PresenceManager, PresenceState};
 use assistd_ipc::{Event, Request};
-use assistd_llm::{EchoBackend, ModelSpec, ServerSpec};
+use assistd_llm::{EchoBackend, LlmBackend, LlmEvent, ModelSpec, ServerSpec};
+use async_trait::async_trait;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{TcpListener, UnixStream};
-use tokio::sync::{Mutex, oneshot, watch};
+use tokio::sync::{Mutex, mpsc, oneshot, watch};
 
 const FAKE_BIN: &str = env!("CARGO_BIN_EXE_fake_llama_server");
 
@@ -342,6 +343,219 @@ async fn query_during_sleeping_triggers_auto_wake() {
         m.state(),
         PresenceState::Active,
         "auto-wake must leave manager in Active"
+    );
+
+    let _ = stop_tx.send(());
+    server.await.unwrap();
+    m.sleep().await.unwrap();
+}
+
+/// Backend that emits one Delta, sleeps for a configurable duration,
+/// then emits Done. Used to put a predictable gap between the first
+/// visible token and the terminal Done event so we can assert that
+/// `sleep()` blocks through the gap rather than killing the generator.
+struct DelayBackend {
+    delay: Duration,
+}
+
+#[async_trait]
+impl LlmBackend for DelayBackend {
+    async fn generate(&self, prompt: String, tx: mpsc::Sender<LlmEvent>) -> anyhow::Result<()> {
+        let _ = tx.send(LlmEvent::Delta { text: prompt }).await;
+        tokio::time::sleep(self.delay).await;
+        let _ = tx.send(LlmEvent::Done).await;
+        Ok(())
+    }
+}
+
+async fn connect_and_send(sock: &std::path::Path, req: &Request) -> Vec<Event> {
+    let stream = UnixStream::connect(sock).await.unwrap();
+    let (read, mut write) = stream.into_split();
+    let mut body = serde_json::to_string(req).unwrap();
+    body.push('\n');
+    write.write_all(body.as_bytes()).await.unwrap();
+    write.shutdown().await.unwrap();
+
+    let mut reader = BufReader::new(read);
+    let mut events = Vec::new();
+    loop {
+        let mut line = String::new();
+        let n = reader.read_line(&mut line).await.unwrap();
+        if n == 0 {
+            break;
+        }
+        let e: Event = serde_json::from_str(line.trim()).unwrap();
+        let terminal = e.is_terminal();
+        events.push(e);
+        if terminal {
+            break;
+        }
+    }
+    events
+}
+
+#[tokio::test]
+async fn sleep_defers_until_inflight_query_done() {
+    let _g = MODE_LOCK.lock().await;
+    init_tracing();
+    let port = grab_port().await;
+    let (m, _shutdown) = new_active_manager(port).await;
+
+    let state = Arc::new(AppState::new(
+        Config::default(),
+        Arc::new(DelayBackend {
+            delay: Duration::from_millis(500),
+        }),
+        m.clone(),
+    ));
+
+    let dir = tempfile::tempdir().unwrap();
+    let sock_path = dir.path().join("assistd.sock");
+    let (stop_tx, stop_rx) = oneshot::channel::<()>();
+    let server_path = sock_path.clone();
+    let server = tokio::spawn(async move {
+        assistd_core::socket::serve_at(&server_path, state, async {
+            let _ = stop_rx.await;
+        })
+        .await
+        .unwrap();
+    });
+
+    for _ in 0..200 {
+        if UnixStream::connect(&sock_path).await.is_ok() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+
+    // Kick off the query; it'll emit a Delta ~immediately, then sleep 500ms,
+    // then emit Done.
+    let req = Request::Query {
+        id: "q1".into(),
+        text: "hello".into(),
+    };
+    let sock_for_client = sock_path.clone();
+    let client_task = tokio::spawn(async move { connect_and_send(&sock_for_client, &req).await });
+
+    // Give the query a head start so the request guard is taken before
+    // we issue the sleep.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Request sleep while the query is still streaming. The sleep must
+    // not complete until the generator finishes.
+    let m_for_sleep = m.clone();
+    let sleep_started = std::time::Instant::now();
+    let sleep_task = tokio::spawn(async move { m_for_sleep.sleep().await });
+
+    // Wait for the client to drain its full event stream.
+    let events = client_task.await.unwrap();
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, Event::Delta { text, .. } if text == "hello")),
+        "expected Delta event in stream, got {events:?}"
+    );
+    assert!(
+        matches!(events.last(), Some(Event::Done { .. })),
+        "expected terminal Done, got {events:?}"
+    );
+    assert!(
+        !events.iter().any(|e| matches!(e, Event::Error { .. })),
+        "no Error events expected, got {events:?}"
+    );
+
+    // Now sleep is free to proceed; it must not have completed before
+    // the generator finished.
+    sleep_task.await.unwrap().expect("sleep returned Err");
+    let sleep_elapsed = sleep_started.elapsed();
+    assert!(
+        sleep_elapsed >= Duration::from_millis(350),
+        "sleep finished in {sleep_elapsed:?}, expected >=350ms (block on the 500ms DelayBackend \
+         minus the 100ms head start and a little slack)"
+    );
+    assert_eq!(m.state(), PresenceState::Sleeping);
+
+    let _ = stop_tx.send(());
+    server.await.unwrap();
+}
+
+#[tokio::test]
+async fn multiple_queries_during_wake_complete_in_order() {
+    let _g = MODE_LOCK.lock().await;
+    init_tracing();
+    let port = grab_port().await;
+    let (m, _shutdown) = new_active_manager(port).await;
+
+    let state = Arc::new(AppState::new(
+        Config::default(),
+        Arc::new(EchoBackend),
+        m.clone(),
+    ));
+
+    let dir = tempfile::tempdir().unwrap();
+    let sock_path = dir.path().join("assistd.sock");
+    let (stop_tx, stop_rx) = oneshot::channel::<()>();
+    let server_path = sock_path.clone();
+    let server = tokio::spawn(async move {
+        assistd_core::socket::serve_at(&server_path, state, async {
+            let _ = stop_rx.await;
+        })
+        .await
+        .unwrap();
+    });
+
+    for _ in 0..200 {
+        if UnixStream::connect(&sock_path).await.is_ok() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+
+    // Put the daemon to sleep so the next queries have to wake it.
+    m.sleep().await.unwrap();
+    assert_eq!(m.state(), PresenceState::Sleeping);
+
+    // Fire 5 concurrent queries with distinct ids. They race into
+    // acquire_request_guard → ensure_active → transition lock; one
+    // wins the wake, the rest queue on the transition mutex.
+    let mut handles = Vec::new();
+    for i in 0..5 {
+        let id = format!("q{i}");
+        let text = format!("msg{i}");
+        let sock = sock_path.clone();
+        let req = Request::Query {
+            id: id.clone(),
+            text: text.clone(),
+        };
+        handles.push((
+            id,
+            text,
+            tokio::spawn(async move { connect_and_send(&sock, &req).await }),
+        ));
+    }
+
+    for (id, text, h) in handles {
+        let events = h.await.unwrap();
+        assert!(
+            !events.iter().any(|e| matches!(e, Event::Error { .. })),
+            "query {id} received Error events: {events:?}"
+        );
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, Event::Delta { text: t, .. } if *t == text)),
+            "query {id} missing expected Delta {text:?}: {events:?}"
+        );
+        assert!(
+            matches!(events.last(), Some(Event::Done { id: done_id }) if *done_id == id),
+            "query {id} missing terminal Done: {events:?}"
+        );
+    }
+
+    assert_eq!(
+        m.state(),
+        PresenceState::Active,
+        "wake must leave manager Active"
     );
 
     let _ = stop_tx.send(());

--- a/crates/assistd/src/chat/app.rs
+++ b/crates/assistd/src/chat/app.rs
@@ -193,19 +193,25 @@ impl App {
         let tx = self.chat_tx.clone();
         let presence = self.presence.clone();
         tokio::spawn(async move {
-            // Auto-wake before generating so a user hitting Enter from
-            // Drowsy/Sleeping sees the response stream once the model is
-            // ready, instead of hitting a raw HTTP error on a dead server.
-            if let Some(p) = presence.as_ref() {
-                if p.state() != PresenceState::Active {
-                    if let Err(e) = p.ensure_active().await {
+            // Auto-wake and take an in-flight guard so a user hitting
+            // Enter from Drowsy/Sleeping sees the response stream once
+            // the model is ready, and so a concurrent sleep waits for
+            // this generation to finish before tearing down
+            // llama-server. The guard is held until the end of this
+            // task.
+            let _request_guard = if let Some(p) = presence.as_ref() {
+                match p.acquire_request_guard().await {
+                    Ok(g) => Some(g),
+                    Err(e) => {
                         let _ = tx
                             .send(ChatEvent::LlmError(format!("wake failed: {e:#}")))
                             .await;
                         return;
                     }
                 }
-            }
+            } else {
+                None
+            };
             let (llm_tx, mut llm_rx) = mpsc::channel::<LlmEvent>(64);
             let tx_fwd = tx.clone();
             let forwarder = tokio::spawn(async move {

--- a/crates/assistd/src/chat/ui.rs
+++ b/crates/assistd/src/chat/ui.rs
@@ -82,23 +82,41 @@ fn render_status(frame: &mut Frame, area: Rect, app: &App) {
     let reversed = Style::default().add_modifier(Modifier::REVERSED);
     let mut left_spans: Vec<Span> = Vec::new();
     left_spans.push(Span::styled(format!("model: {}", app.model_name), reversed));
-    if let Some((dot, label)) = presence_dot(app.presence_state) {
+    let wake_started = app.presence.as_ref().and_then(|p| p.wake_in_progress());
+    if let Some(started) = wake_started {
+        // Override the presence segment during an active wake: the
+        // regular dot + idle countdown are meaningless while the
+        // daemon is mid-transition to Active.
         left_spans.push(Span::raw(" "));
         left_spans.push(Span::styled(
-            "●",
-            Style::default().fg(dot).add_modifier(Modifier::BOLD),
+            format!(
+                "{} waking up ({}s)",
+                app.spinner_char(),
+                started.elapsed().as_secs()
+            ),
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::REVERSED),
         ));
-        left_spans.push(Span::styled(format!(" {label}"), reversed));
-    }
-    if let Some(remaining) = app
-        .presence
-        .as_ref()
-        .and_then(|p| p.time_until_next_transition(&app.sleep_cfg))
-    {
-        left_spans.push(Span::styled(
-            format!(" ({})", format_countdown(remaining)),
-            reversed,
-        ));
+    } else {
+        if let Some((dot, label)) = presence_dot(app.presence_state) {
+            left_spans.push(Span::raw(" "));
+            left_spans.push(Span::styled(
+                "●",
+                Style::default().fg(dot).add_modifier(Modifier::BOLD),
+            ));
+            left_spans.push(Span::styled(format!(" {label}"), reversed));
+        }
+        if let Some(remaining) = app
+            .presence
+            .as_ref()
+            .and_then(|p| p.time_until_next_transition(&app.sleep_cfg))
+        {
+            left_spans.push(Span::styled(
+                format!(" ({})", format_countdown(remaining)),
+                reversed,
+            ));
+        }
     }
     left_spans.push(Span::styled(format!(" │ {state}"), reversed));
     if let Some(r) = rate {


### PR DESCRIPTION
Handling in flight request during sleep states or state transitions. requests made while the deamon or TUI are asleep are not lost during transition to a more wakeful state.