### PR TITLE
Milestone 3 refinement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,12 @@ jobs:
       - name: Test
         run: cargo test --workspace --all-features --locked
 
+      - name: cargo-deny (advisories, licenses, bans)
+        uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check
+          arguments: --all-features
+
       - name: Release build (default features)
         run: cargo build --release -p assistd-cli --locked
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,6 +106,7 @@ dependencies = [
  "anyhow",
  "assistd-ipc",
  "assistd-llm",
+ "async-trait",
  "serde",
  "serde_json",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,13 +16,15 @@ edition = "2024"
 license = "Apache-2.0"
 
 [workspace.dependencies]
-# Internal crates
-assistd-core  = { path = "crates/assistd-core" }
-assistd-ipc   = { path = "crates/assistd-ipc" }
-assistd-llm   = { path = "crates/assistd-llm" }
-assistd-voice = { path = "crates/assistd-voice" }
-assistd-tools = { path = "crates/assistd-tools" }
-assistd-wm    = { path = "crates/assistd-wm" }
+# Internal crates. `version` is declared alongside `path` so tooling that
+# inspects workspace manifests (e.g. cargo-deny) doesn't treat these as
+# wildcard deps. `path` still wins for local builds.
+assistd-core  = { version = "0.1", path = "crates/assistd-core" }
+assistd-ipc   = { version = "0.1", path = "crates/assistd-ipc" }
+assistd-llm   = { version = "0.1", path = "crates/assistd-llm" }
+assistd-voice = { version = "0.1", path = "crates/assistd-voice" }
+assistd-tools = { version = "0.1", path = "crates/assistd-tools" }
+assistd-wm    = { version = "0.1", path = "crates/assistd-wm" }
 
 # External crates
 serde = { version = "1", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,3 +44,10 @@ futures-util = "0.3"
 tracing-appender = "0.2"
 textwrap = "0.16"
 nvml-wrapper = "0.12"
+
+[profile.release]
+lto = "thin"
+codegen-units = 1
+strip = "symbols"
+panic = "abort"
+debug = "line-tables-only"

--- a/config/config.sample.toml
+++ b/config/config.sample.toml
@@ -110,3 +110,10 @@ port = 8384
 # compositor config instead, e.g. Sway:
 #   bindsym $mod+Escape exec assistd cycle
 hotkey = "Super+Escape"
+
+[daemon]
+# Seconds to wait for in-flight IPC connections (e.g. streaming LLM
+# responses) to finish before aborting them on daemon shutdown. 0 aborts
+# all in-flight work immediately; higher values let clients receive a
+# final Done event before the daemon exits.
+# shutdown_grace_secs = 5

--- a/crates/assistd-core/Cargo.toml
+++ b/crates/assistd-core/Cargo.toml
@@ -17,3 +17,4 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"
+async-trait = { workspace = true }

--- a/crates/assistd-core/src/config.rs
+++ b/crates/assistd-core/src/config.rs
@@ -15,6 +15,8 @@ pub struct Config {
     pub remote: RemoteConfig,
     #[serde(default)]
     pub presence: PresenceConfig,
+    #[serde(default)]
+    pub daemon: DaemonConfig,
 }
 
 /// Local model settings.
@@ -177,6 +179,28 @@ fn default_presence_hotkey() -> String {
     "Super+Escape".to_string()
 }
 
+/// Daemon process lifecycle settings.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct DaemonConfig {
+    /// Seconds to wait for in-flight IPC connections (e.g. streaming LLM
+    /// responses) to finish before aborting them on daemon shutdown. `0`
+    /// aborts in-flight work immediately.
+    #[serde(default = "default_shutdown_grace_secs")]
+    pub shutdown_grace_secs: u64,
+}
+
+impl Default for DaemonConfig {
+    fn default() -> Self {
+        Self {
+            shutdown_grace_secs: default_shutdown_grace_secs(),
+        }
+    }
+}
+
+fn default_shutdown_grace_secs() -> u64 {
+    5
+}
+
 fn default_gpu_layers() -> u32 {
     9999
 }
@@ -274,6 +298,7 @@ impl Default for Config {
                 port: 8384,
             },
             presence: PresenceConfig::default(),
+            daemon: DaemonConfig::default(),
         }
     }
 }

--- a/crates/assistd-core/src/lib.rs
+++ b/crates/assistd-core/src/lib.rs
@@ -5,7 +5,7 @@ pub mod state;
 
 pub use assistd_ipc as ipc;
 pub use assistd_ipc::PresenceState;
-pub use config::{Config, PresenceConfig, SleepConfig};
+pub use config::{Config, DaemonConfig, PresenceConfig, SleepConfig};
 pub use presence::{PresenceManager, RequestGuard};
 pub use state::AppState;
 

--- a/crates/assistd-core/src/presence.rs
+++ b/crates/assistd-core/src/presence.rs
@@ -138,6 +138,15 @@ impl PresenceManager {
 
         // Forwarder: when daemon shutdown fires, flip whatever inner-shutdown
         // sender is currently active. Lives for the daemon's lifetime.
+        //
+        // The `JoinHandle` is intentionally discarded: the task is bounded
+        // by the daemon-shutdown watch channel. It exits via one of two
+        // paths — `wait_for` returns `Ok` once shutdown fires (the normal
+        // case), or `Err` if every `watch::Sender` clone for daemon
+        // shutdown is dropped (which implies the daemon is already tearing
+        // down). `PresenceManager` also holds `_daemon_shutdown:
+        // watch::Receiver` below to keep the subscription valid for the
+        // manager's lifetime.
         {
             let mut daemon_rx = daemon_shutdown.clone();
             let current = Arc::clone(&current_inner_shutdown);

--- a/crates/assistd-core/src/socket.rs
+++ b/crates/assistd-core/src/socket.rs
@@ -3,10 +3,12 @@ use assistd_ipc::{Event, Request};
 use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::Duration;
 use thiserror::Error;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{UnixListener, UnixStream};
 use tokio::sync::mpsc;
+use tokio::task::JoinSet;
 use tracing::{debug, error, info, warn};
 
 const EVENT_CHANNEL_CAPACITY: usize = 32;
@@ -83,18 +85,21 @@ async fn accept_loop<F>(
 where
     F: Future<Output = ()>,
 {
+    let grace = Duration::from_secs(state.config.daemon.shutdown_grace_secs);
+    let mut connections: JoinSet<()> = JoinSet::new();
+
     tokio::pin!(shutdown);
     loop {
         tokio::select! {
             _ = &mut shutdown => {
                 info!("shutting down socket listener");
-                return Ok(());
+                break;
             }
             accepted = listener.accept() => {
                 match accepted {
                     Ok((stream, _addr)) => {
                         let conn_state = state.clone();
-                        tokio::spawn(async move {
+                        connections.spawn(async move {
                             if let Err(e) = handle_connection(stream, conn_state).await {
                                 error!("connection error: {e}");
                             }
@@ -105,8 +110,54 @@ where
                     }
                 }
             }
+            // Reap finished connections eagerly so the set doesn't grow
+            // unbounded. `join_next` yields `None` when the set is empty,
+            // which would busy-loop; gate on `len()` to avoid that.
+            Some(res) = connections.join_next(), if !connections.is_empty() => {
+                if let Err(e) = res
+                    && e.is_panic()
+                {
+                    error!("connection task panicked: {e}");
+                }
+            }
         }
     }
+
+    // Stop accepting and drain in-flight handlers with bounded grace so
+    // streaming responses can emit their final `Done` event before the
+    // daemon exits.
+    drop(listener);
+
+    let in_flight = connections.len();
+    if in_flight == 0 {
+        return Ok(());
+    }
+    info!(
+        grace_secs = grace.as_secs(),
+        in_flight, "draining in-flight connections"
+    );
+
+    let drained = tokio::time::timeout(grace, async {
+        while let Some(res) = connections.join_next().await {
+            if let Err(e) = res
+                && e.is_panic()
+            {
+                error!("connection task panicked: {e}");
+            }
+        }
+    })
+    .await;
+
+    if drained.is_err() {
+        let remaining = connections.len();
+        warn!(
+            remaining,
+            "shutdown grace expired; aborting remaining connections"
+        );
+        connections.shutdown().await;
+    }
+
+    Ok(())
 }
 
 async fn handle_connection(stream: UnixStream, state: Arc<AppState>) -> Result<(), SocketError> {
@@ -135,17 +186,26 @@ async fn handle_connection(stream: UnixStream, state: Arc<AppState>) -> Result<(
 
     let (tx, mut rx) = mpsc::channel::<Event>(EVENT_CHANNEL_CAPACITY);
     let dispatch_state = state.clone();
-    let dispatcher = tokio::spawn(async move { dispatch_state.dispatch(req, tx).await });
 
-    while let Some(event) = rx.recv().await {
-        write_event(&mut write_half, &event).await?;
-    }
+    // Dispatch and event-forwarding run concurrently on this task rather
+    // than on a spawned child. If the task is cancelled (e.g. the outer
+    // accept loop hits its shutdown grace and calls `JoinSet::shutdown`),
+    // both halves are torn down together — the dispatcher can't be
+    // orphaned.
+    let dispatch_fut = async move { dispatch_state.dispatch(req, tx).await };
+    let forward_fut = async {
+        while let Some(event) = rx.recv().await {
+            write_event(&mut write_half, &event).await?;
+        }
+        Ok::<(), SocketError>(())
+    };
 
-    match dispatcher.await {
-        Ok(Ok(())) => {}
-        Ok(Err(e)) => error!("dispatch error: {e:#}"),
-        Err(e) => error!("dispatch task panicked: {e}"),
+    let (dispatch_res, forward_res) = tokio::join!(dispatch_fut, forward_fut);
+
+    if let Err(e) = dispatch_res {
+        error!("dispatch error: {e:#}");
     }
+    forward_res?;
 
     write_half.shutdown().await?;
     Ok(())
@@ -346,5 +406,182 @@ mod tests {
 
         tx.send(()).unwrap();
         server.await.unwrap();
+    }
+
+    /// Backend that emits N deltas with a fixed pause between each, then
+    /// Done. Used to exercise graceful shutdown of in-flight streams.
+    struct SlowBackend {
+        deltas: usize,
+        pause: std::time::Duration,
+    }
+
+    #[async_trait::async_trait]
+    impl assistd_llm::LlmBackend for SlowBackend {
+        async fn generate(
+            &self,
+            _prompt: String,
+            tx: tokio::sync::mpsc::Sender<assistd_llm::LlmEvent>,
+        ) -> anyhow::Result<()> {
+            for i in 0..self.deltas {
+                let _ = tx
+                    .send(assistd_llm::LlmEvent::Delta {
+                        text: format!("d{i}"),
+                    })
+                    .await;
+                tokio::time::sleep(self.pause).await;
+            }
+            let _ = tx.send(assistd_llm::LlmEvent::Done).await;
+            Ok(())
+        }
+    }
+
+    /// Backend that emits a single delta then blocks indefinitely on an
+    /// un-awoken channel. Used to exercise the shutdown grace timeout.
+    struct StuckBackend;
+
+    #[async_trait::async_trait]
+    impl assistd_llm::LlmBackend for StuckBackend {
+        async fn generate(
+            &self,
+            _prompt: String,
+            tx: tokio::sync::mpsc::Sender<assistd_llm::LlmEvent>,
+        ) -> anyhow::Result<()> {
+            let _ = tx
+                .send(assistd_llm::LlmEvent::Delta {
+                    text: "stuck".into(),
+                })
+                .await;
+            // Park forever; this future is cancelled when the parent
+            // task is aborted via JoinSet::shutdown.
+            std::future::pending::<()>().await;
+            Ok(())
+        }
+    }
+
+    fn state_with_backend_and_grace(
+        backend: Arc<dyn assistd_llm::LlmBackend>,
+        grace_secs: u64,
+    ) -> Arc<AppState> {
+        let mut config = Config::default();
+        config.daemon.shutdown_grace_secs = grace_secs;
+        Arc::new(AppState::new(
+            config,
+            backend,
+            PresenceManager::stub(PresenceState::Active),
+        ))
+    }
+
+    #[tokio::test]
+    async fn graceful_shutdown_waits_for_in_flight_stream() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("assistd.sock");
+        let (tx, rx) = oneshot::channel::<()>();
+        let server_path = path.clone();
+        let state = state_with_backend_and_grace(
+            Arc::new(SlowBackend {
+                deltas: 3,
+                pause: std::time::Duration::from_millis(50),
+            }),
+            5,
+        );
+        let server = tokio::spawn(async move {
+            serve_at(&server_path, state, async {
+                let _ = rx.await;
+            })
+            .await
+            .unwrap();
+        });
+
+        wait_for_listener(&path).await;
+
+        let stream = UnixStream::connect(&path).await.unwrap();
+        let (read, mut write) = stream.into_split();
+        write
+            .write_all(br#"{"type":"query","id":"s1","text":"go"}"#)
+            .await
+            .unwrap();
+        write.write_all(b"\n").await.unwrap();
+        write.shutdown().await.unwrap();
+
+        let mut reader = BufReader::new(read);
+
+        // Wait for the first Delta, then trigger shutdown mid-stream.
+        let mut first = String::new();
+        let n = reader.read_line(&mut first).await.unwrap();
+        assert!(n > 0, "expected first Delta to arrive");
+        let ev: Event = serde_json::from_str(first.trim()).unwrap();
+        assert!(matches!(ev, Event::Delta { .. }));
+
+        tx.send(()).unwrap();
+
+        // All remaining Deltas and the terminal Done must still arrive
+        // before the stream closes, because grace (5s) comfortably
+        // exceeds the remaining ~100ms of backend work.
+        let mut seen_delta = 1;
+        let mut seen_done = false;
+        loop {
+            let mut line = String::new();
+            let n = reader.read_line(&mut line).await.unwrap();
+            if n == 0 {
+                break;
+            }
+            let event: Event = serde_json::from_str(line.trim()).unwrap();
+            match event {
+                Event::Delta { .. } => seen_delta += 1,
+                Event::Done { .. } => {
+                    seen_done = true;
+                    break;
+                }
+                other => panic!("unexpected event during graceful shutdown: {other:?}"),
+            }
+        }
+        assert_eq!(seen_delta, 3, "expected all 3 deltas to arrive");
+        assert!(seen_done, "expected terminal Done before connection close");
+
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn graceful_shutdown_aborts_after_grace_timeout() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("assistd.sock");
+        let (tx, rx) = oneshot::channel::<()>();
+        let server_path = path.clone();
+        // Grace = 0 (no wait). Shutdown aborts the stuck connection
+        // immediately after the accept loop exits.
+        let state = state_with_backend_and_grace(Arc::new(StuckBackend), 0);
+        let server = tokio::spawn(async move {
+            serve_at(&server_path, state, async {
+                let _ = rx.await;
+            })
+            .await
+            .unwrap();
+        });
+
+        wait_for_listener(&path).await;
+
+        let stream = UnixStream::connect(&path).await.unwrap();
+        let (read, mut write) = stream.into_split();
+        write
+            .write_all(br#"{"type":"query","id":"s2","text":"hang"}"#)
+            .await
+            .unwrap();
+        write.write_all(b"\n").await.unwrap();
+        write.shutdown().await.unwrap();
+
+        let mut reader = BufReader::new(read);
+        let mut first = String::new();
+        let n = reader.read_line(&mut first).await.unwrap();
+        assert!(n > 0, "expected first Delta from StuckBackend");
+
+        tx.send(()).unwrap();
+
+        // Server task must exit promptly — the grace is 0, so the
+        // connection is aborted as soon as shutdown fires. Bound with
+        // a 2s timeout so a regression doesn't hang the test forever.
+        tokio::time::timeout(std::time::Duration::from_secs(2), server)
+            .await
+            .expect("server did not exit within 2s of shutdown")
+            .unwrap();
     }
 }

--- a/crates/assistd-core/src/state.rs
+++ b/crates/assistd-core/src/state.rs
@@ -178,3 +178,140 @@ impl AppState {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Config;
+    use assistd_llm::{EchoBackend, FailedBackend};
+
+    fn test_state(backend: Arc<dyn LlmBackend>, initial_state: PresenceState) -> Arc<AppState> {
+        Arc::new(AppState::new(
+            Config::default(),
+            backend,
+            PresenceManager::stub(initial_state),
+        ))
+    }
+
+    async fn collect_events(mut rx: mpsc::Receiver<Event>) -> Vec<Event> {
+        let mut out = Vec::new();
+        while let Some(ev) = rx.recv().await {
+            out.push(ev);
+        }
+        out
+    }
+
+    #[tokio::test]
+    async fn dispatch_query_emits_delta_then_done() {
+        let state = test_state(Arc::new(EchoBackend), PresenceState::Active);
+        let (tx, rx) = mpsc::channel::<Event>(8);
+        let req = Request::Query {
+            id: "q1".into(),
+            text: "hello".into(),
+        };
+
+        state.dispatch(req, tx).await.unwrap();
+        let events = collect_events(rx).await;
+
+        assert_eq!(events.len(), 2, "expected Delta+Done, got {events:?}");
+        assert!(matches!(
+            &events[0],
+            Event::Delta { id, text } if id == "q1" && text == "hello"
+        ));
+        assert!(matches!(&events[1], Event::Done { id } if id == "q1"));
+    }
+
+    #[tokio::test]
+    async fn dispatch_set_presence_emits_presence_and_done() {
+        // Active → Sleeping avoids hitting the stub's non-existent
+        // control-plane endpoint while still exercising the transition
+        // path end-to-end.
+        let state = test_state(Arc::new(EchoBackend), PresenceState::Active);
+        let (tx, rx) = mpsc::channel::<Event>(8);
+        let req = Request::SetPresence {
+            id: "p1".into(),
+            target: PresenceState::Sleeping,
+        };
+
+        state.clone().dispatch(req, tx).await.unwrap();
+        let events = collect_events(rx).await;
+
+        assert_eq!(events.len(), 2, "expected Presence+Done, got {events:?}");
+        assert!(matches!(
+            &events[0],
+            Event::Presence { id, state: PresenceState::Sleeping } if id == "p1"
+        ));
+        assert!(matches!(&events[1], Event::Done { id } if id == "p1"));
+        assert_eq!(state.presence.state(), PresenceState::Sleeping);
+    }
+
+    #[tokio::test]
+    async fn dispatch_get_presence_reports_current_state_without_transition() {
+        let state = test_state(Arc::new(EchoBackend), PresenceState::Drowsy);
+        let (tx, rx) = mpsc::channel::<Event>(8);
+        let req = Request::GetPresence { id: "g1".into() };
+
+        state.clone().dispatch(req, tx).await.unwrap();
+        let events = collect_events(rx).await;
+
+        assert_eq!(events.len(), 2, "expected Presence+Done, got {events:?}");
+        assert!(matches!(
+            &events[0],
+            Event::Presence { id, state: PresenceState::Drowsy } if id == "g1"
+        ));
+        assert!(matches!(&events[1], Event::Done { id } if id == "g1"));
+        // State must be unchanged — GetPresence is a read-only snapshot.
+        assert_eq!(state.presence.state(), PresenceState::Drowsy);
+    }
+
+    #[tokio::test]
+    async fn dispatch_cycle_advances_to_next_state() {
+        // Drowsy → Sleeping: the Drowsy→Sleeping branch of `sleep()` is
+        // network-free when `llama` is None (as in the stub), so this
+        // exercises the full cycle path without a live server.
+        let state = test_state(Arc::new(EchoBackend), PresenceState::Drowsy);
+        let (tx, rx) = mpsc::channel::<Event>(8);
+        let req = Request::Cycle { id: "c1".into() };
+
+        state.clone().dispatch(req, tx).await.unwrap();
+        let events = collect_events(rx).await;
+
+        assert_eq!(events.len(), 2, "expected Presence+Done, got {events:?}");
+        assert!(matches!(
+            &events[0],
+            Event::Presence { id, state: PresenceState::Sleeping } if id == "c1"
+        ));
+        assert!(matches!(&events[1], Event::Done { id } if id == "c1"));
+        assert_eq!(state.presence.state(), PresenceState::Sleeping);
+    }
+
+    #[tokio::test]
+    async fn dispatch_query_backend_error_emits_error_event() {
+        let backend = Arc::new(FailedBackend::new("backend broken".into()));
+        let state = test_state(backend, PresenceState::Active);
+        let (tx, rx) = mpsc::channel::<Event>(8);
+        let req = Request::Query {
+            id: "q-err".into(),
+            text: "boom".into(),
+        };
+
+        let err = state.dispatch(req, tx).await.unwrap_err();
+        assert!(err.to_string().contains("backend broken"));
+
+        let events = collect_events(rx).await;
+        let err_event = events
+            .iter()
+            .find(|e| matches!(e, Event::Error { .. }))
+            .expect("expected Error event in stream");
+        match err_event {
+            Event::Error { id, message } => {
+                assert_eq!(id, "q-err");
+                assert!(
+                    message.contains("backend broken"),
+                    "error message should propagate backend reason: {message}"
+                );
+            }
+            _ => unreachable!(),
+        }
+    }
+}

--- a/crates/assistd/src/gpu_monitor.rs
+++ b/crates/assistd/src/gpu_monitor.rs
@@ -114,13 +114,23 @@ pub fn spawn_monitor(
         }
     };
 
-    let device_count = nvml.device_count().unwrap_or(0);
+    let device_count = match nvml.device_count() {
+        Ok(n) => n.to_string(),
+        Err(e) => {
+            warn!(
+                target: "assistd::gpu_monitor",
+                "nvml.device_count() failed: {e}. Monitor will still run, \
+                 but per-device enumeration may be unreliable."
+            );
+            "unknown".to_string()
+        }
+    };
     info!(
         target: "assistd::gpu_monitor",
         poll_secs = cfg.gpu_poll_secs,
         threshold_mb = cfg.gpu_vram_threshold_mb,
         auto_wake = cfg.gpu_auto_wake,
-        devices = device_count,
+        devices = %device_count,
         "GPU contention monitor enabled"
     );
 

--- a/deny.toml
+++ b/deny.toml
@@ -20,7 +20,12 @@ all-features = true
 db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
 yanked = "deny"
-ignore = []
+ignore = [
+    # paste 1.0.15 is archived/unmaintained but has no safe upgrade path;
+    # it is pulled in transitively by ratatui 0.29. Revisit when ratatui
+    # switches to `pastey` or a similar replacement.
+    "RUSTSEC-2024-0436",
+]
 
 # ---------------------------------------------------------------------------
 # Licenses — keep the dependency set Apache-2.0-compatible.
@@ -31,16 +36,14 @@ allow = [
     "Apache-2.0",
     "Apache-2.0 WITH LLVM-exception",
     "MIT",
-    "MIT-0",
-    "BSD-2-Clause",
     "BSD-3-Clause",
     "ISC",
-    "0BSD",
-    "Unicode-DFS-2016",
     "Unicode-3.0",
-    "MPL-2.0",
     "Zlib",
-    "CC0-1.0",
+    # webpki-roots 1.x ships Mozilla's root CA list under the Community
+    # Data License Agreement. It's a permissive data license and is fine
+    # for an Apache-2.0 downstream.
+    "CDLA-Permissive-2.0",
 ]
 
 # ---------------------------------------------------------------------------
@@ -56,6 +59,10 @@ allow = [
 [bans]
 multiple-versions = "warn"
 wildcards = "deny"
+# Workspace-internal crates use `path = ...` which cargo-deny would
+# otherwise flag as a wildcard. These are not published; they travel as
+# a unit with the workspace.
+allow-wildcard-paths = true
 highlight = "all"
 
 skip = [

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,88 @@
+# cargo-deny configuration for assistd.
+#
+# Checks licenses, advisories, and dependency duplication. Run locally with
+#   cargo deny check
+# or see .github/workflows/ci.yml for the CI invocation.
+#
+# Documentation: https://embarkstudios.github.io/cargo-deny/
+
+[graph]
+# Only the host target matters for this daemon.
+targets = [
+    { triple = "x86_64-unknown-linux-gnu" },
+]
+all-features = true
+
+# ---------------------------------------------------------------------------
+# Advisories — block known-vulnerable or yanked versions.
+# ---------------------------------------------------------------------------
+[advisories]
+db-path = "~/.cargo/advisory-db"
+db-urls = ["https://github.com/rustsec/advisory-db"]
+yanked = "deny"
+ignore = []
+
+# ---------------------------------------------------------------------------
+# Licenses — keep the dependency set Apache-2.0-compatible.
+# ---------------------------------------------------------------------------
+[licenses]
+confidence-threshold = 0.93
+allow = [
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "MIT",
+    "MIT-0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "0BSD",
+    "Unicode-DFS-2016",
+    "Unicode-3.0",
+    "MPL-2.0",
+    "Zlib",
+    "CC0-1.0",
+]
+
+# ---------------------------------------------------------------------------
+# Bans / multiple-version check.
+# ---------------------------------------------------------------------------
+#
+# We warn on duplicates rather than deny them: most are transitive via
+# mainstream crates (ratatui, nvml-wrapper, reqwest) that we don't control,
+# and an ecosystem-wide bump typically resolves them on its own. The
+# `skip` list below documents known, benign duplicates as of 2026-04 so
+# CI stays green without silently losing signal on *new* duplicates that
+# show up in future dependency updates.
+[bans]
+multiple-versions = "warn"
+wildcards = "deny"
+highlight = "all"
+
+skip = [
+    # Proc-macro helpers pulled in by different ecosystems (ratatui's
+    # `instability` vs. nvml-wrapper's `wrapcenum-derive`).
+    { name = "darling", version = "0.20" },
+    { name = "darling_core", version = "0.20" },
+    { name = "darling_macro", version = "0.20" },
+    # Transitive via crossterm (older) vs tempfile/x11rb (newer).
+    { name = "rustix", version = "0.38" },
+    { name = "linux-raw-sys", version = "0.4" },
+    # Transitive via ring/rustls (older) vs tempfile/uuid (newer).
+    { name = "getrandom", version = "0.2" },
+    # Transitive via ratatui (older) vs toml_edit/indexmap (newer).
+    { name = "hashbrown", version = "0.15" },
+    # Transitive via ratatui/unicode-truncate (older) vs newer consumers.
+    { name = "unicode-width", version = "0.1" },
+    # nvml-wrapper still pins thiserror 1; global-hotkey and
+    # tracing-appender pull thiserror 2.
+    { name = "thiserror", version = "1" },
+    { name = "thiserror-impl", version = "1" },
+]
+
+# ---------------------------------------------------------------------------
+# Sources — only crates.io is trusted.
+# ---------------------------------------------------------------------------
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]


### PR DESCRIPTION
- crates/assistd-core/src/socket.rs — accept_loop now uses JoinSet and    
  drains in-flight connections with bounded grace on shutdown.              
  handle_connection runs dispatch + forwarding via tokio::join! so task     
  cancellation tears both down together (no orphaned dispatchers). 2 new    
  tests pin the drain-with-grace and grace-timeout contracts.           
- crates/assistd-core/src/state.rs — 5 new unit tests pin  
  AppState::dispatch routing for                           
  Query/SetPresence/GetPresence/Cycle/backend-error paths.                  
- crates/assistd-core/src/presence.rs:139-161 — invariant comment on the
  shutdown-forwarder task.                                                  
- Cargo.toml — [profile.release] with lto = "thin", codegen-units = 1,    
  strip = "symbols", panic = "abort", debug = "line-tables-only".           
- crates/assistd/src/gpu_monitor.rs:117 — replaced unwrap_or(0) with a
  match that logs warn! on NVML errors.                                     
- crates/assistd-core/src/config.rs + config/config.sample.toml + lib.rs —
   new DaemonConfig { shutdown_grace_secs: u64 } (default 5), exported      
  alongside existing configs.                                               
- deny.toml + .github/workflows/ci.yml — cargo-deny CI step (advisories,
  licenses, bans with documented skip list).