### PR TITLE
Implement progressive --help discovery system

### DIFF
--- a/crates/assistd-tools/src/chain/executor.rs
+++ b/crates/assistd-tools/src/chain/executor.rs
@@ -217,6 +217,12 @@ mod tests {
         fn name(&self) -> &str {
             self.name
         }
+        fn summary(&self) -> &'static str {
+            "test stub"
+        }
+        fn help(&self) -> String {
+            "stub help".to_string()
+        }
         async fn run(&self, _input: CommandInput) -> Result<CommandOutput> {
             *self.invoked.lock().unwrap() = true;
             Ok(CommandOutput {
@@ -235,6 +241,12 @@ mod tests {
         fn name(&self) -> &str {
             "echo_stdin"
         }
+        fn summary(&self) -> &'static str {
+            "test: echo stdin"
+        }
+        fn help(&self) -> String {
+            "usage: echo_stdin".to_string()
+        }
         async fn run(&self, input: CommandInput) -> Result<CommandOutput> {
             Ok(CommandOutput::ok(input.stdin))
         }
@@ -246,6 +258,12 @@ mod tests {
     impl Command for LineCount {
         fn name(&self) -> &str {
             "lc"
+        }
+        fn summary(&self) -> &'static str {
+            "test: count lines"
+        }
+        fn help(&self) -> String {
+            "usage: lc".to_string()
         }
         async fn run(&self, input: CommandInput) -> Result<CommandOutput> {
             let n = input.stdin.iter().filter(|b| **b == b'\n').count();
@@ -259,6 +277,12 @@ mod tests {
     impl Command for Flood {
         fn name(&self) -> &str {
             "flood"
+        }
+        fn summary(&self) -> &'static str {
+            "test: emit N bytes"
+        }
+        fn help(&self) -> String {
+            "usage: flood".to_string()
         }
         async fn run(&self, _input: CommandInput) -> Result<CommandOutput> {
             Ok(CommandOutput::ok(vec![b'x'; self.0]))
@@ -463,6 +487,12 @@ mod tests {
         impl Command for Err1 {
             fn name(&self) -> &str {
                 "boom"
+            }
+            fn summary(&self) -> &'static str {
+                "test: always fails"
+            }
+            fn help(&self) -> String {
+                "usage: boom".to_string()
             }
             async fn run(&self, _: CommandInput) -> Result<CommandOutput> {
                 Ok(CommandOutput::failed(1, b"something went wrong\n".to_vec()))

--- a/crates/assistd-tools/src/command.rs
+++ b/crates/assistd-tools/src/command.rs
@@ -69,9 +69,26 @@ impl CommandOutput {
 }
 
 /// A single internal command (`cat`, `grep`, `bash`, …).
+///
+/// The `summary` / `help` split backs the progressive `--help` discovery
+/// system: `summary` is a ≤80-char one-liner that [`CommandRegistry`]
+/// aggregates for the `run` tool's Level-0 description (the list the LLM
+/// sees in its tool schema); `help` is the full usage block a command
+/// emits when invoked with insufficient arguments (Level-1). Commands
+/// with subcommands can return subcommand-specific help from within their
+/// own `run` body (Level-2).
 #[async_trait]
 pub trait Command: Send + Sync + 'static {
     fn name(&self) -> &str;
+    /// One-line advertisement (≤80 chars, no trailing newline). Used to
+    /// build the `run` tool's Level-0 description. Convention: terse verb
+    /// phrase, e.g. `"filter lines matching a pattern (supports -i, -v, -c)"`.
+    fn summary(&self) -> &'static str;
+    /// Full usage block. Emitted verbatim on stdout when the command is
+    /// called with insufficient arguments. Convention: first line begins
+    /// with `usage: <name> …` so the LLM can visually disambiguate help
+    /// output from a real `[<name>]\terror: …` failure.
+    fn help(&self) -> String;
     async fn run(&self, input: CommandInput) -> Result<CommandOutput>;
 }
 
@@ -113,6 +130,16 @@ impl CommandRegistry {
         v.sort_unstable();
         v
     }
+
+    /// `(name, summary)` pairs, sorted alphabetically by name. Consumed
+    /// by `RunTool::new` to build the dynamic Level-0 description the
+    /// LLM sees in its tool schema.
+    pub fn sorted_summaries(&self) -> Vec<(&str, &'static str)> {
+        let mut v: Vec<(&str, &'static str)> =
+            self.commands.iter().map(|c| (c.name(), c.summary())).collect();
+        v.sort_unstable_by_key(|(n, _)| *n);
+        v
+    }
 }
 
 #[cfg(test)]
@@ -126,6 +153,12 @@ mod tests {
         fn name(&self) -> &str {
             self.0
         }
+        fn summary(&self) -> &'static str {
+            "stub command for tests"
+        }
+        fn help(&self) -> String {
+            "stub help".to_string()
+        }
         async fn run(&self, _input: CommandInput) -> Result<CommandOutput> {
             Ok(CommandOutput::ok(Vec::new()))
         }
@@ -138,6 +171,63 @@ mod tests {
         reg.register(Stub("cat"));
         reg.register(Stub("ls"));
         assert_eq!(reg.sorted_names(), vec!["cat", "grep", "ls"]);
+    }
+
+    #[test]
+    fn sorted_summaries_is_alphabetical_and_paired() {
+        let mut reg = CommandRegistry::new();
+        reg.register(Stub("grep"));
+        reg.register(Stub("cat"));
+        reg.register(Stub("ls"));
+        let pairs = reg.sorted_summaries();
+        assert_eq!(pairs.len(), 3);
+        assert_eq!(pairs[0].0, "cat");
+        assert_eq!(pairs[1].0, "grep");
+        assert_eq!(pairs[2].0, "ls");
+        // Every pair carries a non-empty summary.
+        for (name, summary) in &pairs {
+            assert!(!summary.is_empty(), "{name} has empty summary");
+        }
+    }
+
+    /// Acceptance criterion #6: every registered production command has a
+    /// non-empty `help()` return value. Also asserts `summary()` is
+    /// non-empty and within the ≤80-char budget, since the Level-0
+    /// description is the contract the LLM actually consumes.
+    #[test]
+    fn every_registered_command_has_nonempty_help_and_summary() {
+        use crate::commands::{
+            BashCommand, CatCommand, EchoCommand, GrepCommand, LsCommand, SeeCommand, WcCommand,
+            WebCommand, WriteCommand,
+        };
+        let mut reg = CommandRegistry::new();
+        reg.register(CatCommand);
+        reg.register(LsCommand);
+        reg.register(GrepCommand);
+        reg.register(WcCommand);
+        reg.register(EchoCommand);
+        reg.register(WriteCommand);
+        reg.register(SeeCommand);
+        reg.register(WebCommand::new());
+        reg.register(BashCommand::default());
+        assert_eq!(reg.len(), 9);
+        for (name, summary) in reg.sorted_summaries() {
+            assert!(!summary.is_empty(), "{name} has empty summary");
+            assert!(
+                summary.len() <= 80,
+                "{name} summary is {} chars (>80): {summary:?}",
+                summary.len()
+            );
+            let help = reg
+                .get(name)
+                .expect("command registered")
+                .help();
+            assert!(!help.is_empty(), "{name} has empty help");
+            assert!(
+                help.contains("usage:"),
+                "{name} help should contain `usage:` line — got {help:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/assistd-tools/src/command.rs
+++ b/crates/assistd-tools/src/command.rs
@@ -135,8 +135,11 @@ impl CommandRegistry {
     /// by `RunTool::new` to build the dynamic Level-0 description the
     /// LLM sees in its tool schema.
     pub fn sorted_summaries(&self) -> Vec<(&str, &'static str)> {
-        let mut v: Vec<(&str, &'static str)> =
-            self.commands.iter().map(|c| (c.name(), c.summary())).collect();
+        let mut v: Vec<(&str, &'static str)> = self
+            .commands
+            .iter()
+            .map(|c| (c.name(), c.summary()))
+            .collect();
         v.sort_unstable_by_key(|(n, _)| *n);
         v
     }
@@ -218,10 +221,7 @@ mod tests {
                 "{name} summary is {} chars (>80): {summary:?}",
                 summary.len()
             );
-            let help = reg
-                .get(name)
-                .expect("command registered")
-                .help();
+            let help = reg.get(name).expect("command registered").help();
             assert!(!help.is_empty(), "{name} has empty help");
             assert!(
                 help.contains("usage:"),

--- a/crates/assistd-tools/src/commands/bash.rs
+++ b/crates/assistd-tools/src/commands/bash.rs
@@ -44,12 +44,31 @@ impl Command for BashCommand {
         "bash"
     }
 
+    fn summary(&self) -> &'static str {
+        "escape hatch: run a bash -c <script> subprocess (30s timeout)"
+    }
+
+    fn help(&self) -> String {
+        "usage: bash \"<script>\"\n\
+         \n\
+         Spawn a real `bash -c <script>` subprocess. The escape hatch for \
+         anything the in-process commands can't express: redirections, env \
+         expansion, backgrounding, pipes the chain parser doesn't support.\n\
+         \n\
+         Stdin is forwarded to the script's stdin. Stdout/stderr/exit-code \
+         are captured. Exit 124 on timeout (30s default), 127 if the spawn \
+         itself failed, 137 if killed by signal.\n"
+            .to_string()
+    }
+
     async fn run(&self, input: CommandInput) -> Result<CommandOutput> {
         if input.args.is_empty() {
-            return Ok(CommandOutput::failed(
-                2,
-                b"missing script argument; use: bash \"<script>\"\n".to_vec(),
-            ));
+            return Ok(CommandOutput {
+                stdout: self.help().into_bytes(),
+                stderr: Vec::new(),
+                exit_code: 2,
+                attachments: Vec::new(),
+            });
         }
         let script = input.args.join(" ");
 

--- a/crates/assistd-tools/src/commands/cat.rs
+++ b/crates/assistd-tools/src/commands/cat.rs
@@ -15,6 +15,23 @@ impl Command for CatCommand {
         "cat"
     }
 
+    fn summary(&self) -> &'static str {
+        "read text files or stdin; binary rejected (see `see`, `cat -b`)"
+    }
+
+    fn help(&self) -> String {
+        "usage: cat [-b] [FILE]...\n\
+         \n\
+         Concatenate files, or echo stdin if no files given. Binary files \
+         are rejected so their raw bytes don't pollute the model's context.\n\
+         \n\
+         Flags:\n  \
+           -b  print metadata (mime, size) instead of content — safe for binary files\n\
+         \n\
+         For image files, use `see PATH` to attach them as a vision input.\n"
+            .to_string()
+    }
+
     async fn run(&self, input: CommandInput) -> Result<CommandOutput> {
         let (metadata_only, files) = partition_flags(&input.args);
 

--- a/crates/assistd-tools/src/commands/echo.rs
+++ b/crates/assistd-tools/src/commands/echo.rs
@@ -12,6 +12,18 @@ impl Command for EchoCommand {
         "echo"
     }
 
+    fn summary(&self) -> &'static str {
+        "write arguments joined by spaces, followed by a newline"
+    }
+
+    fn help(&self) -> String {
+        "usage: echo [ARGS...]\n\
+         \n\
+         Write the argument list joined by single spaces, followed by a \
+         newline. With no arguments, emits a bare newline.\n"
+            .to_string()
+    }
+
     async fn run(&self, input: CommandInput) -> Result<CommandOutput> {
         let mut out = input.args.join(" ").into_bytes();
         out.push(b'\n');

--- a/crates/assistd-tools/src/commands/grep.rs
+++ b/crates/assistd-tools/src/commands/grep.rs
@@ -58,15 +58,51 @@ impl Command for GrepCommand {
         "grep"
     }
 
+    fn summary(&self) -> &'static str {
+        "filter lines matching a pattern (supports -i, -v, -c)"
+    }
+
+    fn help(&self) -> String {
+        "usage: grep [-ivc] PATTERN [FILE]\n\
+         \n\
+         Print lines from FILE (or stdin) that match the regex PATTERN.\n\
+         \n\
+         Flags:\n  \
+           -i  case-insensitive\n  \
+           -v  invert match (print non-matching lines)\n  \
+           -c  print the count instead of the matching lines\n\
+         \n\
+         Flags can be combined (e.g. `-ivc`). Exit 0 if any line matched \
+         (or the count is non-zero under `-c`), 1 if no matches, 2 on \
+         usage/input errors.\n"
+            .to_string()
+    }
+
     async fn run(&self, input: CommandInput) -> Result<CommandOutput> {
+        if input.args.is_empty() {
+            return Ok(CommandOutput {
+                stdout: self.help().into_bytes(),
+                stderr: Vec::new(),
+                exit_code: 2,
+                attachments: Vec::new(),
+            });
+        }
         let (flags, positional) = match parse_flags(&input.args) {
             Ok(v) => v,
             Err(msg) => {
-                return Ok(CommandOutput::failed(2, format!("{msg}\n").into_bytes()));
+                return Ok(CommandOutput::failed(
+                    2,
+                    format!("error: {msg}\n").into_bytes(),
+                ));
             }
         };
         if positional.is_empty() {
-            return Ok(CommandOutput::failed(2, b"missing pattern\n".to_vec()));
+            return Ok(CommandOutput {
+                stdout: self.help().into_bytes(),
+                stderr: Vec::new(),
+                exit_code: 2,
+                attachments: Vec::new(),
+            });
         }
 
         let pattern = &positional[0];

--- a/crates/assistd-tools/src/commands/ls.rs
+++ b/crates/assistd-tools/src/commands/ls.rs
@@ -15,6 +15,20 @@ impl Command for LsCommand {
         "ls"
     }
 
+    fn summary(&self) -> &'static str {
+        "list directory entries (type, size, name); defaults to cwd"
+    }
+
+    fn help(&self) -> String {
+        "usage: ls [PATH]\n\
+         \n\
+         List directory entries alphabetically, one per line, formatted as \
+         `<type>\\t<size>\\t<name>`. `<type>` is `dir`, `file`, or `symlink`; \
+         `<size>` is bytes from the entry's (symlink-preserving) metadata. \
+         Defaults to the daemon's CWD if PATH is omitted.\n"
+            .to_string()
+    }
+
     async fn run(&self, input: CommandInput) -> Result<CommandOutput> {
         let path = input.args.first().map(|s| s.as_str()).unwrap_or(".");
         let mut reader = match tokio::fs::read_dir(path).await {

--- a/crates/assistd-tools/src/commands/see.rs
+++ b/crates/assistd-tools/src/commands/see.rs
@@ -19,11 +19,35 @@ impl Command for SeeCommand {
         "see"
     }
 
+    fn summary(&self) -> &'static str {
+        "attach an image file as a vision input for the next LLM turn"
+    }
+
+    fn help(&self) -> String {
+        "usage: see PATH\n\
+         \n\
+         Read the image file at PATH and attach it to the tool result as a \
+         vision input. The chat loop surfaces the attachment on the model's \
+         next turn. Attachments flow through pipes untouched (e.g. \
+         `see img.png | wc` still surfaces the image).\n\
+         \n\
+         Exit 1 if the file is missing or not a recognized image format.\n"
+            .to_string()
+    }
+
     async fn run(&self, input: CommandInput) -> Result<CommandOutput> {
+        if input.args.is_empty() {
+            return Ok(CommandOutput {
+                stdout: self.help().into_bytes(),
+                stderr: Vec::new(),
+                exit_code: 2,
+                attachments: Vec::new(),
+            });
+        }
         if input.args.len() != 1 {
             return Ok(CommandOutput::failed(
                 2,
-                b"see expects exactly one path argument\n".to_vec(),
+                b"error: see expects exactly one path argument\n".to_vec(),
             ));
         }
         let path = &input.args[0];

--- a/crates/assistd-tools/src/commands/wc.rs
+++ b/crates/assistd-tools/src/commands/wc.rs
@@ -13,6 +13,21 @@ impl Command for WcCommand {
         "wc"
     }
 
+    fn summary(&self) -> &'static str {
+        "count lines/words/bytes on stdin; -l for lines only"
+    }
+
+    fn help(&self) -> String {
+        "usage: wc [-l]\n\
+         \n\
+         Count newlines, whitespace-separated words, and bytes read from \
+         stdin. Output is `<lines> <words> <bytes>` on one line.\n\
+         \n\
+         Flags:\n  \
+           -l  print only the line count\n"
+            .to_string()
+    }
+
     async fn run(&self, input: CommandInput) -> Result<CommandOutput> {
         let mut lines_only = false;
         for a in &input.args {

--- a/crates/assistd-tools/src/commands/web.rs
+++ b/crates/assistd-tools/src/commands/web.rs
@@ -46,18 +46,41 @@ impl Command for WebCommand {
         "web"
     }
 
+    fn summary(&self) -> &'static str {
+        "HTTP GET a URL and return the body as stdout (http/https only)"
+    }
+
+    fn help(&self) -> String {
+        "usage: web URL\n\
+         \n\
+         HTTP GET the URL (http or https only) and return the response body \
+         as stdout. 30-second timeout; response body capped at 10 MiB.\n\
+         \n\
+         Non-2xx statuses exit 1 so `||` fallbacks fire; transport errors \
+         also exit 1. Exit 2 on usage errors (wrong arg count, non-http scheme).\n"
+            .to_string()
+    }
+
     async fn run(&self, input: CommandInput) -> Result<CommandOutput> {
+        if input.args.is_empty() {
+            return Ok(CommandOutput {
+                stdout: self.help().into_bytes(),
+                stderr: Vec::new(),
+                exit_code: 2,
+                attachments: Vec::new(),
+            });
+        }
         if input.args.len() != 1 {
             return Ok(CommandOutput::failed(
                 2,
-                b"web expects exactly one URL argument\n".to_vec(),
+                b"error: web expects exactly one URL argument\n".to_vec(),
             ));
         }
         let url = &input.args[0];
         if !(url.starts_with("http://") || url.starts_with("https://")) {
             return Ok(CommandOutput::failed(
                 2,
-                format!("{url}: only http(s):// URLs are allowed\n").into_bytes(),
+                format!("error: {url}: only http(s):// URLs are allowed\n").into_bytes(),
             ));
         }
 

--- a/crates/assistd-tools/src/commands/write.rs
+++ b/crates/assistd-tools/src/commands/write.rs
@@ -21,12 +21,30 @@ impl Command for WriteCommand {
         "write"
     }
 
+    fn summary(&self) -> &'static str {
+        "write a file from stdin, or from inline args joined by spaces"
+    }
+
+    fn help(&self) -> String {
+        "usage: write PATH [CONTENT...]\n\
+         \n\
+         Write bytes to PATH. Two shapes:\n  \
+           `echo \"hi\" | write /tmp/x`   — stdin is the file content (pipeline form)\n  \
+           `write /tmp/x hello world`   — args beyond PATH are joined by spaces and written\n\
+         \n\
+         If both args and stdin are provided, args win and stdin is \
+         silently discarded. Exit 1 on write failure (permissions, no-such-dir, etc.).\n"
+            .to_string()
+    }
+
     async fn run(&self, input: CommandInput) -> Result<CommandOutput> {
         if input.args.is_empty() {
-            return Ok(CommandOutput::failed(
-                2,
-                b"missing path argument\n".to_vec(),
-            ));
+            return Ok(CommandOutput {
+                stdout: self.help().into_bytes(),
+                stderr: Vec::new(),
+                exit_code: 2,
+                attachments: Vec::new(),
+            });
         }
         let path = &input.args[0];
         let content: Vec<u8> = if input.args.len() > 1 {

--- a/crates/assistd-tools/src/run.rs
+++ b/crates/assistd-tools/src/run.rs
@@ -154,12 +154,12 @@ fn render_attachment(a: &Attachment) -> Value {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ToolRegistry;
     use crate::command::{Command, CommandInput, CommandOutput};
     use crate::commands::{
         BashCommand, CatCommand, EchoCommand, GrepCommand, LsCommand, SeeCommand, WcCommand,
         WebCommand, WriteCommand,
     };
-    use crate::ToolRegistry;
     use async_trait::async_trait;
     use regex::Regex;
     use std::path::Path;
@@ -671,7 +671,9 @@ mod tests {
         let dir = fresh_dir();
         let tool = tool_with(dir.path(), full_registry());
         let desc = tool.description();
-        for name in ["cat", "ls", "grep", "wc", "echo", "write", "see", "web", "bash"] {
+        for name in [
+            "cat", "ls", "grep", "wc", "echo", "write", "see", "web", "bash",
+        ] {
             assert!(desc.contains(name), "description missing `{name}`: {desc}");
         }
         // Summary text from a representative command should appear.
@@ -681,7 +683,8 @@ mod tests {
         );
         // Level-1 discovery hint tells the LLM how to drill in.
         assert!(
-            desc.to_lowercase().contains("no (or insufficient) arguments")
+            desc.to_lowercase()
+                .contains("no (or insufficient) arguments")
                 || desc.to_lowercase().contains("usage"),
             "description missing drill-in hint: {desc}"
         );
@@ -740,7 +743,9 @@ mod tests {
         let desc = schemas[0]["function"]["description"]
             .as_str()
             .expect("description is a string");
-        for name in ["cat", "ls", "grep", "wc", "echo", "write", "see", "web", "bash"] {
+        for name in [
+            "cat", "ls", "grep", "wc", "echo", "write", "see", "web", "bash",
+        ] {
             assert!(desc.contains(name), "schema description missing `{name}`");
         }
     }

--- a/crates/assistd-tools/src/run.rs
+++ b/crates/assistd-tools/src/run.rs
@@ -28,16 +28,60 @@ pub struct RunTool {
     registry: Arc<CommandRegistry>,
     spec: PresentSpec,
     counter: Arc<AtomicU64>,
+    /// Level-0 description, built once in `new` from
+    /// `registry.sorted_summaries()`. Returned by reference from
+    /// [`Tool::description`] — owned here so the trait's `&str` signature
+    /// is honored without requiring a static string.
+    description: String,
 }
 
 impl RunTool {
     pub fn new(registry: Arc<CommandRegistry>, spec: PresentSpec) -> Self {
+        let description = build_description(&registry);
         Self {
             registry,
             spec,
             counter: Arc::new(AtomicU64::new(0)),
+            description,
         }
     }
+}
+
+/// Build the Level-0 description the LLM sees in its tool schema. The
+/// header/footer are static; the middle block is a bulleted list of
+/// `(name, summary)` pairs pulled from every registered command. The
+/// "run a command with no arguments" footer is the discovery hook: the
+/// LLM learns that calling a command bare returns Level-1 usage.
+fn build_description(registry: &CommandRegistry) -> String {
+    let mut s = String::with_capacity(1024);
+    s.push_str(
+        "Execute a shell-style command in the daemon's working directory. \
+         Supports pipelines (|), and/or (&&, ||), and sequencing (;). \
+         Redirections (>, <), env expansion ($VAR), and backgrounding (&) \
+         are NOT supported — use `bash \"…\"` for a real shell when needed. \
+         Large outputs are truncated; the truncation notice includes a \
+         `Full output: /tmp/assistd-output/cmd-N.txt` path that subsequent \
+         `run` calls can grep/cat to read the full content.\n\n\
+         Available commands:\n",
+    );
+    let pairs = registry.sorted_summaries();
+    let name_width = pairs.iter().map(|(n, _)| n.len()).max().unwrap_or(0);
+    for (name, summary) in pairs {
+        s.push_str("  ");
+        s.push_str(name);
+        for _ in name.len()..name_width {
+            s.push(' ');
+        }
+        s.push_str(" — ");
+        s.push_str(summary);
+        s.push('\n');
+    }
+    s.push_str(
+        "\nCall a command with no (or insufficient) arguments to see its \
+         usage (exit code 2, stdout). Errors in real calls exit with a \
+         `[<name>]\\t` stderr prefix — distinct from help on stdout.",
+    );
+    s
 }
 
 #[async_trait]
@@ -47,14 +91,7 @@ impl Tool for RunTool {
     }
 
     fn description(&self) -> &str {
-        "Execute a shell-style command in the daemon's working directory. \
-         Supports pipelines (|), and/or (&&, ||), and sequencing (;). \
-         Built-in commands: cat, ls, grep, wc, echo, write, see, web, bash. \
-         Redirections (>, <), env expansion ($VAR), and backgrounding (&) \
-         are NOT supported — use `bash \"…\"` for a real shell when needed. \
-         Large outputs are truncated; the truncation notice includes a \
-         `Full output: /tmp/assistd-output/cmd-N.txt` path that subsequent \
-         `run` calls can grep/cat to read the full content."
+        &self.description
     }
 
     fn parameters_schema(&self) -> Value {
@@ -118,7 +155,11 @@ fn render_attachment(a: &Attachment) -> Value {
 mod tests {
     use super::*;
     use crate::command::{Command, CommandInput, CommandOutput};
-    use crate::commands::{CatCommand, EchoCommand, GrepCommand, LsCommand, SeeCommand, WcCommand};
+    use crate::commands::{
+        BashCommand, CatCommand, EchoCommand, GrepCommand, LsCommand, SeeCommand, WcCommand,
+        WebCommand, WriteCommand,
+    };
+    use crate::ToolRegistry;
     use async_trait::async_trait;
     use regex::Regex;
     use std::path::Path;
@@ -132,6 +173,23 @@ mod tests {
         r.register(LsCommand);
         r.register(WcCommand);
         r.register(SeeCommand);
+        Arc::new(r)
+    }
+
+    /// Full 9-command registry matching the daemon's production set.
+    /// Used by Level-0 description tests that need to verify every
+    /// command name flows into the LLM-facing schema.
+    fn full_registry() -> Arc<CommandRegistry> {
+        let mut r = CommandRegistry::new();
+        r.register(CatCommand);
+        r.register(LsCommand);
+        r.register(GrepCommand);
+        r.register(WcCommand);
+        r.register(EchoCommand);
+        r.register(WriteCommand);
+        r.register(SeeCommand);
+        r.register(WebCommand::new());
+        r.register(BashCommand::default());
         Arc::new(r)
     }
 
@@ -382,6 +440,12 @@ mod tests {
         fn name(&self) -> &str {
             "lines"
         }
+        fn summary(&self) -> &'static str {
+            "test: emit N lines"
+        }
+        fn help(&self) -> String {
+            "usage: lines".to_string()
+        }
         async fn run(&self, _input: CommandInput) -> Result<CommandOutput> {
             let mut v = Vec::with_capacity(self.0 * 8);
             for i in 1..=self.0 {
@@ -398,6 +462,12 @@ mod tests {
         fn name(&self) -> &str {
             "bytecount"
         }
+        fn summary(&self) -> &'static str {
+            "test: count bytes"
+        }
+        fn help(&self) -> String {
+            "usage: bytecount".to_string()
+        }
         async fn run(&self, input: CommandInput) -> Result<CommandOutput> {
             Ok(CommandOutput::ok(
                 format!("{}\n", input.stdin.len()).into_bytes(),
@@ -412,6 +482,12 @@ mod tests {
         fn name(&self) -> &str {
             "emitpng"
         }
+        fn summary(&self) -> &'static str {
+            "test: emit PNG"
+        }
+        fn help(&self) -> String {
+            "usage: emitpng".to_string()
+        }
         async fn run(&self, _input: CommandInput) -> Result<CommandOutput> {
             Ok(CommandOutput::ok(PNG_BYTES.to_vec()))
         }
@@ -423,6 +499,12 @@ mod tests {
     impl Command for Noisy {
         fn name(&self) -> &str {
             "noisy"
+        }
+        fn summary(&self) -> &'static str {
+            "test: noisy output"
+        }
+        fn help(&self) -> String {
+            "usage: noisy".to_string()
         }
         async fn run(&self, _input: CommandInput) -> Result<CommandOutput> {
             Ok(CommandOutput {
@@ -578,6 +660,185 @@ mod tests {
         assert!(output.contains("line 3\n"));
         assert!(!output.contains("line 4\n"));
         assert!(output.contains("--- output truncated (10 lines,"));
+    }
+
+    // --- progressive help: Level 0 (tool description) --------------------
+
+    /// Acceptance #1: the `run` tool's description lists every registered
+    /// command with its one-line summary.
+    #[test]
+    fn run_tool_description_lists_all_commands() {
+        let dir = fresh_dir();
+        let tool = tool_with(dir.path(), full_registry());
+        let desc = tool.description();
+        for name in ["cat", "ls", "grep", "wc", "echo", "write", "see", "web", "bash"] {
+            assert!(desc.contains(name), "description missing `{name}`: {desc}");
+        }
+        // Summary text from a representative command should appear.
+        assert!(
+            desc.contains("filter lines matching a pattern"),
+            "description missing grep summary: {desc}"
+        );
+        // Level-1 discovery hint tells the LLM how to drill in.
+        assert!(
+            desc.to_lowercase().contains("no (or insufficient) arguments")
+                || desc.to_lowercase().contains("usage"),
+            "description missing drill-in hint: {desc}"
+        );
+    }
+
+    /// Acceptance #4: adding a new command to the registry automatically
+    /// includes it in the Level-0 summary without touching any tool-side
+    /// description string.
+    #[test]
+    fn run_tool_description_auto_updates_when_command_added() {
+        struct Frobnicate;
+        #[async_trait]
+        impl Command for Frobnicate {
+            fn name(&self) -> &str {
+                "frobnicate"
+            }
+            fn summary(&self) -> &'static str {
+                "frobnicate the widget"
+            }
+            fn help(&self) -> String {
+                "usage: frobnicate".to_string()
+            }
+            async fn run(&self, _input: CommandInput) -> Result<CommandOutput> {
+                Ok(CommandOutput::ok(Vec::new()))
+            }
+        }
+        let mut reg = CommandRegistry::new();
+        reg.register(CatCommand);
+        reg.register(Frobnicate);
+        let dir = fresh_dir();
+        let tool = tool_with(dir.path(), Arc::new(reg));
+        let desc = tool.description();
+        assert!(desc.contains("frobnicate"), "missing name: {desc}");
+        assert!(
+            desc.contains("frobnicate the widget"),
+            "missing summary: {desc}"
+        );
+    }
+
+    /// Acceptance #1, wire-level: the OpenAI-compatible schema (what the
+    /// LLM actually consumes) exposes the dynamic description verbatim.
+    #[test]
+    fn openai_schemas_description_includes_all_commands() {
+        let dir = fresh_dir();
+        let mut tools = ToolRegistry::new();
+        tools.register(RunTool::new(
+            full_registry(),
+            PresentSpec {
+                max_lines: 200,
+                max_bytes: 50 * 1024,
+                overflow_dir: dir.path().to_path_buf(),
+            },
+        ));
+        let schemas = tools.openai_schemas();
+        assert_eq!(schemas.len(), 1);
+        let desc = schemas[0]["function"]["description"]
+            .as_str()
+            .expect("description is a string");
+        for name in ["cat", "ls", "grep", "wc", "echo", "write", "see", "web", "bash"] {
+            assert!(desc.contains(name), "schema description missing `{name}`");
+        }
+    }
+
+    // --- progressive help: Level 1 (command-level help on missing args) --
+
+    /// Acceptance #2, #5: calling a command with no arguments returns its
+    /// help text on stdout with a non-zero exit code so the LLM can tell
+    /// help from successful execution.
+    #[test]
+    fn run_grep_no_args_returns_help_on_stdout_exit_2() {
+        let dir = fresh_dir();
+        let tool = tool_with_dir(dir.path());
+        let result = invoke(&tool, "grep");
+        assert_eq!(result["exit_code"], 2);
+        let stdout = result["stdout"].as_str().unwrap();
+        assert!(
+            stdout.starts_with("usage: grep"),
+            "stdout should start with `usage: grep`: {stdout:?}"
+        );
+        assert!(stdout.contains("PATTERN"), "help missing PATTERN: {stdout}");
+        // Help goes to stdout; stderr stays empty (no `[grep]\t` prefix).
+        assert_eq!(result["stderr"].as_str().unwrap(), "");
+        let output = result["output"].as_str().unwrap();
+        assert_footer(output, 2);
+    }
+
+    #[test]
+    fn run_see_no_args_returns_help_on_stdout_exit_2() {
+        let dir = fresh_dir();
+        let mut reg = CommandRegistry::new();
+        reg.register(SeeCommand);
+        let tool = tool_with(dir.path(), Arc::new(reg));
+        let result = invoke(&tool, "see");
+        assert_eq!(result["exit_code"], 2);
+        let stdout = result["stdout"].as_str().unwrap();
+        assert!(stdout.starts_with("usage: see"), "{stdout:?}");
+        assert_eq!(result["stderr"].as_str().unwrap(), "");
+    }
+
+    #[test]
+    fn run_write_no_args_returns_help_on_stdout_exit_2() {
+        let dir = fresh_dir();
+        let mut reg = CommandRegistry::new();
+        reg.register(WriteCommand);
+        let tool = tool_with(dir.path(), Arc::new(reg));
+        let result = invoke(&tool, "write");
+        assert_eq!(result["exit_code"], 2);
+        let stdout = result["stdout"].as_str().unwrap();
+        assert!(stdout.starts_with("usage: write"), "{stdout:?}");
+        assert_eq!(result["stderr"].as_str().unwrap(), "");
+    }
+
+    #[test]
+    fn run_web_no_args_returns_help_on_stdout_exit_2() {
+        let dir = fresh_dir();
+        let mut reg = CommandRegistry::new();
+        reg.register(WebCommand::new());
+        let tool = tool_with(dir.path(), Arc::new(reg));
+        let result = invoke(&tool, "web");
+        assert_eq!(result["exit_code"], 2);
+        let stdout = result["stdout"].as_str().unwrap();
+        assert!(stdout.starts_with("usage: web"), "{stdout:?}");
+        assert_eq!(result["stderr"].as_str().unwrap(), "");
+    }
+
+    #[test]
+    fn run_bash_no_args_returns_help_on_stdout_exit_2() {
+        let dir = fresh_dir();
+        let mut reg = CommandRegistry::new();
+        reg.register(BashCommand::default());
+        let tool = tool_with(dir.path(), Arc::new(reg));
+        let result = invoke(&tool, "bash");
+        assert_eq!(result["exit_code"], 2);
+        let stdout = result["stdout"].as_str().unwrap();
+        assert!(stdout.starts_with("usage: bash"), "{stdout:?}");
+        assert_eq!(result["stderr"].as_str().unwrap(), "");
+    }
+
+    /// Help output on stdout is visually distinct from a real usage error
+    /// on stderr. A real grep error (bad regex) still goes to stderr with
+    /// the `[grep]\t` executor prefix — exits 2 like help does, but the
+    /// transport is different. This test locks the distinction.
+    #[test]
+    fn run_grep_real_usage_error_still_on_stderr() {
+        let dir = fresh_dir();
+        let tool = tool_with_dir(dir.path());
+        // Unrecognized flag — triggers parse_flags error path, which
+        // remains on stderr (unlike the no-args path, which emits help).
+        let result = invoke(&tool, "grep -x foo");
+        assert_eq!(result["exit_code"], 2);
+        let stderr = result["stderr"].as_str().unwrap();
+        assert!(
+            stderr.contains("[grep]\t"),
+            "real errors keep executor prefix: {stderr}"
+        );
+        // Stdout stays empty — the usage error didn't go to stdout.
+        assert_eq!(result["stdout"].as_str().unwrap(), "");
     }
 
     // --- OpenAI schema ----------------------------------------------------


### PR DESCRIPTION
help command for tool use descriptions.
- Command trait gained summary() -> &'static str and help() -> String.    
- CommandRegistry gained sorted_summaries().                              
- All 9 commands implement both methods; grep, see, write, web, bash emit help on stdout + exit 2 when invoked without required args.               
- RunTool caches a dynamic description built from registry.sorted_summaries() at construction.