### PR TITLE
Implement error-message-as-navigation pattern

### DIFF
--- a/crates/assistd-tools/src/chain/executor.rs
+++ b/crates/assistd-tools/src/chain/executor.rs
@@ -13,7 +13,7 @@ use std::future::Future;
 use std::pin::Pin;
 
 use super::Chain;
-use crate::command::{CommandInput, CommandOutput, CommandRegistry};
+use crate::command::{CommandInput, CommandOutput, CommandRegistry, error_line};
 
 /// Maximum bytes we buffer between pipe stages. Prevents one command
 /// from exhausting daemon memory. On overflow we return exit 141 (the
@@ -42,8 +42,13 @@ pub fn execute<'a>(
                         stdout: Vec::new(),
                         stderr: merge(
                             left.stderr,
-                            format!("[pipe]\tstage output exceeded {PIPE_BUF_MAX} bytes\n")
-                                .into_bytes(),
+                            error_line(
+                                "pipe",
+                                format_args!("stage output exceeded {PIPE_BUF_MAX} bytes"),
+                                "Try",
+                                "pipe through wc -l or head first to shrink the stream",
+                            )
+                            .into_bytes(),
                         ),
                         exit_code: 141,
                         attachments: left.attachments,
@@ -112,7 +117,13 @@ async fn run_command(
     if name.is_empty() {
         return Ok(CommandOutput::failed(
             2,
-            b"[error] empty command\n".to_vec(),
+            error_line(
+                "run",
+                "empty command",
+                "Use",
+                "run <cmd> (see tool description for available commands)",
+            )
+            .into_bytes(),
         ));
     }
 
@@ -451,8 +462,9 @@ mod tests {
         let out = execute(&chain, &r, Vec::new()).await.unwrap();
         assert_eq!(out.exit_code, 141);
         let stderr = String::from_utf8_lossy(&out.stderr);
-        assert!(stderr.contains("[pipe]"), "{stderr}");
+        assert!(stderr.contains("[error] pipe: "), "{stderr}");
         assert!(stderr.contains("exceeded"), "{stderr}");
+        assert!(stderr.contains("Try: "), "{stderr}");
     }
 
     #[tokio::test]

--- a/crates/assistd-tools/src/command.rs
+++ b/crates/assistd-tools/src/command.rs
@@ -7,9 +7,73 @@
 //! A `Command` is distinct from a [`crate::Tool`]: the LLM only ever sees
 //! one `Tool` (`run`); the `CommandRegistry` is an internal lookup table
 //! that `run` consults as it walks each chain stage.
+//!
+//! # Error-message-as-navigation convention
+//!
+//! Every stderr line a command emits must carry both *what went wrong* and
+//! *what to do instead*, so the LLM recovers in one step instead of blind
+//! retries. The format is:
+//!
+//! ```text
+//! [error] <cmd>: <what-went-wrong>. <Hint>: <recovery>\n
+//! ```
+//!
+//! - `<cmd>` — the command name (`cat`, `see`, `bash`, …) or a pseudo-tag
+//!   for pre-dispatch failures (`parse`, `pipe`, `unknown command`).
+//! - `<Hint>` — one of `Use:`, `Try:`, `Check:`, `Available:` — the first
+//!   two phrase actionable alternatives; the latter two phrase diagnostics.
+//! - `<recovery>` — either a concrete `run`-executable command the LLM can
+//!   issue verbatim (e.g. `see photo.png`, `ls /dir`, `cat -b file.bin`)
+//!   or a short check instruction (`ls -l <path>`).
+//!
+//! Use [`error_line`] to build a line, or [`io_error_nav`] to classify a
+//! `std::io::Error` against the path that produced it. Never return a bare
+//! non-zero `exit_code` without context — if a subprocess or downstream
+//! library emitted stderr, forward it so the LLM can see *why*.
 
 use anyhow::Result;
 use async_trait::async_trait;
+
+/// Format a single stderr line conforming to the error-navigation
+/// convention. Emits exactly `[error] <cmd>: <what>. <hint>: <recovery>\n`.
+///
+/// `hint` is the label without the trailing colon (e.g. `"Use"`, `"Try"`,
+/// `"Check"`, `"Available"`) — the colon and space are added for you.
+pub fn error_line(
+    cmd: &str,
+    what: impl std::fmt::Display,
+    hint: &str,
+    recovery: impl std::fmt::Display,
+) -> String {
+    format!("[error] {cmd}: {what}. {hint}: {recovery}\n")
+}
+
+/// Classify a `std::io::Error` against the `path` that produced it and
+/// emit a convention-compliant stderr line. Used by every file-touching
+/// command so NotFound and PermissionDenied get uniform navigation hints.
+pub fn io_error_nav(cmd: &str, path: &str, e: &std::io::Error) -> String {
+    use std::io::ErrorKind;
+    match e.kind() {
+        ErrorKind::NotFound => error_line(
+            cmd,
+            format_args!("file not found: {path}"),
+            "Use",
+            "ls to check the path",
+        ),
+        ErrorKind::PermissionDenied => error_line(
+            cmd,
+            format_args!("permission denied: {path}"),
+            "Check",
+            format_args!("ls -l {path}"),
+        ),
+        _ => error_line(
+            cmd,
+            format_args!("{path}: {e}"),
+            "Try",
+            "a different path or check with ls",
+        ),
+    }
+}
 
 /// Input to a single chain stage.
 pub struct CommandInput {
@@ -190,6 +254,113 @@ mod tests {
         // Every pair carries a non-empty summary.
         for (name, summary) in &pairs {
             assert!(!summary.is_empty(), "{name} has empty summary");
+        }
+    }
+
+    /// Acceptance for the error-message-as-navigation convention: every
+    /// registered command, when driven into a failure path, emits stderr
+    /// containing `[error] ` AND a hint word (`Use:` / `Try:` / `Check:` /
+    /// `Available:`). This is the gate that catches new commands added
+    /// without a convention-compliant error path.
+    ///
+    /// Drives one case per command with an input that's guaranteed to
+    /// fail. `echo` has no failure mode and is skipped. Permission-denied
+    /// assertions live in platform-gated per-command tests because
+    /// creating an unreadable file portably is brittle.
+    #[test]
+    fn every_registered_command_emits_convention_compliant_error() {
+        use crate::commands::{
+            BashCommand, CatCommand, GrepCommand, LsCommand, SeeCommand, WcCommand, WebCommand,
+            WriteCommand,
+        };
+
+        fn contains_hint(s: &str) -> bool {
+            s.contains("Use:")
+                || s.contains("Try:")
+                || s.contains("Check:")
+                || s.contains("Available:")
+        }
+
+        async fn run_cmd<C: Command>(cmd: C, args: Vec<String>) -> CommandOutput {
+            cmd.run(CommandInput {
+                args,
+                stdin: Vec::new(),
+            })
+            .await
+            .expect("run returns Ok on handled failures")
+        }
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let cases: Vec<(&str, CommandOutput)> = vec![
+            (
+                "cat",
+                rt.block_on(run_cmd(
+                    CatCommand,
+                    vec!["/nonexistent/assistd-convention-test".into()],
+                )),
+            ),
+            (
+                "ls",
+                rt.block_on(run_cmd(
+                    LsCommand,
+                    vec!["/nonexistent/assistd-convention-test".into()],
+                )),
+            ),
+            (
+                "see",
+                rt.block_on(run_cmd(
+                    SeeCommand,
+                    vec!["/nonexistent/assistd-convention-test.png".into()],
+                )),
+            ),
+            (
+                "grep",
+                rt.block_on(run_cmd(GrepCommand, vec!["-x".into(), "pat".into()])),
+            ),
+            (
+                "write",
+                rt.block_on(run_cmd(
+                    WriteCommand,
+                    vec!["/nonexistent/assistd-convention-test".into(), "x".into()],
+                )),
+            ),
+            ("wc", rt.block_on(run_cmd(WcCommand, vec!["-q".into()]))),
+            (
+                "web",
+                rt.block_on(run_cmd(
+                    WebCommand::new(),
+                    vec!["file:///etc/passwd".into()],
+                )),
+            ),
+            // bash timeout exercises assistd's own error wrapper (not a
+            // subprocess stderr forward). 50ms is plenty for a sleep.
+            (
+                "bash",
+                rt.block_on(run_cmd(
+                    BashCommand::new(std::time::Duration::from_millis(50)),
+                    vec!["sleep 5".into()],
+                )),
+            ),
+        ];
+
+        for (name, out) in cases {
+            assert_ne!(
+                out.exit_code, 0,
+                "{name}: failure input should exit non-zero"
+            );
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            assert!(
+                stderr.contains("[error] "),
+                "{name}: stderr missing `[error] ` tag — got {stderr:?}"
+            );
+            assert!(
+                stderr.contains(&format!("[error] {name}: ")),
+                "{name}: stderr should say `[error] {name}: ` — got {stderr:?}"
+            );
+            assert!(
+                contains_hint(&stderr),
+                "{name}: stderr missing recovery hint (Use:/Try:/Check:/Available:) — got {stderr:?}"
+            );
         }
     }
 

--- a/crates/assistd-tools/src/commands/bash.rs
+++ b/crates/assistd-tools/src/commands/bash.rs
@@ -20,7 +20,7 @@ use tokio::io::AsyncWriteExt;
 use tokio::process::Command as ProcCommand;
 use tokio::time::timeout;
 
-use crate::command::{Command, CommandInput, CommandOutput};
+use crate::command::{Command, CommandInput, CommandOutput, error_line};
 
 pub struct BashCommand {
     pub timeout: Duration,
@@ -87,7 +87,13 @@ impl Command for BashCommand {
             Err(e) => {
                 return Ok(CommandOutput::failed(
                     127,
-                    format!("spawn failed: {e}\n").into_bytes(),
+                    error_line(
+                        "bash",
+                        format_args!("spawn failed: {e}"),
+                        "Check",
+                        "bash is on PATH",
+                    )
+                    .into_bytes(),
                 ));
             }
         };
@@ -105,13 +111,25 @@ impl Command for BashCommand {
             Ok(Err(e)) => {
                 return Ok(CommandOutput::failed(
                     1,
-                    format!("wait failed: {e}\n").into_bytes(),
+                    error_line(
+                        "bash",
+                        format_args!("wait failed: {e}"),
+                        "Try",
+                        "re-running the command",
+                    )
+                    .into_bytes(),
                 ));
             }
             Err(_) => {
                 return Ok(CommandOutput::failed(
                     124, // GNU timeout convention
-                    format!("script exceeded {}s timeout\n", self.timeout.as_secs()).into_bytes(),
+                    error_line(
+                        "bash",
+                        format_args!("script exceeded {}s timeout", self.timeout.as_secs()),
+                        "Try",
+                        "a shorter script or split into steps",
+                    )
+                    .into_bytes(),
                 ));
             }
         };
@@ -179,6 +197,9 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(out.exit_code, 124);
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(stderr.contains("[error] bash: script exceeded"), "{stderr}");
+        assert!(stderr.contains("Try: "), "{stderr}");
     }
 
     #[tokio::test]
@@ -191,5 +212,28 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(out.exit_code, 2);
+    }
+
+    /// Acceptance: `bash "<nonexistent-dep>"` must forward the subprocess's
+    /// own stderr ("command not found") so the LLM sees *which* dependency
+    /// is missing — not a bare exit:127.
+    #[tokio::test]
+    async fn bash_missing_dependency_forwards_subprocess_stderr() {
+        let out = BashCommand::default()
+            .run(CommandInput {
+                args: vec!["assistd-definitely-not-a-real-binary-xyz".into()],
+                stdin: Vec::new(),
+            })
+            .await
+            .unwrap();
+        // bash itself prints `bash: <cmd>: command not found` to stderr and
+        // exits 127. We forward both verbatim.
+        assert_eq!(out.exit_code, 127);
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(stderr.contains("command not found"), "{stderr}");
+        assert!(
+            stderr.contains("assistd-definitely-not-a-real-binary-xyz"),
+            "{stderr}"
+        );
     }
 }

--- a/crates/assistd-tools/src/commands/cat.rs
+++ b/crates/assistd-tools/src/commands/cat.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use async_trait::async_trait;
 
-use crate::command::{Command, CommandInput, CommandOutput};
+use crate::command::{Command, CommandInput, CommandOutput, error_line, io_error_nav};
 
 /// `cat [FILE]...` — concatenate files, or echo stdin if no files given.
 /// Binary files are rejected so their raw bytes don't pollute the model's
@@ -50,7 +50,7 @@ impl Command for CatCommand {
                 Err(e) => {
                     return Ok(CommandOutput::failed(
                         1,
-                        format!("{path}: {e}\n").into_bytes(),
+                        io_error_nav("cat", path, &e).into_bytes(),
                     ));
                 }
             };
@@ -61,10 +61,22 @@ impl Command for CatCommand {
             }
 
             if let Some(mime) = sniff_binary(&bytes) {
-                let msg = format!(
-                    "[error] binary {mime} file ({}). Use: see {path}\n",
-                    human_size(bytes.len())
-                );
+                let size = human_size(bytes.len());
+                let msg = if mime.starts_with("image/") {
+                    error_line(
+                        "cat",
+                        format_args!("binary image file ({size}): {path}"),
+                        "Use",
+                        format_args!("see {path}"),
+                    )
+                } else {
+                    error_line(
+                        "cat",
+                        format_args!("binary {mime} file ({size}): {path}"),
+                        "Use",
+                        format_args!("cat -b {path}"),
+                    )
+                };
                 return Ok(CommandOutput::failed(1, msg.into_bytes()));
             }
             out.extend_from_slice(&bytes);
@@ -200,7 +212,11 @@ mod tests {
             .unwrap();
         assert_eq!(out.exit_code, 1);
         let stderr = String::from_utf8_lossy(&out.stderr);
-        assert!(stderr.contains("/nonexistent/path/xyz"), "{stderr}");
+        assert!(
+            stderr.contains("[error] cat: file not found: /nonexistent/path/xyz"),
+            "{stderr}"
+        );
+        assert!(stderr.contains("Use: ls to check the path"), "{stderr}");
     }
 
     #[tokio::test]
@@ -229,7 +245,10 @@ mod tests {
             .unwrap();
         assert_eq!(out.exit_code, 1);
         let stderr = String::from_utf8_lossy(&out.stderr);
-        assert!(stderr.contains("[error] binary image/png file"), "{stderr}");
+        assert!(
+            stderr.contains("[error] cat: binary image file"),
+            "{stderr}"
+        );
         assert!(stderr.contains("Use: see "), "{stderr}");
         assert!(out.stdout.is_empty(), "must not leak bytes on rejection");
     }
@@ -251,9 +270,10 @@ mod tests {
         assert_eq!(out.exit_code, 1);
         let stderr = String::from_utf8_lossy(&out.stderr);
         assert!(
-            stderr.contains("binary application/octet-stream"),
+            stderr.contains("[error] cat: binary application/octet-stream"),
             "{stderr}"
         );
+        assert!(stderr.contains("Use: cat -b "), "{stderr}");
     }
 
     #[tokio::test]

--- a/crates/assistd-tools/src/commands/grep.rs
+++ b/crates/assistd-tools/src/commands/grep.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use regex::RegexBuilder;
 
-use crate::command::{Command, CommandInput, CommandOutput};
+use crate::command::{Command, CommandInput, CommandOutput, error_line, io_error_nav};
 
 /// `grep [-i] [-v] [-c] PATTERN [FILE]` — print lines from FILE (or
 /// stdin) that match `PATTERN`.
@@ -92,7 +92,8 @@ impl Command for GrepCommand {
             Err(msg) => {
                 return Ok(CommandOutput::failed(
                     2,
-                    format!("error: {msg}\n").into_bytes(),
+                    error_line("grep", msg, "Use", "grep (no args) for supported flags")
+                        .into_bytes(),
                 ));
             }
         };
@@ -114,7 +115,13 @@ impl Command for GrepCommand {
             Err(e) => {
                 return Ok(CommandOutput::failed(
                     2,
-                    format!("bad pattern: {e}\n").into_bytes(),
+                    error_line(
+                        "grep",
+                        format_args!("bad regex pattern: {e}"),
+                        "Check",
+                        "escape regex metachars; run grep for usage",
+                    )
+                    .into_bytes(),
                 ));
             }
         };
@@ -126,7 +133,7 @@ impl Command for GrepCommand {
                 Err(e) => {
                     return Ok(CommandOutput::failed(
                         2,
-                        format!("{path}: {e}\n").into_bytes(),
+                        io_error_nav("grep", path, &e).into_bytes(),
                     ));
                 }
             }
@@ -139,7 +146,13 @@ impl Command for GrepCommand {
             Err(_) => {
                 return Ok(CommandOutput::failed(
                     2,
-                    b"input is not valid UTF-8\n".to_vec(),
+                    error_line(
+                        "grep",
+                        "input is not valid UTF-8",
+                        "Try",
+                        "grep on a text file or pipe from cat",
+                    )
+                    .into_bytes(),
                 ));
             }
         };
@@ -251,6 +264,13 @@ mod tests {
         let out = run_grep(&["-x", "foo"], b"").await;
         assert_eq!(out.exit_code, 2);
         let stderr = String::from_utf8_lossy(&out.stderr);
-        assert!(stderr.contains("'-x'"), "{stderr}");
+        assert!(
+            stderr.contains("[error] grep: unknown flag '-x'"),
+            "{stderr}"
+        );
+        assert!(
+            stderr.contains("Use: grep (no args) for supported flags"),
+            "{stderr}"
+        );
     }
 }

--- a/crates/assistd-tools/src/commands/ls.rs
+++ b/crates/assistd-tools/src/commands/ls.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use async_trait::async_trait;
 
-use crate::command::{Command, CommandInput, CommandOutput};
+use crate::command::{Command, CommandInput, CommandOutput, io_error_nav};
 
 /// `ls [PATH]` — list directory entries alphabetically, one per line,
 /// formatted as `<type>\t<size>\t<name>`. Type is `dir`, `file`, or
@@ -36,7 +36,7 @@ impl Command for LsCommand {
             Err(e) => {
                 return Ok(CommandOutput::failed(
                     1,
-                    format!("{path}: {e}\n").into_bytes(),
+                    io_error_nav("ls", path, &e).into_bytes(),
                 ));
             }
         };
@@ -66,7 +66,7 @@ impl Command for LsCommand {
                 Err(e) => {
                     return Ok(CommandOutput::failed(
                         1,
-                        format!("{path}: {e}\n").into_bytes(),
+                        io_error_nav("ls", path, &e).into_bytes(),
                     ));
                 }
             }
@@ -145,5 +145,11 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(out.exit_code, 1);
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            stderr.contains("[error] ls: file not found: /definitely/not/here"),
+            "{stderr}"
+        );
+        assert!(stderr.contains("Use: ls to check the path"), "{stderr}");
     }
 }

--- a/crates/assistd-tools/src/commands/see.rs
+++ b/crates/assistd-tools/src/commands/see.rs
@@ -8,7 +8,7 @@
 use anyhow::Result;
 use async_trait::async_trait;
 
-use crate::command::{Attachment, Command, CommandInput, CommandOutput};
+use crate::command::{Attachment, Command, CommandInput, CommandOutput, error_line, io_error_nav};
 use crate::commands::cat::human_size;
 
 pub struct SeeCommand;
@@ -47,7 +47,13 @@ impl Command for SeeCommand {
         if input.args.len() != 1 {
             return Ok(CommandOutput::failed(
                 2,
-                b"error: see expects exactly one path argument\n".to_vec(),
+                error_line(
+                    "see",
+                    "expects exactly one path argument",
+                    "Use",
+                    "see <PATH>",
+                )
+                .into_bytes(),
             ));
         }
         let path = &input.args[0];
@@ -56,20 +62,32 @@ impl Command for SeeCommand {
             Err(e) => {
                 return Ok(CommandOutput::failed(
                     1,
-                    format!("{path}: {e}\n").into_bytes(),
+                    io_error_nav("see", path, &e).into_bytes(),
                 ));
             }
         };
         let Some(t) = infer::get(&bytes) else {
             return Ok(CommandOutput::failed(
                 1,
-                format!("{path}: not an image file\n").into_bytes(),
+                error_line(
+                    "see",
+                    format_args!("not an image file: {path}"),
+                    "Use",
+                    format_args!("cat {path}"),
+                )
+                .into_bytes(),
             ));
         };
         if !infer::is_image(&bytes) {
             return Ok(CommandOutput::failed(
                 1,
-                format!("{path}: not an image file (detected {})\n", t.mime_type()).into_bytes(),
+                error_line(
+                    "see",
+                    format_args!("not an image file: {path} (detected {})", t.mime_type()),
+                    "Use",
+                    format_args!("cat {path}"),
+                )
+                .into_bytes(),
             ));
         }
         let mime = t.mime_type().to_string();
@@ -135,7 +153,11 @@ mod tests {
             .unwrap();
         assert_eq!(out.exit_code, 1);
         let stderr = String::from_utf8_lossy(&out.stderr);
-        assert!(stderr.contains("not an image"), "{stderr}");
+        assert!(
+            stderr.contains("[error] see: not an image file:"),
+            "{stderr}"
+        );
+        assert!(stderr.contains("Use: cat "), "{stderr}");
         assert!(out.attachments.is_empty());
     }
 
@@ -149,6 +171,12 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(out.exit_code, 1);
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            stderr.contains("[error] see: file not found: /nonexistent/image.png"),
+            "{stderr}"
+        );
+        assert!(stderr.contains("Use: ls to check the path"), "{stderr}");
         assert!(out.attachments.is_empty());
     }
 
@@ -174,5 +202,11 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(out.exit_code, 2);
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            stderr.contains("[error] see: expects exactly one path argument"),
+            "{stderr}"
+        );
+        assert!(stderr.contains("Use: see <PATH>"), "{stderr}");
     }
 }

--- a/crates/assistd-tools/src/commands/wc.rs
+++ b/crates/assistd-tools/src/commands/wc.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use async_trait::async_trait;
 
-use crate::command::{Command, CommandInput, CommandOutput};
+use crate::command::{Command, CommandInput, CommandOutput, error_line};
 
 /// `wc [-l]` — count lines (`-l`) or "lines words bytes" (default) from
 /// stdin. Only `-l` is accepted in v1; other flags return exit 2.
@@ -36,7 +36,13 @@ impl Command for WcCommand {
                 other => {
                     return Ok(CommandOutput::failed(
                         2,
-                        format!("flag '{other}' not supported in v1\n").into_bytes(),
+                        error_line(
+                            "wc",
+                            format_args!("flag '{other}' not supported in v1"),
+                            "Use",
+                            "wc or wc -l",
+                        )
+                        .into_bytes(),
                     ));
                 }
             }
@@ -94,5 +100,11 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(out.exit_code, 2);
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            stderr.contains("[error] wc: flag '-w' not supported in v1"),
+            "{stderr}"
+        );
+        assert!(stderr.contains("Use: wc or wc -l"), "{stderr}");
     }
 }

--- a/crates/assistd-tools/src/commands/web.rs
+++ b/crates/assistd-tools/src/commands/web.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 use anyhow::Result;
 use async_trait::async_trait;
 
-use crate::command::{Command, CommandInput, CommandOutput};
+use crate::command::{Command, CommandInput, CommandOutput, error_line};
 
 /// Hard cap on response bytes. Mirrors the chain executor's
 /// `PIPE_BUF_MAX` so a multi-megabyte page doesn't blow the next
@@ -73,14 +73,26 @@ impl Command for WebCommand {
         if input.args.len() != 1 {
             return Ok(CommandOutput::failed(
                 2,
-                b"error: web expects exactly one URL argument\n".to_vec(),
+                error_line(
+                    "web",
+                    "expects exactly one URL argument",
+                    "Use",
+                    "web <URL>",
+                )
+                .into_bytes(),
             ));
         }
         let url = &input.args[0];
         if !(url.starts_with("http://") || url.starts_with("https://")) {
             return Ok(CommandOutput::failed(
                 2,
-                format!("error: {url}: only http(s):// URLs are allowed\n").into_bytes(),
+                error_line(
+                    "web",
+                    format_args!("only http(s):// URLs are allowed: {url}"),
+                    "Use",
+                    "web https://... or web http://...",
+                )
+                .into_bytes(),
             ));
         }
 
@@ -89,7 +101,13 @@ impl Command for WebCommand {
             Err(e) => {
                 return Ok(CommandOutput::failed(
                     1,
-                    format!("{url}: {e}\n").into_bytes(),
+                    error_line(
+                        "web",
+                        format_args!("transport error: {url}: {e}"),
+                        "Try",
+                        "a different URL or check the endpoint is reachable",
+                    )
+                    .into_bytes(),
                 ));
             }
         };
@@ -97,10 +115,15 @@ impl Command for WebCommand {
         if !status.is_success() {
             return Ok(CommandOutput::failed(
                 1,
-                format!(
-                    "HTTP {} {}\n",
-                    status.as_u16(),
-                    status.canonical_reason().unwrap_or("")
+                error_line(
+                    "web",
+                    format_args!(
+                        "HTTP {} {}: {url}",
+                        status.as_u16(),
+                        status.canonical_reason().unwrap_or("")
+                    ),
+                    "Try",
+                    "a different URL or check the endpoint is reachable",
                 )
                 .into_bytes(),
             ));
@@ -111,16 +134,27 @@ impl Command for WebCommand {
             Err(e) => {
                 return Ok(CommandOutput::failed(
                     1,
-                    format!("{url}: body read failed: {e}\n").into_bytes(),
+                    error_line(
+                        "web",
+                        format_args!("body read failed: {url}: {e}"),
+                        "Try",
+                        "re-running or a different URL",
+                    )
+                    .into_bytes(),
                 ));
             }
         };
         if body.len() > BODY_MAX {
             return Ok(CommandOutput::failed(
                 1,
-                format!(
-                    "{url}: response body exceeded {BODY_MAX} bytes (got {})\n",
-                    body.len()
+                error_line(
+                    "web",
+                    format_args!(
+                        "response body exceeded {BODY_MAX} bytes (got {}): {url}",
+                        body.len()
+                    ),
+                    "Try",
+                    "a URL path that returns less content",
                 )
                 .into_bytes(),
             ));
@@ -182,7 +216,8 @@ mod tests {
             .unwrap();
         assert_eq!(out.exit_code, 1);
         let stderr = String::from_utf8_lossy(&out.stderr);
-        assert!(stderr.contains("HTTP 404"), "{stderr}");
+        assert!(stderr.contains("[error] web: HTTP 404"), "{stderr}");
+        assert!(stderr.contains("Try: "), "{stderr}");
     }
 
     #[tokio::test]
@@ -196,7 +231,11 @@ mod tests {
             .unwrap();
         assert_eq!(out.exit_code, 2);
         let stderr = String::from_utf8_lossy(&out.stderr);
-        assert!(stderr.contains("http(s)"), "{stderr}");
+        assert!(
+            stderr.contains("[error] web: only http(s):// URLs are allowed"),
+            "{stderr}"
+        );
+        assert!(stderr.contains("Use: web http"), "{stderr}");
     }
 
     #[tokio::test]

--- a/crates/assistd-tools/src/commands/write.rs
+++ b/crates/assistd-tools/src/commands/write.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use async_trait::async_trait;
 
-use crate::command::{Command, CommandInput, CommandOutput};
+use crate::command::{Command, CommandInput, CommandOutput, io_error_nav};
 
 /// `write PATH [CONTENT...]` — write to PATH.
 ///
@@ -56,7 +56,7 @@ impl Command for WriteCommand {
             Ok(()) => Ok(CommandOutput::ok(Vec::new())),
             Err(e) => Ok(CommandOutput::failed(
                 1,
-                format!("{path}: {e}\n").into_bytes(),
+                io_error_nav("write", path, &e).into_bytes(),
             )),
         }
     }
@@ -157,5 +157,13 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(out.exit_code, 1);
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(stderr.contains("[error] write: "), "{stderr}");
+        // Missing parent dir surfaces as NotFound on most platforms.
+        assert!(
+            stderr.contains("Use: ls to check the path")
+                || stderr.contains("Try: a different path"),
+            "{stderr}"
+        );
     }
 }

--- a/crates/assistd-tools/src/run.rs
+++ b/crates/assistd-tools/src/run.rs
@@ -20,9 +20,9 @@ use base64::engine::general_purpose::STANDARD as B64;
 use serde_json::{Value, json};
 
 use crate::Tool;
-use crate::chain::{execute, parse_chain};
-use crate::command::{Attachment, CommandRegistry};
-use crate::presentation::{PresentSpec, present};
+use crate::chain::{ParseError, execute, parse_chain};
+use crate::command::{Attachment, CommandOutput, CommandRegistry, error_line};
+use crate::presentation::{PresentResult, PresentSpec, present};
 
 pub struct RunTool {
     registry: Arc<CommandRegistry>,
@@ -79,7 +79,11 @@ fn build_description(registry: &CommandRegistry) -> String {
     s.push_str(
         "\nCall a command with no (or insufficient) arguments to see its \
          usage (exit code 2, stdout). Errors in real calls exit with a \
-         `[<name>]\\t` stderr prefix — distinct from help on stdout.",
+         `[<name>]\\t` stderr prefix — distinct from help on stdout. Each \
+         error line follows `[error] <cmd>: <what-went-wrong>. <Hint>: \
+         <recovery>` where `<Hint>` is one of `Use:` / `Try:` / `Check:` / \
+         `Available:` — the recovery clause is a concrete command or check \
+         you can run next.",
     );
     s
 }
@@ -115,30 +119,82 @@ impl Tool for RunTool {
             .and_then(|v| v.as_str())
             .ok_or_else(|| anyhow!("`command` (string) is required"))?;
 
-        let chain = parse_chain(command).map_err(|e| anyhow!("parse error: {e}"))?;
         let start = Instant::now();
+        let chain = match parse_chain(command) {
+            Ok(c) => c,
+            Err(e) => {
+                // Surface parse errors through `present()` like any other
+                // failure so the LLM gets the usual `[stderr] ... [exit:N | Xms]`
+                // shape instead of a raw anyhow at the tool boundary.
+                let stderr = parse_error_line(&e).into_bytes();
+                let failed = CommandOutput::failed(2, stderr);
+                let r = present(failed, &self.spec, &self.counter, start.elapsed());
+                return Ok(build_result(r));
+            }
+        };
         let out = execute(&chain, &self.registry, Vec::new()).await?;
         let duration = start.elapsed();
 
         let r = present(out, &self.spec, &self.counter, duration);
-
-        let mut result = json!({
-            "output":      r.output,
-            "stdout":      r.stdout_raw,
-            "stderr":      r.stderr_raw,
-            "exit_code":   r.exit_code,
-            "truncated":   r.truncated,
-            "duration_ms": r.duration_ms,
-        });
-        if let Some(p) = &r.overflow_file {
-            result["overflow_file"] = json!(p.to_string_lossy());
-        }
-        if !r.attachments.is_empty() {
-            let rendered: Vec<Value> = r.attachments.iter().map(render_attachment).collect();
-            result["attachments"] = Value::Array(rendered);
-        }
-        Ok(result)
+        Ok(build_result(r))
     }
+}
+
+/// Translate a [`ParseError`] into a convention-compliant stderr line.
+/// Each variant gets a targeted recovery hint.
+fn parse_error_line(e: &ParseError) -> String {
+    match e {
+        ParseError::Empty => error_line("parse", "empty command", "Use", "run <cmd>"),
+        ParseError::UnterminatedQuote => error_line(
+            "parse",
+            "unterminated quoted string",
+            "Check",
+            "match all \" pairs",
+        ),
+        ParseError::UnexpectedOperator(s) => error_line(
+            "parse",
+            format_args!("unexpected operator '{s}' at start of expression"),
+            "Try",
+            "put a command before the operator",
+        ),
+        ParseError::TrailingOperator(s) => error_line(
+            "parse",
+            format_args!("trailing operator '{s}'"),
+            "Try",
+            "add a command after the operator",
+        ),
+        ParseError::EmptyCommand => error_line(
+            "parse",
+            "empty command between operators",
+            "Try",
+            "add a command between operators",
+        ),
+        ParseError::Unsupported(m) => error_line(
+            "parse",
+            *m,
+            "Use",
+            "bash \"...\" for unsupported shell features",
+        ),
+    }
+}
+
+fn build_result(r: PresentResult) -> Value {
+    let mut result = json!({
+        "output":      r.output,
+        "stdout":      r.stdout_raw,
+        "stderr":      r.stderr_raw,
+        "exit_code":   r.exit_code,
+        "truncated":   r.truncated,
+        "duration_ms": r.duration_ms,
+    });
+    if let Some(p) = &r.overflow_file {
+        result["overflow_file"] = json!(p.to_string_lossy());
+    }
+    if !r.attachments.is_empty() {
+        let rendered: Vec<Value> = r.attachments.iter().map(render_attachment).collect();
+        result["attachments"] = Value::Array(rendered);
+    }
+    result
 }
 
 fn render_attachment(a: &Attachment) -> Value {
@@ -279,10 +335,14 @@ mod tests {
         let result = invoke(&tool, &cmd);
         assert_eq!(result["exit_code"], 1);
         let stderr = result["stderr"].as_str().unwrap();
-        assert!(stderr.contains("binary image/png"), "{stderr}");
+        assert!(
+            stderr.contains("[error] cat: binary image file"),
+            "{stderr}"
+        );
+        assert!(stderr.contains("Use: see "), "{stderr}");
         let output = result["output"].as_str().unwrap();
         assert!(output.contains("[stderr] "), "output={output}");
-        assert!(output.contains("binary image/png"), "output={output}");
+        assert!(output.contains("binary image file"), "output={output}");
         assert_footer(output, 1);
     }
 
@@ -410,14 +470,19 @@ mod tests {
     }
 
     #[test]
-    fn run_parse_error_surfaces() {
+    fn run_parse_error_surfaces_as_present_result() {
+        // Parse errors flow through `present()` like any other failure: the
+        // LLM sees the usual `[stderr] ... [exit:N | Xms]` shape with a
+        // `[error] parse: ...` line, not a raw anyhow at the tool boundary.
         let dir = fresh_dir();
         let tool = tool_with_dir(dir.path());
-        let rt = tokio::runtime::Runtime::new().unwrap();
-        let err = rt
-            .block_on(tool.invoke(json!({ "command": "echo hi |" })))
-            .unwrap_err();
-        assert!(err.to_string().contains("parse error"), "{err}");
+        let result = invoke(&tool, "echo hi |");
+        assert_eq!(result["exit_code"], 2);
+        let stderr = result["stderr"].as_str().unwrap();
+        assert!(stderr.contains("[error] parse: "), "{stderr}");
+        let output = result["output"].as_str().unwrap();
+        assert!(output.contains("[stderr] "), "{output}");
+        assert_footer(output, 2);
     }
 
     #[test]


### PR DESCRIPTION
Error message as navigation pattern. The model gets explicit error information related to tool invocations (error number and message)