### PR TITLE
Implement the agent loop (single tool variant)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,6 +108,7 @@ dependencies = [
  "assistd-llm",
  "assistd-tools",
  "async-trait",
+ "base64",
  "serde",
  "serde_json",
  "tempfile",

--- a/config/config.sample.toml
+++ b/config/config.sample.toml
@@ -26,7 +26,7 @@ port = 8385
 [chat]
 # System prompt injected as the first message of every request. Leave empty
 # (system_prompt = "") to skip system-prompt injection entirely.
-system_prompt = "You are assistd, a concise local desktop assistant running on a Linux workstation. Answer precisely and in a conversational tone."
+system_prompt = "You are assistd, a concise local desktop assistant running on a Linux workstation. You have a `run` tool that executes shell-style commands (bash, cat, ls, grep, wc, echo, write, see, web) — prefer calling `run` over guessing when a question is about this machine or its files. Pipes (|), and/or (&&, ||), and sequencing (;) are supported inside a single `run` call, so a one-liner like `cat log.txt | grep ERROR | wc -l` is usually better than three separate tool calls. Answer precisely and in a conversational tone."
 # Approximate token budget for the full request (system + history). Must be
 # strictly less than model.context_length. When exceeded, older messages are
 # summarized and replaced by a single summary message.
@@ -117,3 +117,11 @@ hotkey = "Super+Escape"
 # all in-flight work immediately; higher values let clients receive a
 # final Done event before the daemon exits.
 # shutdown_grace_secs = 5
+
+[agent]
+# Maximum number of LLM invocations per user turn. The agent loop sends
+# the `run` tool schema to the model, executes any requested commands,
+# and iterates until the model returns plain text — or until this cap
+# is hit. 20 is deliberately generous: each `run` call is cheap and
+# pipelines reduce the number of round-trips needed for most queries.
+# max_iterations = 20

--- a/crates/assistd-core/Cargo.toml
+++ b/crates/assistd-core/Cargo.toml
@@ -9,6 +9,8 @@ assistd-ipc = { workspace = true }
 assistd-llm = { workspace = true }
 assistd-tools = { workspace = true }
 anyhow = { workspace = true }
+async-trait = { workspace = true }
+base64 = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/assistd-core/src/agent.rs
+++ b/crates/assistd-core/src/agent.rs
@@ -1,0 +1,623 @@
+//! Single-tool agent loop.
+//!
+//! Orchestrates one "user turn": push the user's prompt into the backend's
+//! conversation state, call [`LlmBackend::step`] with the current tool
+//! schemas, dispatch any tool calls the model requests through the
+//! shared `ToolRegistry`, feed results back, and iterate. Emits
+//! [`LlmEvent::ToolCall`] / [`LlmEvent::ToolResult`] on `tx` so callers
+//! (daemon IPC, TUI) can surface the intermediate state to users.
+//!
+//! Invariant: the caller holds whatever turn-level lock is needed to
+//! prevent concurrent agent turns from interleaving in the backend's
+//! conversation state. `AppState::handle_query` owns that lock.
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use anyhow::Result;
+use assistd_llm::{LlmBackend, LlmEvent, StepOutcome, ToolCall, ToolResultPayload};
+use assistd_tools::{Attachment, ToolRegistry};
+use serde_json::Value;
+use tokio::sync::mpsc;
+use tracing::{debug, info, warn};
+
+/// Run one agent turn end-to-end.
+///
+/// Lifecycle:
+/// 1. Push `user_text` into conversation state.
+/// 2. Call `backend.step(tools_schemas, tx)`.
+/// 3. If the step returned text, send [`LlmEvent::Done`] and stop.
+/// 4. Otherwise: for each requested tool call, emit
+///    [`LlmEvent::ToolCall`], dispatch it via the registry, emit
+///    [`LlmEvent::ToolResult`], and collect a [`ToolResultPayload`].
+///    After the loop, push the collected results back with
+///    `backend.push_tool_results(...)` and go to step 2.
+/// 5. If `max_iterations` is exhausted, emit a user-visible error delta
+///    and [`LlmEvent::Done`].
+///
+/// Cancellation: if `tx` is closed (client disconnected) between
+/// iterations, the loop returns `Ok(())` without running further tool
+/// calls or LLM round trips.
+pub async fn run_agent_turn(
+    backend: Arc<dyn LlmBackend>,
+    tools: Arc<ToolRegistry>,
+    max_iterations: u32,
+    user_text: String,
+    tx: mpsc::Sender<LlmEvent>,
+) -> Result<()> {
+    backend.push_user(user_text).await?;
+    let schemas = tools.openai_schemas();
+
+    for iteration in 0..max_iterations {
+        if tx.is_closed() {
+            debug!(
+                target: "assistd::agent",
+                iteration,
+                "client disconnected between iterations; stopping"
+            );
+            return Ok(());
+        }
+
+        let outcome = match backend.step(schemas.clone(), tx.clone()).await {
+            Ok(o) => o,
+            Err(e) => {
+                let _ = tx
+                    .send(LlmEvent::Delta {
+                        text: format!("\n[agent error: {e}]\n"),
+                    })
+                    .await;
+                let _ = tx.send(LlmEvent::Done).await;
+                return Err(e);
+            }
+        };
+
+        match outcome {
+            StepOutcome::Final => {
+                let _ = tx.send(LlmEvent::Done).await;
+                return Ok(());
+            }
+            StepOutcome::ToolCalls(calls) => {
+                let mut results = Vec::with_capacity(calls.len());
+                for call in calls {
+                    if tx.is_closed() {
+                        debug!(
+                            target: "assistd::agent",
+                            iteration,
+                            tool = %call.name,
+                            "client disconnected mid-call; stopping without dispatch"
+                        );
+                        // Unwind: push synthetic errors for all pending calls
+                        // so conversation state isn't left with a dangling
+                        // assistant-with-tool_calls on the next turn.
+                        results.push(ToolResultPayload {
+                            call_id: call.id,
+                            name: call.name,
+                            content: "[error] run: agent turn cancelled before dispatch.\n\
+                                       [exit:-1 | 0ms]"
+                                .to_string(),
+                            attachments: Vec::new(),
+                        });
+                        break;
+                    }
+
+                    // Surface the in-flight call to clients before it runs.
+                    let _ = tx
+                        .send(LlmEvent::ToolCall {
+                            id: call.id.clone(),
+                            name: call.name.clone(),
+                            arguments: call.arguments.clone(),
+                        })
+                        .await;
+
+                    let (payload, raw_result) = dispatch_tool_call(&tools, &call, iteration).await;
+
+                    // Emit the result for downstream observers. Ignore
+                    // send errors — the next `tx.is_closed()` check will
+                    // catch the disconnect.
+                    let _ = tx
+                        .send(LlmEvent::ToolResult {
+                            id: payload.call_id.clone(),
+                            name: payload.name.clone(),
+                            result: raw_result,
+                        })
+                        .await;
+
+                    results.push(payload);
+                }
+                backend.push_tool_results(results).await?;
+            }
+        }
+    }
+
+    warn!(
+        target: "assistd::agent",
+        max_iterations,
+        "agent turn exceeded max iterations; giving up"
+    );
+    let _ = tx
+        .send(LlmEvent::Delta {
+            text: format!("\n[agent exceeded max_iterations={max_iterations}; stopping]\n"),
+        })
+        .await;
+    let _ = tx.send(LlmEvent::Done).await;
+    Ok(())
+}
+
+/// Dispatch one tool call and produce both the LLM-facing payload and the
+/// raw JSON result (for event emission).
+///
+/// Error handling: failures at any level become synthetic tool results
+/// formatted with the Layer 2 navigational-hint convention
+/// (`[error] <cmd>: <what>. <Hint>: <recovery>`) so the model can
+/// self-correct on the next step. Only fundamental errors (like a
+/// `send` failure on `tx`) bubble up to the loop — and even those
+/// result in graceful shutdown, not a hung history.
+async fn dispatch_tool_call(
+    tools: &ToolRegistry,
+    call: &ToolCall,
+    iteration: u32,
+) -> (ToolResultPayload, Value) {
+    let start = Instant::now();
+
+    let Some(tool) = tools.get(&call.name) else {
+        let duration_ms = start.elapsed().as_millis();
+        let content = format!(
+            "[error] agent: unknown tool '{}'. Available: {}. [exit:-1 | {}ms]",
+            call.name,
+            tools.names().collect::<Vec<_>>().join(", "),
+            duration_ms
+        );
+        warn!(
+            target: "assistd::agent",
+            iteration,
+            tool = %call.name,
+            duration_ms = duration_ms,
+            "unknown tool"
+        );
+        let raw = serde_json::json!({
+            "output": content,
+            "exit_code": -1,
+            "duration_ms": duration_ms,
+            "truncated": false,
+        });
+        return (
+            ToolResultPayload {
+                call_id: call.id.clone(),
+                name: call.name.clone(),
+                content,
+                attachments: Vec::new(),
+            },
+            raw,
+        );
+    };
+
+    let result = tool.invoke(call.arguments.clone()).await;
+    let duration = start.elapsed();
+    let duration_ms = duration.as_millis();
+
+    let raw = match result {
+        Ok(v) => v,
+        Err(e) => {
+            let content = format!(
+                "[error] {}: tool invocation failed. Check: {e}. \
+                 Try: a different command.\n[exit:-1 | {duration_ms}ms]",
+                call.name
+            );
+            warn!(
+                target: "assistd::agent",
+                iteration,
+                tool = %call.name,
+                duration_ms = duration_ms,
+                error = %e,
+                "tool invocation errored"
+            );
+            let raw = serde_json::json!({
+                "output": content,
+                "exit_code": -1,
+                "duration_ms": duration_ms,
+                "truncated": false,
+            });
+            return (
+                ToolResultPayload {
+                    call_id: call.id.clone(),
+                    name: call.name.clone(),
+                    content,
+                    attachments: Vec::new(),
+                },
+                raw,
+            );
+        }
+    };
+
+    let content = raw
+        .get("output")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let exit_code = raw.get("exit_code").and_then(|v| v.as_i64()).unwrap_or(0);
+    let output_size = content.len();
+    let command = call
+        .arguments
+        .get("command")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+
+    info!(
+        target: "assistd::agent",
+        iteration,
+        tool = %call.name,
+        command = %command,
+        exit_code = exit_code,
+        output_size = output_size,
+        duration_ms = duration_ms,
+        "tool call complete"
+    );
+
+    let attachments = raw
+        .get("attachments")
+        .and_then(|v| v.as_array())
+        .map(|arr| arr.iter().filter_map(parse_attachment).collect::<Vec<_>>())
+        .unwrap_or_default();
+
+    (
+        ToolResultPayload {
+            call_id: call.id.clone(),
+            name: call.name.clone(),
+            content,
+            attachments,
+        },
+        raw,
+    )
+}
+
+/// Decode one `attachments[i]` entry from a RunTool result. Currently
+/// only handles `{"type": "image", "mime": "...", "data": <base64>}`.
+fn parse_attachment(v: &Value) -> Option<Attachment> {
+    let kind = v.get("type")?.as_str()?;
+    if kind != "image" {
+        return None;
+    }
+    let mime = v.get("mime")?.as_str()?.to_string();
+    let data_b64 = v.get("data")?.as_str()?;
+    use base64::Engine;
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(data_b64)
+        .ok()?;
+    Some(Attachment::Image { mime, bytes })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assistd_llm::{LlmBackend, LlmEvent, StepOutcome, ToolCall};
+    use assistd_tools::{CommandRegistry, PresentSpec, RunTool};
+    use async_trait::async_trait;
+    use std::sync::Mutex as StdMutex;
+
+    /// Scripted mock backend: returns queued step outcomes in order.
+    /// Records what was pushed so tests can assert the loop fed results
+    /// back correctly.
+    struct MockBackend {
+        outcomes: StdMutex<Vec<StepOutcome>>,
+        pushed_users: StdMutex<Vec<String>>,
+        pushed_results: StdMutex<Vec<Vec<ToolResultPayload>>>,
+    }
+
+    impl MockBackend {
+        fn with(outcomes: Vec<StepOutcome>) -> Arc<Self> {
+            Arc::new(Self {
+                outcomes: StdMutex::new(outcomes),
+                pushed_users: StdMutex::new(Vec::new()),
+                pushed_results: StdMutex::new(Vec::new()),
+            })
+        }
+    }
+
+    #[async_trait]
+    impl LlmBackend for MockBackend {
+        async fn generate(
+            &self,
+            _prompt: String,
+            _tx: mpsc::Sender<LlmEvent>,
+        ) -> anyhow::Result<()> {
+            unimplemented!("mock uses step path only")
+        }
+
+        async fn push_user(&self, text: String) -> anyhow::Result<()> {
+            self.pushed_users.lock().unwrap().push(text);
+            Ok(())
+        }
+
+        async fn push_tool_results(&self, results: Vec<ToolResultPayload>) -> anyhow::Result<()> {
+            self.pushed_results.lock().unwrap().push(results);
+            Ok(())
+        }
+
+        async fn step(
+            &self,
+            _tools: Vec<Value>,
+            tx: mpsc::Sender<LlmEvent>,
+        ) -> anyhow::Result<StepOutcome> {
+            let outcome = {
+                let mut q = self.outcomes.lock().unwrap();
+                if q.is_empty() {
+                    StepOutcome::Final
+                } else {
+                    q.remove(0)
+                }
+            };
+            if matches!(outcome, StepOutcome::Final) {
+                // Emulate a real step sending a text delta on Final so
+                // callers can observe streaming.
+                let _ = tx.send(LlmEvent::Delta { text: "ok".into() }).await;
+            }
+            Ok(outcome)
+        }
+    }
+
+    fn call(id: &str, command: &str) -> ToolCall {
+        ToolCall {
+            id: id.into(),
+            name: "run".into(),
+            arguments: serde_json::json!({ "command": command }),
+        }
+    }
+
+    fn tools_with_echo() -> Arc<ToolRegistry> {
+        use assistd_tools::commands::EchoCommand;
+        let mut reg = CommandRegistry::new();
+        reg.register(EchoCommand);
+        let mut tools = ToolRegistry::new();
+        tools.register(RunTool::new(
+            Arc::new(reg),
+            PresentSpec {
+                max_lines: 200,
+                max_bytes: 50 * 1024,
+                overflow_dir: std::env::temp_dir()
+                    .join(format!("assistd-agent-test-{}", std::process::id())),
+            },
+        ));
+        Arc::new(tools)
+    }
+
+    async fn collect(rx: &mut mpsc::Receiver<LlmEvent>) -> Vec<LlmEvent> {
+        let mut out = Vec::new();
+        while let Some(ev) = rx.recv().await {
+            out.push(ev);
+        }
+        out
+    }
+
+    #[tokio::test]
+    async fn simple_query_one_step_final() {
+        let backend = MockBackend::with(vec![StepOutcome::Final]);
+        let tools = tools_with_echo();
+        let (tx, mut rx) = mpsc::channel(16);
+        run_agent_turn(backend.clone(), tools, 10, "what is 2+2?".into(), tx)
+            .await
+            .unwrap();
+        let events = collect(&mut rx).await;
+        assert!(matches!(events.last(), Some(LlmEvent::Done)));
+        assert_eq!(backend.pushed_users.lock().unwrap().len(), 1);
+        // No tool calls dispatched → no tool_results pushed.
+        assert!(backend.pushed_results.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn multi_step_tool_then_final() {
+        let backend = MockBackend::with(vec![
+            StepOutcome::ToolCalls(vec![call("c-1", "echo hello")]),
+            StepOutcome::Final,
+        ]);
+        let tools = tools_with_echo();
+        let (tx, mut rx) = mpsc::channel(16);
+        run_agent_turn(backend.clone(), tools, 10, "say hello".into(), tx)
+            .await
+            .unwrap();
+        let events = collect(&mut rx).await;
+
+        // Expected event sequence (intermixed with deltas):
+        // ToolCall, ToolResult, Delta("ok"), Done
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, LlmEvent::ToolCall { name, .. } if name == "run"))
+        );
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, LlmEvent::ToolResult { name, .. } if name == "run"))
+        );
+        assert!(matches!(events.last(), Some(LlmEvent::Done)));
+
+        // And the backend saw the echoed result pushed back before the
+        // second step.
+        let pushed = backend.pushed_results.lock().unwrap();
+        assert_eq!(pushed.len(), 1);
+        assert_eq!(pushed[0].len(), 1);
+        assert!(
+            pushed[0][0].content.contains("hello"),
+            "result content should contain echo output: {:?}",
+            pushed[0][0].content
+        );
+    }
+
+    #[tokio::test]
+    async fn piped_command_completes_in_one_iteration() {
+        // A single `run` call with pipes — no need for multiple iterations.
+        let backend = MockBackend::with(vec![
+            StepOutcome::ToolCalls(vec![call(
+                "c-1",
+                "echo \"alpha\nbeta\nalpha\" | grep alpha | wc -l",
+            )]),
+            StepOutcome::Final,
+        ]);
+        use assistd_tools::commands::{EchoCommand, GrepCommand, WcCommand};
+        let mut reg = CommandRegistry::new();
+        reg.register(EchoCommand);
+        reg.register(GrepCommand);
+        reg.register(WcCommand);
+        let mut tools = ToolRegistry::new();
+        tools.register(RunTool::new(
+            Arc::new(reg),
+            PresentSpec {
+                max_lines: 200,
+                max_bytes: 50 * 1024,
+                overflow_dir: std::env::temp_dir()
+                    .join(format!("assistd-agent-test-pipe-{}", std::process::id())),
+            },
+        ));
+        let tools = Arc::new(tools);
+
+        let (tx, mut rx) = mpsc::channel(16);
+        run_agent_turn(backend.clone(), tools, 10, "how many?".into(), tx)
+            .await
+            .unwrap();
+        let events = collect(&mut rx).await;
+        // Exactly one ToolCall/ToolResult pair.
+        let calls = events
+            .iter()
+            .filter(|e| matches!(e, LlmEvent::ToolCall { .. }))
+            .count();
+        assert_eq!(calls, 1);
+
+        let results = backend.pushed_results.lock().unwrap();
+        assert_eq!(results.len(), 1);
+        // `echo "alpha\nbeta\nalpha"` prints 1 line; grep alpha filters
+        // the full body; wc -l counts it. The exact count depends on
+        // how echo interprets \n — but the content should start with an
+        // integer and contain an [exit:0] footer.
+        assert!(
+            results[0][0].content.contains("[exit:0"),
+            "expected success footer: {:?}",
+            results[0][0].content
+        );
+    }
+
+    #[tokio::test]
+    async fn exceeds_max_iterations_emits_error_delta_and_done() {
+        // Keep requesting tool calls forever.
+        let outcomes: Vec<StepOutcome> = (0..10)
+            .map(|i| {
+                StepOutcome::ToolCalls(vec![call(&format!("c-{i}"), &format!("echo iter{i}"))])
+            })
+            .collect();
+        let backend = MockBackend::with(outcomes);
+        let tools = tools_with_echo();
+        let (tx, mut rx) = mpsc::channel(64);
+        run_agent_turn(backend, tools, 3, "loop it".into(), tx)
+            .await
+            .unwrap();
+        let events = collect(&mut rx).await;
+
+        let delta_text: String = events
+            .iter()
+            .filter_map(|e| match e {
+                LlmEvent::Delta { text } => Some(text.clone()),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            delta_text.contains("max_iterations=3"),
+            "expected cap message: {delta_text:?}"
+        );
+        assert!(matches!(events.last(), Some(LlmEvent::Done)));
+    }
+
+    #[tokio::test]
+    async fn unknown_tool_passes_error_to_next_step() {
+        // Model calls a non-existent tool; dispatch produces an error
+        // payload rather than aborting; next step sees it and goes Final.
+        let backend = MockBackend::with(vec![
+            StepOutcome::ToolCalls(vec![ToolCall {
+                id: "c-1".into(),
+                name: "nonexistent".into(),
+                arguments: serde_json::json!({}),
+            }]),
+            StepOutcome::Final,
+        ]);
+        let tools = tools_with_echo();
+        let (tx, mut rx) = mpsc::channel(16);
+        run_agent_turn(backend.clone(), tools, 10, "go".into(), tx)
+            .await
+            .unwrap();
+        drop(collect(&mut rx).await);
+        let pushed = backend.pushed_results.lock().unwrap();
+        assert_eq!(pushed.len(), 1);
+        let payload = &pushed[0][0];
+        assert!(
+            payload.content.starts_with("[error] agent: unknown tool"),
+            "expected unknown-tool error prefix: {:?}",
+            payload.content
+        );
+    }
+
+    #[tokio::test]
+    async fn tool_invoke_err_becomes_synthetic_error_result() {
+        // A hand-written tool that errors at the Rust level (rather than
+        // via a non-zero exit code) triggers the dispatch `Err` path and
+        // must be converted into a synthetic tool-result payload so the
+        // next step can self-correct.
+        struct ErrTool;
+        #[async_trait]
+        impl assistd_tools::Tool for ErrTool {
+            fn name(&self) -> &str {
+                "run"
+            }
+            fn description(&self) -> &str {
+                "errors on invoke"
+            }
+            fn parameters_schema(&self) -> Value {
+                serde_json::json!({"type":"object"})
+            }
+            async fn invoke(&self, _args: Value) -> anyhow::Result<Value> {
+                anyhow::bail!("boom")
+            }
+        }
+        let mut reg = ToolRegistry::new();
+        reg.register(ErrTool);
+        let reg = Arc::new(reg);
+
+        let backend = MockBackend::with(vec![
+            StepOutcome::ToolCalls(vec![call("c-1", "whatever")]),
+            StepOutcome::Final,
+        ]);
+        let (tx, mut rx) = mpsc::channel(16);
+        run_agent_turn(backend.clone(), reg, 10, "go".into(), tx)
+            .await
+            .unwrap();
+        drop(collect(&mut rx).await);
+        let pushed = backend.pushed_results.lock().unwrap();
+        let payload = &pushed[0][0];
+        assert!(
+            payload
+                .content
+                .starts_with("[error] run: tool invocation failed"),
+            "expected tool-error prefix: {:?}",
+            payload.content
+        );
+    }
+
+    #[tokio::test]
+    async fn client_disconnect_between_iterations_stops_loop() {
+        let backend = MockBackend::with(vec![
+            StepOutcome::ToolCalls(vec![call("c-1", "echo a")]),
+            // If we ever reach this outcome it's a bug.
+            StepOutcome::ToolCalls(vec![call("c-2", "echo b")]),
+        ]);
+        let tools = tools_with_echo();
+        let (tx, rx) = mpsc::channel::<LlmEvent>(16);
+        drop(rx);
+        // Channel is closed from the start, so the very first is_closed
+        // check bails the loop before any step runs.
+        run_agent_turn(backend.clone(), tools, 10, "go".into(), tx)
+            .await
+            .unwrap();
+        // With the receiver already dropped, no step was called.
+        let pushed = backend.pushed_results.lock().unwrap();
+        assert!(
+            pushed.is_empty(),
+            "no tool results should be pushed after disconnect: {pushed:?}"
+        );
+    }
+}

--- a/crates/assistd-core/src/config.rs
+++ b/crates/assistd-core/src/config.rs
@@ -19,6 +19,8 @@ pub struct Config {
     pub daemon: DaemonConfig,
     #[serde(default)]
     pub tools: ToolsConfig,
+    #[serde(default)]
+    pub agent: AgentConfig,
 }
 
 /// Local model settings.
@@ -250,6 +252,32 @@ fn default_tools_overflow_dir() -> String {
     "/tmp/assistd-output".to_string()
 }
 
+/// Agent-loop configuration. The loop sends the LLM a single-tool
+/// (`run`) schema and iterates through tool calls until the model
+/// produces plain text or the cap is hit.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentConfig {
+    /// Maximum number of LLM invocations per user turn. Caps runaway
+    /// loops where the model keeps calling tools without resolving the
+    /// user's query. Default 20 — higher than a multi-tool agent because
+    /// each `run` call is cheap and composable (pipes replace what
+    /// would be multiple tool calls in other systems).
+    #[serde(default = "default_agent_max_iterations")]
+    pub max_iterations: u32,
+}
+
+impl Default for AgentConfig {
+    fn default() -> Self {
+        Self {
+            max_iterations: default_agent_max_iterations(),
+        }
+    }
+}
+
+fn default_agent_max_iterations() -> u32 {
+    20
+}
+
 fn default_gpu_layers() -> u32 {
     9999
 }
@@ -312,7 +340,13 @@ impl Default for Config {
             chat: ChatConfig {
                 system_prompt:
                     "You are assistd, a concise local desktop assistant running on a Linux \
-                     workstation. Answer precisely and in a conversational tone."
+                     workstation. You have a `run` tool that executes shell-style commands \
+                     (bash, cat, ls, grep, wc, echo, write, see, web) — prefer calling `run` \
+                     over guessing when a question is about this machine or its files. Pipes \
+                     (|), and/or (&&, ||), and sequencing (;) are supported inside a single \
+                     `run` call, so a one-liner like `cat log.txt | grep ERROR | wc -l` is \
+                     usually better than three separate tool calls. Answer precisely and in \
+                     a conversational tone."
                         .to_string(),
                 max_history_tokens: 6000,
                 summary_target_tokens: 1000,
@@ -349,6 +383,7 @@ impl Default for Config {
             presence: PresenceConfig::default(),
             daemon: DaemonConfig::default(),
             tools: ToolsConfig::default(),
+            agent: AgentConfig::default(),
         }
     }
 }
@@ -531,6 +566,10 @@ impl Config {
         }
         if self.tools.output.overflow_dir.is_empty() {
             errors.push("tools.output.overflow_dir must not be empty".into());
+        }
+
+        if self.agent.max_iterations == 0 {
+            errors.push("agent.max_iterations must be greater than 0".into());
         }
 
         if errors.is_empty() {
@@ -1157,5 +1196,76 @@ port = 8384
         config.tools.output.overflow_dir = String::new();
         let errs = validation_errors(config.validate().unwrap_err());
         assert!(errs.iter().any(|e| e.contains("tools.output.overflow_dir")));
+    }
+
+    #[test]
+    fn agent_config_defaults_to_20_iterations() {
+        let cfg = AgentConfig::default();
+        assert_eq!(cfg.max_iterations, 20);
+    }
+
+    #[test]
+    fn validation_catches_zero_agent_max_iterations() {
+        let mut config = Config::default();
+        config.agent.max_iterations = 0;
+        let errs = validation_errors(config.validate().unwrap_err());
+        assert!(errs.iter().any(|e| e.contains("agent.max_iterations")));
+    }
+
+    #[test]
+    fn missing_agent_section_uses_defaults() {
+        // Old config.toml files written before the agent loop landed must
+        // still parse and receive the default iteration cap.
+        let toml_str = r#"
+[model]
+name = "test/model-GGUF:Q4_K_M"
+context_length = 8192
+
+[llama_server]
+binary_path = "llama-server"
+host = "127.0.0.1"
+port = 8385
+
+[chat]
+system_prompt = "hi"
+max_history_tokens = 4000
+summary_target_tokens = 500
+preserve_recent_turns = 2
+temperature = 0.5
+max_response_tokens = 1024
+max_summary_tokens = 800
+request_timeout_secs = 60
+
+[voice]
+enabled = false
+hotkey = "Super+V"
+
+[compositor]
+type = "sway"
+
+[sleep]
+suspend = false
+
+[remote]
+enabled = false
+bind_address = "127.0.0.1"
+port = 8384
+"#;
+        let cfg: Config = toml::from_str(toml_str).expect("parse without [agent]");
+        assert_eq!(cfg.agent.max_iterations, 20);
+        cfg.validate().expect("defaults validate");
+    }
+
+    #[test]
+    fn default_system_prompt_mentions_run_tool() {
+        // Without this hint, Qwen3-class models often answer from training
+        // data instead of invoking the tool. The default prompt must
+        // therefore explicitly mention `run` and prefer tool use.
+        let cfg = Config::default();
+        let prompt = &cfg.chat.system_prompt;
+        assert!(
+            prompt.contains("`run`") && prompt.contains("shell"),
+            "system prompt should mention the run tool: {prompt:?}"
+        );
     }
 }

--- a/crates/assistd-core/src/lib.rs
+++ b/crates/assistd-core/src/lib.rs
@@ -1,14 +1,71 @@
+pub mod agent;
 pub mod config;
 pub mod presence;
 pub mod socket;
 pub mod state;
 
+pub use agent::run_agent_turn;
 pub use assistd_ipc as ipc;
 pub use assistd_ipc::PresenceState;
 pub use assistd_tools::{CommandRegistry, ToolRegistry};
-pub use config::{Config, DaemonConfig, PresenceConfig, SleepConfig};
+pub use config::{AgentConfig, Config, DaemonConfig, PresenceConfig, SleepConfig};
 pub use presence::{PresenceManager, RequestGuard};
 pub use state::AppState;
+
+use anyhow::{Context, Result};
+use assistd_tools::{
+    PresentSpec, RunTool,
+    commands::{
+        BashCommand, CatCommand, EchoCommand, GrepCommand, LsCommand, SeeCommand, WcCommand,
+        WebCommand, WriteCommand,
+    },
+};
+use std::path::PathBuf;
+use std::sync::Arc;
+
+/// Build the shared tool registry used by both the daemon and the chat
+/// TUI. Clears and recreates `overflow_dir` so per-process spill files
+/// land in a known-empty location at every startup.
+///
+/// `overflow_dir` is taken as an owned parameter so callers (daemon vs
+/// TUI) can use different paths — sharing one directory would race
+/// when both processes try to reset it.
+pub fn build_tools(config: &Config, overflow_dir: PathBuf) -> Result<Arc<ToolRegistry>> {
+    if overflow_dir.exists() {
+        std::fs::remove_dir_all(&overflow_dir).with_context(|| {
+            format!(
+                "failed to clear tools.output.overflow_dir {}",
+                overflow_dir.display()
+            )
+        })?;
+    }
+    std::fs::create_dir_all(&overflow_dir).with_context(|| {
+        format!(
+            "failed to create tools.output.overflow_dir {}",
+            overflow_dir.display()
+        )
+    })?;
+
+    let mut commands = CommandRegistry::new();
+    commands.register(CatCommand);
+    commands.register(LsCommand);
+    commands.register(GrepCommand);
+    commands.register(WcCommand);
+    commands.register(EchoCommand);
+    commands.register(WriteCommand);
+    commands.register(SeeCommand);
+    commands.register(WebCommand::new());
+    commands.register(BashCommand::default());
+
+    let present_spec = PresentSpec {
+        max_lines: config.tools.output.max_lines as usize,
+        max_bytes: (config.tools.output.max_kb as usize) * 1024,
+        overflow_dir,
+    };
+    let mut tools = ToolRegistry::new();
+    tools.register(RunTool::new(Arc::new(commands), present_spec));
+    Ok(Arc::new(tools))
+}
 
 /// Returns the version string of the assistd-core crate.
 pub fn version() -> &'static str {

--- a/crates/assistd-core/src/socket.rs
+++ b/crates/assistd-core/src/socket.rs
@@ -233,7 +233,7 @@ mod tests {
     fn test_state() -> Arc<AppState> {
         Arc::new(AppState::new(
             Config::default(),
-            Arc::new(assistd_llm::EchoBackend),
+            Arc::new(assistd_llm::EchoBackend::new()),
             PresenceManager::stub(PresenceState::Active),
             Arc::new(assistd_tools::ToolRegistry::default()),
         ))
@@ -434,6 +434,33 @@ mod tests {
             let _ = tx.send(assistd_llm::LlmEvent::Done).await;
             Ok(())
         }
+
+        async fn push_user(&self, _text: String) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn push_tool_results(
+            &self,
+            _results: Vec<assistd_llm::ToolResultPayload>,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn step(
+            &self,
+            _tools: Vec<serde_json::Value>,
+            tx: tokio::sync::mpsc::Sender<assistd_llm::LlmEvent>,
+        ) -> anyhow::Result<assistd_llm::StepOutcome> {
+            for i in 0..self.deltas {
+                let _ = tx
+                    .send(assistd_llm::LlmEvent::Delta {
+                        text: format!("d{i}"),
+                    })
+                    .await;
+                tokio::time::sleep(self.pause).await;
+            }
+            Ok(assistd_llm::StepOutcome::Final)
+        }
     }
 
     /// Backend that emits a single delta then blocks indefinitely on an
@@ -456,6 +483,31 @@ mod tests {
             // task is aborted via JoinSet::shutdown.
             std::future::pending::<()>().await;
             Ok(())
+        }
+
+        async fn push_user(&self, _text: String) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn push_tool_results(
+            &self,
+            _results: Vec<assistd_llm::ToolResultPayload>,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn step(
+            &self,
+            _tools: Vec<serde_json::Value>,
+            tx: tokio::sync::mpsc::Sender<assistd_llm::LlmEvent>,
+        ) -> anyhow::Result<assistd_llm::StepOutcome> {
+            let _ = tx
+                .send(assistd_llm::LlmEvent::Delta {
+                    text: "stuck".into(),
+                })
+                .await;
+            std::future::pending::<()>().await;
+            Ok(assistd_llm::StepOutcome::Final)
         }
     }
 

--- a/crates/assistd-core/src/state.rs
+++ b/crates/assistd-core/src/state.rs
@@ -1,10 +1,10 @@
-use crate::{Config, PresenceManager};
+use crate::{Config, PresenceManager, run_agent_turn};
 use anyhow::Result;
 use assistd_ipc::{Event, PresenceState, Request};
 use assistd_llm::{LlmBackend, LlmEvent};
 use assistd_tools::ToolRegistry;
 use std::sync::Arc;
-use tokio::sync::mpsc;
+use tokio::sync::{Mutex, mpsc};
 
 /// Shared, long-lived daemon state handed to every request handler.
 ///
@@ -17,6 +17,12 @@ pub struct AppState {
     pub llm: Arc<dyn LlmBackend>,
     pub presence: Arc<PresenceManager>,
     pub tools: Arc<ToolRegistry>,
+    /// Serializes entire agent turns. Concurrent queries each grab this
+    /// lock before running `run_agent_turn`, so one query's tool-call /
+    /// tool-result cycle never interleaves with another's — which would
+    /// otherwise leave the backend's conversation state with dangling
+    /// `tool_calls` messages.
+    agent_turn_lock: Arc<Mutex<()>>,
 }
 
 impl AppState {
@@ -31,6 +37,7 @@ impl AppState {
             llm,
             presence,
             tools,
+            agent_turn_lock: Arc::new(Mutex::new(())),
         }
     }
 
@@ -75,15 +82,44 @@ impl AppState {
             }
         };
 
+        // Serialize agent turns. Concurrent queries each wait here so
+        // one turn's assistant/tool_calls/tool_result triplet lands in
+        // conversation state atomically — otherwise a second query
+        // could push its own user message between this turn's steps.
+        let _agent_guard = self.agent_turn_lock.clone().lock_owned().await;
+
         let (llm_tx, mut llm_rx) = mpsc::channel::<LlmEvent>(32);
         let llm = self.llm.clone();
-        let generator = tokio::spawn(async move { llm.generate(text, llm_tx).await });
+        let tools = self.tools.clone();
+        let max_iterations = self.config.agent.max_iterations;
+        let generator =
+            tokio::spawn(
+                async move { run_agent_turn(llm, tools, max_iterations, text, llm_tx).await },
+            );
 
         while let Some(llm_event) = llm_rx.recv().await {
             let wire_event = match llm_event {
                 LlmEvent::Delta { text } => Event::Delta {
                     id: id.clone(),
                     text,
+                },
+                LlmEvent::ToolCall {
+                    id: _call_id,
+                    name,
+                    arguments,
+                } => Event::ToolCall {
+                    id: id.clone(),
+                    name,
+                    args: arguments,
+                },
+                LlmEvent::ToolResult {
+                    id: _call_id,
+                    name,
+                    result,
+                } => Event::ToolResult {
+                    id: id.clone(),
+                    name,
+                    result,
                 },
                 LlmEvent::Done => Event::Done { id: id.clone() },
             };
@@ -190,7 +226,8 @@ impl AppState {
 mod tests {
     use super::*;
     use crate::Config;
-    use assistd_llm::{EchoBackend, FailedBackend};
+    use assistd_llm::{EchoBackend, FailedBackend, StepOutcome, ToolCall, ToolResultPayload};
+    use assistd_tools::{CommandRegistry, PresentSpec, RunTool, commands::EchoCommand};
 
     fn test_state(backend: Arc<dyn LlmBackend>, initial_state: PresenceState) -> Arc<AppState> {
         Arc::new(AppState::new(
@@ -211,7 +248,7 @@ mod tests {
 
     #[tokio::test]
     async fn dispatch_query_emits_delta_then_done() {
-        let state = test_state(Arc::new(EchoBackend), PresenceState::Active);
+        let state = test_state(Arc::new(EchoBackend::new()), PresenceState::Active);
         let (tx, rx) = mpsc::channel::<Event>(8);
         let req = Request::Query {
             id: "q1".into(),
@@ -234,7 +271,7 @@ mod tests {
         // Active → Sleeping avoids hitting the stub's non-existent
         // control-plane endpoint while still exercising the transition
         // path end-to-end.
-        let state = test_state(Arc::new(EchoBackend), PresenceState::Active);
+        let state = test_state(Arc::new(EchoBackend::new()), PresenceState::Active);
         let (tx, rx) = mpsc::channel::<Event>(8);
         let req = Request::SetPresence {
             id: "p1".into(),
@@ -255,7 +292,7 @@ mod tests {
 
     #[tokio::test]
     async fn dispatch_get_presence_reports_current_state_without_transition() {
-        let state = test_state(Arc::new(EchoBackend), PresenceState::Drowsy);
+        let state = test_state(Arc::new(EchoBackend::new()), PresenceState::Drowsy);
         let (tx, rx) = mpsc::channel::<Event>(8);
         let req = Request::GetPresence { id: "g1".into() };
 
@@ -277,7 +314,7 @@ mod tests {
         // Drowsy → Sleeping: the Drowsy→Sleeping branch of `sleep()` is
         // network-free when `llama` is None (as in the stub), so this
         // exercises the full cycle path without a live server.
-        let state = test_state(Arc::new(EchoBackend), PresenceState::Drowsy);
+        let state = test_state(Arc::new(EchoBackend::new()), PresenceState::Drowsy);
         let (tx, rx) = mpsc::channel::<Event>(8);
         let req = Request::Cycle { id: "c1".into() };
 
@@ -321,5 +358,130 @@ mod tests {
             }
             _ => unreachable!(),
         }
+    }
+
+    /// MockBackend that scripts StepOutcomes and records pushed tool
+    /// results. Same shape as the one in `agent::tests` but re-declared
+    /// here so we can wire it into AppState and exercise IPC mapping.
+    struct ScriptedBackend {
+        outcomes: std::sync::Mutex<Vec<StepOutcome>>,
+    }
+
+    #[async_trait::async_trait]
+    impl LlmBackend for ScriptedBackend {
+        async fn generate(
+            &self,
+            _prompt: String,
+            _tx: mpsc::Sender<LlmEvent>,
+        ) -> anyhow::Result<()> {
+            unimplemented!("uses step path")
+        }
+        async fn push_user(&self, _text: String) -> anyhow::Result<()> {
+            Ok(())
+        }
+        async fn push_tool_results(&self, _results: Vec<ToolResultPayload>) -> anyhow::Result<()> {
+            Ok(())
+        }
+        async fn step(
+            &self,
+            _tools: Vec<serde_json::Value>,
+            _tx: mpsc::Sender<LlmEvent>,
+        ) -> anyhow::Result<StepOutcome> {
+            let outcome = {
+                let mut q = self.outcomes.lock().unwrap();
+                if q.is_empty() {
+                    StepOutcome::Final
+                } else {
+                    q.remove(0)
+                }
+            };
+            Ok(outcome)
+        }
+    }
+
+    fn state_with_echo_tools(backend: Arc<dyn LlmBackend>) -> Arc<AppState> {
+        let mut commands = CommandRegistry::new();
+        commands.register(EchoCommand);
+        let mut tools = ToolRegistry::new();
+        tools.register(RunTool::new(
+            Arc::new(commands),
+            PresentSpec {
+                max_lines: 200,
+                max_bytes: 50 * 1024,
+                overflow_dir: std::env::temp_dir()
+                    .join(format!("assistd-state-test-{}", std::process::id())),
+            },
+        ));
+        Arc::new(AppState::new(
+            Config::default(),
+            backend,
+            PresenceManager::stub(PresenceState::Active),
+            Arc::new(tools),
+        ))
+    }
+
+    #[tokio::test]
+    async fn dispatch_query_forwards_tool_call_and_result_events() {
+        // One tool call, then Final. We expect the forwarder to map
+        // LlmEvent::ToolCall → Event::ToolCall (with the request id),
+        // LlmEvent::ToolResult → Event::ToolResult, then Done.
+        let backend = Arc::new(ScriptedBackend {
+            outcomes: std::sync::Mutex::new(vec![
+                StepOutcome::ToolCalls(vec![ToolCall {
+                    id: "call-opaque".into(),
+                    name: "run".into(),
+                    arguments: serde_json::json!({"command": "echo hi"}),
+                }]),
+                StepOutcome::Final,
+            ]),
+        });
+        let state = state_with_echo_tools(backend);
+        let (tx, rx) = mpsc::channel::<Event>(16);
+        let req = Request::Query {
+            id: "req-42".into(),
+            text: "go".into(),
+        };
+        state.dispatch(req, tx).await.unwrap();
+
+        let events = collect_events(rx).await;
+
+        let tool_call = events
+            .iter()
+            .find(|e| matches!(e, Event::ToolCall { .. }))
+            .expect("expected Event::ToolCall in stream");
+        match tool_call {
+            Event::ToolCall { id, name, args } => {
+                // IPC id is the *request* id, not the LLM's call id.
+                assert_eq!(id, "req-42");
+                assert_eq!(name, "run");
+                assert_eq!(args["command"], "echo hi");
+            }
+            _ => unreachable!(),
+        }
+
+        let tool_result = events
+            .iter()
+            .find(|e| matches!(e, Event::ToolResult { .. }))
+            .expect("expected Event::ToolResult in stream");
+        match tool_result {
+            Event::ToolResult { id, name, result } => {
+                assert_eq!(id, "req-42");
+                assert_eq!(name, "run");
+                // RunTool's echo produces "hi\n" with a success footer.
+                assert!(
+                    result["output"]
+                        .as_str()
+                        .map(|s| s.contains("hi") && s.contains("[exit:0"))
+                        .unwrap_or(false),
+                    "expected echo output in result: {result}"
+                );
+            }
+            _ => unreachable!(),
+        }
+
+        assert!(
+            matches!(events.last(), Some(Event::Done { id }) if id == "req-42"),
+            "expected terminal Done: {events:?}"
+        );
     }
 }

--- a/crates/assistd-llm/src/chat/client.rs
+++ b/crates/assistd-llm/src/chat/client.rs
@@ -6,20 +6,28 @@
 //! it is held for the full duration of the streaming HTTP call — serializing
 //! concurrent queries is the right trade-off for a single-user desktop
 //! assistant: the second query always sees the first query's final reply.
+//!
+//! Tool-use support comes via three extra `LlmBackend` methods:
+//! `push_user`, `push_tool_results`, and `step`. The agent loop in
+//! `assistd-core` drives them: `push_user(text)` at the start of a turn,
+//! then `step` → handle the outcome → `push_tool_results(...)` if needed →
+//! `step` again, until `StepOutcome::Final`.
 
+use std::collections::BTreeMap;
 use std::time::Duration;
 
 use anyhow::Result;
 use async_trait::async_trait;
+use serde_json::Value;
 use tokio::sync::{Mutex, mpsc};
 use tracing::{debug, warn};
 
 use super::config::ChatSpec;
-use super::conversation::{Conversation, Summarizer};
+use super::conversation::{Conversation, Summarizer, ToolCallRecord};
 use super::error::ChatClientError;
 use super::sse::{SseEvent, SseLineReader};
 use super::wire;
-use crate::{LlmBackend, LlmEvent};
+use crate::{LlmBackend, LlmEvent, StepOutcome, ToolCall, ToolResultPayload};
 
 const MODEL_NAME: &str = "local";
 const ERROR_BODY_CAP: usize = 1024;
@@ -52,11 +60,11 @@ impl LlamaChatClient {
         })
     }
 
-    async fn stream_chat(
+    async fn stream_openai(
         &self,
         payload: &wire::ChatRequest<'_>,
         tx: &mpsc::Sender<LlmEvent>,
-    ) -> StreamResult {
+    ) -> StreamOutcome {
         let url = format!("{}/v1/chat/completions", self.base_url);
         let mut response = match self
             .client
@@ -67,21 +75,20 @@ impl LlamaChatClient {
             .await
         {
             Ok(r) => r,
-            Err(e) => return StreamResult::PreEmitError(ChatClientError::Http(e)),
+            Err(e) => return StreamOutcome::PreEmitError(ChatClientError::Http(e)),
         };
 
         let status = response.status();
         if !status.is_success() {
             let body = read_body_capped(&mut response, ERROR_BODY_CAP).await;
-            return StreamResult::PreEmitError(ChatClientError::Server {
+            return StreamOutcome::PreEmitError(ChatClientError::Server {
                 status: status.as_u16(),
                 body,
             });
         }
 
         let mut reader = SseLineReader::new();
-        let mut accumulated = String::new();
-        let mut has_emitted = false;
+        let mut accum = StreamAccum::default();
         let mut saw_done = false;
 
         loop {
@@ -89,11 +96,7 @@ impl LlamaChatClient {
                 Ok(Some(c)) => c,
                 Ok(None) => break,
                 Err(e) => {
-                    return fold_mid_stream_error(
-                        accumulated,
-                        has_emitted,
-                        ChatClientError::Http(e),
-                    );
+                    return fold_mid_stream_error(accum, ChatClientError::Http(e));
                 }
             };
             reader.feed(&chunk);
@@ -103,7 +106,7 @@ impl LlamaChatClient {
                     Ok(Some(e)) => e,
                     Ok(None) => break,
                     Err(e) => {
-                        return fold_mid_stream_error(accumulated, has_emitted, e);
+                        return fold_mid_stream_error(accum, e);
                     }
                 };
                 match event {
@@ -112,27 +115,32 @@ impl LlamaChatClient {
                         {
                             Ok(p) => p,
                             Err(e) => {
-                                return fold_mid_stream_error(
-                                    accumulated,
-                                    has_emitted,
-                                    ChatClientError::Json(e),
-                                );
+                                return fold_mid_stream_error(accum, ChatClientError::Json(e));
                             }
                         };
                         let Some(choice) = parsed.choices.into_iter().next() else {
                             continue;
                         };
-                        let Some(text) = choice.delta.content else {
-                            continue;
-                        };
-                        if text.is_empty() {
-                            continue;
+                        if let Some(reason) = choice.finish_reason {
+                            accum.finish_reason = Some(reason);
                         }
-                        accumulated.push_str(&text);
-                        has_emitted = true;
-                        if tx.send(LlmEvent::Delta { text }).await.is_err() {
-                            debug!(target: "assistd::chat", "client disconnected mid-stream");
-                            return StreamResult::ClientDisconnected(accumulated);
+                        if let Some(calls) = choice.delta.tool_calls {
+                            for delta in calls {
+                                accum.merge_tool_call_delta(delta);
+                            }
+                        }
+                        if let Some(text) = choice.delta.content
+                            && !text.is_empty()
+                        {
+                            accum.text.push_str(&text);
+                            accum.has_emitted = true;
+                            if tx.send(LlmEvent::Delta { text }).await.is_err() {
+                                debug!(
+                                    target: "assistd::chat",
+                                    "client disconnected mid-stream"
+                                );
+                                return StreamOutcome::ClientDisconnected(accum);
+                            }
                         }
                     }
                     SseEvent::Done => {
@@ -150,11 +158,12 @@ impl LlamaChatClient {
         if !saw_done {
             warn!(
                 target: "assistd::chat",
-                "stream ended before [DONE] marker; accumulated {} bytes",
-                accumulated.len()
+                "stream ended before [DONE] marker; accumulated {} bytes text, {} tool-call builders",
+                accum.text.len(),
+                accum.tool_calls.len()
             );
         }
-        StreamResult::Ok(accumulated)
+        StreamOutcome::Ok(accum)
     }
 }
 
@@ -188,28 +197,106 @@ impl LlmBackend for LlamaChatClient {
             stream: true,
             temperature: self.spec.temperature,
             max_tokens: self.spec.max_response_tokens,
+            tools: None,
+            tool_choice: None,
         };
 
-        match self.stream_chat(&payload, &tx).await {
-            StreamResult::Ok(text) => {
-                conv.push_assistant(text);
+        match self.stream_openai(&payload, &tx).await {
+            StreamOutcome::Ok(accum) => {
+                conv.push_assistant(accum.text);
                 let _ = tx.send(LlmEvent::Done).await;
                 Ok(())
             }
-            StreamResult::PartialAfterEmit(text) => {
-                conv.push_assistant(text);
+            StreamOutcome::PartialAfterEmit(accum) => {
+                conv.push_assistant(accum.text);
                 let _ = tx.send(LlmEvent::Done).await;
                 Ok(())
             }
-            StreamResult::ClientDisconnected(text) => {
-                conv.push_assistant(text);
+            StreamOutcome::ClientDisconnected(accum) => {
+                conv.push_assistant(accum.text);
                 Ok(())
             }
-            StreamResult::PreEmitError(e) => {
+            StreamOutcome::PreEmitError(e) => {
                 conv.rollback_last_user();
                 Err(anyhow::Error::new(e))
             }
         }
+    }
+
+    async fn push_user(&self, text: String) -> Result<()> {
+        let mut conv = self.conv.lock().await;
+        conv.push_user(text);
+        Ok(())
+    }
+
+    async fn push_tool_results(&self, results: Vec<ToolResultPayload>) -> Result<()> {
+        let mut conv = self.conv.lock().await;
+        for r in results {
+            // `[tool:<name>]\n<body>` — the prefix is the truncator's
+            // pair-detection anchor (see TOOL_RESULT_PREFIX) and gives
+            // the model a stable header it can visually spot in replayed
+            // history. Attachments (if any) ride along as multimodal
+            // content parts.
+            let content = format!("[tool:{}]\n{}", r.name, r.content);
+            if r.attachments.is_empty() {
+                conv.push_user(content);
+            } else {
+                conv.push_user_with_attachments(content, r.attachments);
+            }
+        }
+        Ok(())
+    }
+
+    async fn step(&self, tools: Vec<Value>, tx: mpsc::Sender<LlmEvent>) -> Result<StepOutcome> {
+        let mut conv = self.conv.lock().await;
+
+        if let Err(e) = conv.ensure_budget(self, &self.spec).await {
+            warn!(
+                target: "assistd::chat",
+                "ensure_budget failed ({e}); falling back to truncation"
+            );
+            conv.truncate_to_budget(&self.spec);
+        }
+
+        let wire_messages = conv.as_wire_messages();
+        let has_tools = !tools.is_empty();
+        let payload = wire::ChatRequest {
+            model: MODEL_NAME,
+            messages: wire_messages,
+            stream: true,
+            temperature: self.spec.temperature,
+            max_tokens: self.spec.max_response_tokens,
+            tools: if has_tools { Some(tools) } else { None },
+            tool_choice: if has_tools { Some("auto") } else { None },
+        };
+
+        let outcome = self.stream_openai(&payload, &tx).await;
+        match outcome {
+            StreamOutcome::Ok(accum)
+            | StreamOutcome::PartialAfterEmit(accum)
+            | StreamOutcome::ClientDisconnected(accum) => commit_step(&mut conv, accum),
+            StreamOutcome::PreEmitError(e) => Err(anyhow::Error::new(e)),
+        }
+    }
+}
+
+/// Translate a completed stream into conversation commits + [`StepOutcome`].
+///
+/// On `finish_reason: "tool_calls"` (or an inferred tool-call outcome —
+/// non-empty builders even without an explicit reason) we drop any
+/// accumulated narrative text. Qwen3 and similar reasoning models
+/// sometimes prefix tool calls with `<think>...</think>` content that
+/// would poison the assistant-with-tool_calls message on replay.
+fn commit_step(conv: &mut Conversation, accum: StreamAccum) -> Result<StepOutcome> {
+    let wants_tool_calls =
+        accum.finish_reason.as_deref() == Some("tool_calls") && !accum.tool_calls.is_empty();
+    if wants_tool_calls || (!accum.tool_calls.is_empty() && accum.finish_reason.is_none()) {
+        let (records, parsed) = accum.finalize_tool_calls()?;
+        conv.push_assistant_with_tool_calls(None, records);
+        Ok(StepOutcome::ToolCalls(parsed))
+    } else {
+        conv.push_assistant(accum.text);
+        Ok(StepOutcome::Final)
     }
 }
 
@@ -227,16 +314,22 @@ impl Summarizer for LlamaChatClient {
             messages: vec![
                 wire::ChatMessage {
                     role: "system",
-                    content: wire::ContentBody::Text(SUMMARY_SYSTEM_PROMPT),
+                    content: Some(wire::ContentBody::Text(SUMMARY_SYSTEM_PROMPT)),
+                    tool_calls: None,
+                    tool_call_id: None,
                 },
                 wire::ChatMessage {
                     role: "user",
-                    content: wire::ContentBody::Text(&dialogue),
+                    content: Some(wire::ContentBody::Text(&dialogue)),
+                    tool_calls: None,
+                    tool_call_id: None,
                 },
             ],
             stream: false,
             temperature: SUMMARY_TEMPERATURE,
             max_tokens,
+            tools: None,
+            tool_choice: None,
         };
 
         let mut response = self.client.post(&url).json(&payload).send().await?;
@@ -260,31 +353,103 @@ impl Summarizer for LlamaChatClient {
     }
 }
 
-enum StreamResult {
+/// Running accumulator for one `stream_openai` call.
+#[derive(Debug, Default)]
+struct StreamAccum {
+    text: String,
+    /// `BTreeMap` so a fallback iteration order (ascending `index`) is
+    /// stable when we finalize, matching the order in which the model
+    /// emitted the calls.
+    tool_calls: BTreeMap<u32, ToolCallBuilder>,
+    finish_reason: Option<String>,
+    has_emitted: bool,
+}
+
+impl StreamAccum {
+    fn merge_tool_call_delta(&mut self, delta: wire::ToolCallDelta) {
+        let entry = self.tool_calls.entry(delta.index).or_default();
+        if let Some(id) = delta.id {
+            entry.id = id;
+        }
+        if let Some(f) = delta.function {
+            if let Some(name) = f.name {
+                entry.name = name;
+            }
+            if let Some(args) = f.arguments {
+                entry.arguments.push_str(&args);
+            }
+        }
+    }
+
+    /// Turn the builder map into `(records, parsed_calls)`:
+    /// - `records` go into conversation history (arguments verbatim)
+    /// - `parsed_calls` are what the agent loop dispatches (arguments as
+    ///   `Value`). We parse arguments here so a malformed call surfaces
+    ///   as an `Err` from `step` rather than propagating garbage into
+    ///   tool dispatch.
+    fn finalize_tool_calls(self) -> Result<(Vec<ToolCallRecord>, Vec<ToolCall>)> {
+        let mut records = Vec::with_capacity(self.tool_calls.len());
+        let mut parsed = Vec::with_capacity(self.tool_calls.len());
+        for (index, b) in self.tool_calls {
+            if b.name.is_empty() {
+                anyhow::bail!("tool call at index {index} has no name");
+            }
+            let id = if b.id.is_empty() {
+                format!("call-{index}")
+            } else {
+                b.id.clone()
+            };
+            let arguments_json = if b.arguments.is_empty() {
+                "{}".to_string()
+            } else {
+                b.arguments.clone()
+            };
+            let arguments_value = serde_json::from_str::<Value>(&arguments_json)
+                .map_err(|e| anyhow::anyhow!("tool call {id}: malformed arguments JSON: {e}"))?;
+            records.push(ToolCallRecord {
+                id: id.clone(),
+                name: b.name.clone(),
+                arguments: arguments_json,
+            });
+            parsed.push(ToolCall {
+                id,
+                name: b.name,
+                arguments: arguments_value,
+            });
+        }
+        Ok((records, parsed))
+    }
+}
+
+#[derive(Debug, Default)]
+struct ToolCallBuilder {
+    id: String,
+    name: String,
+    arguments: String,
+}
+
+enum StreamOutcome {
     /// Stream completed cleanly with a `[DONE]` marker (or EOF after deltas).
-    Ok(String),
+    Ok(StreamAccum),
     /// Stream errored after we'd already forwarded deltas — return what we have.
-    PartialAfterEmit(String),
+    PartialAfterEmit(StreamAccum),
     /// The consumer dropped the receiver mid-stream; stop quietly.
-    ClientDisconnected(String),
+    ClientDisconnected(StreamAccum),
     /// Stream errored before any deltas were forwarded — propagate as `Err`.
     PreEmitError(ChatClientError),
 }
 
-fn fold_mid_stream_error(
-    accumulated: String,
-    has_emitted: bool,
-    err: ChatClientError,
-) -> StreamResult {
-    if has_emitted {
+fn fold_mid_stream_error(accum: StreamAccum, err: ChatClientError) -> StreamOutcome {
+    if accum.has_emitted || !accum.tool_calls.is_empty() {
         warn!(
             target: "assistd::chat",
-            "mid-stream error after {} bytes emitted: {err}",
-            accumulated.len()
+            "mid-stream error after {} bytes / {} tool-call builders: {err}",
+            accum.text.len(),
+            accum.tool_calls.len()
         );
-        StreamResult::PartialAfterEmit(accumulated)
+        StreamOutcome::PartialAfterEmit(accum)
     } else {
-        StreamResult::PreEmitError(err)
+        StreamOutcome::PreEmitError(err)
     }
 }
 

--- a/crates/assistd-llm/src/chat/conversation.rs
+++ b/crates/assistd-llm/src/chat/conversation.rs
@@ -17,6 +17,11 @@ use super::error::ChatClientError;
 use super::wire;
 
 const SUMMARY_PREFIX: &str = "[Conversation summary] ";
+/// Tool-result user messages carry this prefix so (1) the model can
+/// distinguish tool output from genuine user speech when history is
+/// replayed, (2) the truncator can pair the result with its assistant
+/// `tool_calls` predecessor and drop both atomically.
+pub const TOOL_RESULT_PREFIX: &str = "[tool:";
 const TOKENS_PER_MESSAGE_OVERHEAD: u32 = 4;
 /// Conservative per-image token weight for budget math. Real usage
 /// depends on the vision model, but 1000 tokens errs on the side of
@@ -40,6 +45,18 @@ impl Role {
     }
 }
 
+/// One tool call recorded on an assistant turn. Mirrors the OpenAI shape
+/// `{id, type: "function", function: {name, arguments}}`. `arguments` is the
+/// JSON-encoded argument string the model emitted, stored verbatim so the
+/// replayed wire payload preserves whatever whitespace/formatting the model
+/// used — some servers compare it against their own re-serialization.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolCallRecord {
+    pub id: String,
+    pub name: String,
+    pub arguments: String,
+}
+
 #[derive(Debug, Clone)]
 pub struct Message {
     pub role: Role,
@@ -49,6 +66,10 @@ pub struct Message {
     /// a tool-call (typically `see`) produced an image the model should
     /// see on its next turn.
     pub attachments: Vec<Attachment>,
+    /// Non-empty only on assistant messages that requested tool calls.
+    /// When present, the outgoing wire message is rendered with
+    /// `content: null` (or omitted) and a `tool_calls` array.
+    pub tool_calls: Vec<ToolCallRecord>,
 }
 
 /// Summarizer trait so unit tests can inject a fake without spinning up
@@ -90,6 +111,7 @@ impl Conversation {
             role: Role::User,
             content,
             attachments: Vec::new(),
+            tool_calls: Vec::new(),
         });
     }
 
@@ -102,6 +124,7 @@ impl Conversation {
             role: Role::User,
             content,
             attachments,
+            tool_calls: Vec::new(),
         });
     }
 
@@ -110,6 +133,29 @@ impl Conversation {
             role: Role::Assistant,
             content,
             attachments: Vec::new(),
+            tool_calls: Vec::new(),
+        });
+    }
+
+    /// Append an assistant turn that requested tool calls. `content` is the
+    /// assistant's narration (typically empty — models usually emit tool
+    /// calls without accompanying text when `finish_reason: "tool_calls"`).
+    /// `calls` must be non-empty; on the wire the message will render with
+    /// `content` omitted and `tool_calls: [...]` populated.
+    pub fn push_assistant_with_tool_calls(
+        &mut self,
+        content: Option<String>,
+        calls: Vec<ToolCallRecord>,
+    ) {
+        debug_assert!(
+            !calls.is_empty(),
+            "push_assistant_with_tool_calls requires at least one call"
+        );
+        self.messages.push(Message {
+            role: Role::Assistant,
+            content: content.unwrap_or_default(),
+            attachments: Vec::new(),
+            tool_calls: calls,
         });
     }
 
@@ -139,16 +185,45 @@ impl Conversation {
     /// the user explicitly configured it empty. Messages with attachments
     /// are rendered as a multimodal `content` array (text part + one
     /// `image_url` part per attachment); text-only messages stay as plain
-    /// strings for compatibility with non-vision models.
+    /// strings for compatibility with non-vision models. Assistant messages
+    /// carrying `tool_calls` render with `content: null` (omitted) and a
+    /// populated `tool_calls` array.
     pub fn as_wire_messages(&self) -> Vec<wire::ChatMessage<'_>> {
         let mut out = Vec::with_capacity(self.messages.len() + 1);
         if !self.system_prompt.is_empty() {
             out.push(wire::ChatMessage {
                 role: Role::System.as_wire(),
-                content: wire::ContentBody::Text(&self.system_prompt),
+                content: Some(wire::ContentBody::Text(&self.system_prompt)),
+                tool_calls: None,
+                tool_call_id: None,
             });
         }
         for m in &self.messages {
+            if !m.tool_calls.is_empty() {
+                // Assistant-with-tool_calls: omit content entirely (the
+                // OpenAI spec allows null/absent; some templates require
+                // absent). Any accompanying narration is dropped at
+                // commit time, so `m.content` is usually empty here.
+                let specs: Vec<wire::ToolCallSpec<'_>> = m
+                    .tool_calls
+                    .iter()
+                    .map(|c| wire::ToolCallSpec {
+                        id: &c.id,
+                        kind: "function",
+                        function: wire::FunctionCallSpec {
+                            name: &c.name,
+                            arguments: &c.arguments,
+                        },
+                    })
+                    .collect();
+                out.push(wire::ChatMessage {
+                    role: m.role.as_wire(),
+                    content: None,
+                    tool_calls: Some(specs),
+                    tool_call_id: None,
+                });
+                continue;
+            }
             let content = if m.attachments.is_empty() {
                 wire::ContentBody::Text(&m.content)
             } else {
@@ -161,7 +236,9 @@ impl Conversation {
             };
             out.push(wire::ChatMessage {
                 role: m.role.as_wire(),
-                content,
+                content: Some(content),
+                tool_calls: None,
+                tool_call_id: None,
             });
         }
         out
@@ -224,6 +301,7 @@ impl Conversation {
             role: Role::System,
             content: format!("{SUMMARY_PREFIX}{body}"),
             attachments: Vec::new(),
+            tool_calls: Vec::new(),
         };
 
         let drop_end = preserve_from;
@@ -242,7 +320,10 @@ impl Conversation {
 
     /// Infallible fallback: drop the oldest non-system, non-summary messages
     /// repeatedly until we fit in budget (or we've reduced history to just
-    /// the latest user message).
+    /// the latest user message). Tool-call/result pairs are dropped
+    /// atomically so the wire payload never carries an assistant
+    /// `tool_calls` without a matching result (or vice versa) — most
+    /// server-side chat templates reject that.
     pub fn truncate_to_budget(&mut self, spec: &ChatSpec) {
         let budget = effective_budget(spec);
         while self.approx_total_tokens() > budget {
@@ -253,6 +334,32 @@ impl Conversation {
                 );
                 break;
             };
+            self.drop_with_pair(idx);
+        }
+    }
+
+    /// Remove `idx` and, if it's half of a tool-call/result pair, the
+    /// matching sibling. Handles two shapes:
+    /// 1. Assistant-with-tool_calls at `idx` → also drop the immediately
+    ///    following tool-result user message (if present).
+    /// 2. Tool-result user message at `idx` → also drop the immediately
+    ///    preceding assistant-with-tool_calls (if present). This direction
+    ///    only fires if callers hit it directly; `first_droppable_index`
+    ///    always returns the assistant half first.
+    fn drop_with_pair(&mut self, idx: usize) {
+        if idx >= self.messages.len() {
+            return;
+        }
+        let drop_trailing_result = matches!(
+            self.messages.get(idx),
+            Some(m) if m.role == Role::Assistant && !m.tool_calls.is_empty()
+        );
+        self.messages.remove(idx);
+        if drop_trailing_result
+            && idx < self.messages.len()
+            && self.messages[idx].role == Role::User
+            && self.messages[idx].content.starts_with(TOOL_RESULT_PREFIX)
+        {
             self.messages.remove(idx);
         }
     }
@@ -295,6 +402,19 @@ impl Conversation {
                 }
             }
         }
+        // If the boundary landed on a tool-result user message, its
+        // preceding assistant-with-tool_calls would be orphaned on
+        // summarize. Walk back to include any matching assistant half,
+        // keeping the pair intact.
+        while idx > start
+            && self
+                .messages
+                .get(idx)
+                .map(|m| m.role == Role::User && m.content.starts_with(TOOL_RESULT_PREFIX))
+                .unwrap_or(false)
+        {
+            idx -= 1;
+        }
         idx.max(start)
     }
 
@@ -322,9 +442,23 @@ fn approx_tokens(text: &str) -> u32 {
 
 fn approx_message_tokens(m: &Message) -> u32 {
     let image_cost = (m.attachments.len() as u32).saturating_mul(TOKENS_PER_IMAGE);
+    // Each tool-call entry contributes its id + name + arguments verbatim
+    // plus a small per-entry structural overhead (braces, type, field
+    // names). `approx_tokens` over-counts slightly on purpose.
+    let tool_call_bytes: usize = m
+        .tool_calls
+        .iter()
+        .map(|c| c.id.len() + c.name.len() + c.arguments.len() + 32)
+        .sum();
+    let tool_call_cost = approx_tokens_bytes(tool_call_bytes);
     TOKENS_PER_MESSAGE_OVERHEAD
         .saturating_add(approx_tokens(&m.content))
         .saturating_add(image_cost)
+        .saturating_add(tool_call_cost)
+}
+
+fn approx_tokens_bytes(n: usize) -> u32 {
+    ((n as u32).saturating_add(3)) / 4
 }
 
 fn attachment_to_part(att: &Attachment) -> wire::ContentPart<'_> {
@@ -460,7 +594,7 @@ mod tests {
         let wire = c.as_wire_messages();
         assert_eq!(wire.len(), 2);
         assert_eq!(wire[0].role, "system");
-        assert_eq!(wire[0].content, wire::ContentBody::Text("sys"));
+        assert_eq!(wire[0].content, Some(wire::ContentBody::Text("sys")));
         assert_eq!(wire[1].role, "user");
     }
 
@@ -495,8 +629,8 @@ mod tests {
         assert_eq!(wire.len(), 1);
         assert_eq!(wire[0].role, "user");
         let parts = match &wire[0].content {
-            wire::ContentBody::Parts(p) => p,
-            other => panic!("expected Parts, got {other:?}"),
+            Some(wire::ContentBody::Parts(p)) => p,
+            other => panic!("expected Some(Parts), got {other:?}"),
         };
         assert_eq!(parts.len(), 2);
         match &parts[0] {
@@ -516,7 +650,10 @@ mod tests {
         let mut c = Conversation::new(String::new());
         c.push_user("hello".into());
         let wire = c.as_wire_messages();
-        assert!(matches!(wire[0].content, wire::ContentBody::Text("hello")));
+        assert!(matches!(
+            wire[0].content,
+            Some(wire::ContentBody::Text("hello"))
+        ));
     }
 
     #[test]
@@ -662,5 +799,148 @@ mod tests {
         let truncated = truncate_utf8(s, 4);
         assert!(truncated.ends_with('…'));
         assert!(truncated.chars().filter(|c| *c != '…').all(|c| c == '世'));
+    }
+
+    // --- tool-call conversation support ----------------------------------
+
+    fn mk_call(id: &str, args: &str) -> ToolCallRecord {
+        ToolCallRecord {
+            id: id.into(),
+            name: "run".into(),
+            arguments: args.into(),
+        }
+    }
+
+    #[test]
+    fn push_assistant_with_tool_calls_records_calls() {
+        let mut c = Conversation::new(String::new());
+        c.push_user("do it".into());
+        c.push_assistant_with_tool_calls(None, vec![mk_call("call-1", r#"{"command":"ls"}"#)]);
+        let last = c.messages.last().unwrap();
+        assert_eq!(last.role, Role::Assistant);
+        assert_eq!(last.content, "");
+        assert_eq!(last.tool_calls.len(), 1);
+        assert_eq!(last.tool_calls[0].id, "call-1");
+        assert_eq!(last.tool_calls[0].name, "run");
+        assert_eq!(last.tool_calls[0].arguments, r#"{"command":"ls"}"#);
+    }
+
+    #[test]
+    fn as_wire_messages_renders_tool_calls_with_content_absent() {
+        let mut c = Conversation::new(String::new());
+        c.push_user("do it".into());
+        c.push_assistant_with_tool_calls(None, vec![mk_call("call-1", r#"{"command":"ls"}"#)]);
+        let wire = c.as_wire_messages();
+        assert_eq!(wire.len(), 2);
+        assert_eq!(wire[1].role, "assistant");
+        assert!(wire[1].content.is_none(), "content must be absent");
+        let calls = wire[1].tool_calls.as_ref().expect("tool_calls present");
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].id, "call-1");
+        assert_eq!(calls[0].kind, "function");
+        assert_eq!(calls[0].function.name, "run");
+        assert_eq!(calls[0].function.arguments, r#"{"command":"ls"}"#);
+
+        // Serialized JSON must omit `content` (null is not equivalent for
+        // strict Jinja templates).
+        let json = serde_json::to_value(&wire[1]).unwrap();
+        assert!(
+            json.get("content").is_none(),
+            "content key must be omitted: {json}"
+        );
+        assert_eq!(json["tool_calls"][0]["function"]["name"], "run");
+    }
+
+    #[test]
+    fn tool_calls_contribute_to_token_budget() {
+        let mut c = Conversation::new(String::new());
+        c.push_user("q".into());
+        let baseline = c.approx_total_tokens();
+
+        let mut c2 = Conversation::new(String::new());
+        c2.push_user("q".into());
+        c2.push_assistant_with_tool_calls(
+            None,
+            vec![mk_call(
+                "call-1",
+                r#"{"command":"a very long command string here to make the call nontrivial"}"#,
+            )],
+        );
+        let with_call = c2.approx_total_tokens();
+        assert!(
+            with_call > baseline,
+            "tool_calls should add to token count: {with_call} vs {baseline}"
+        );
+    }
+
+    #[test]
+    fn truncate_drops_tool_call_pair_atomically() {
+        let mut c = Conversation::new(String::new());
+        // Old messages we'll summarize/truncate:
+        c.push_user("old q".into());
+        c.push_assistant_with_tool_calls(None, vec![mk_call("c-1", r#"{"command":"ls"}"#)]);
+        c.push_user_with_attachments("[tool:run]\nsome output\n".into(), Vec::new());
+        c.push_assistant("old reply".into());
+        // The latest turn (kept by preserve):
+        c.push_user("latest".into());
+
+        c.truncate_to_budget(&spec(10, 1, 10_000));
+
+        // The remaining history must not carry a dangling tool_calls
+        // without a matching result (or vice versa).
+        for (i, m) in c.messages.iter().enumerate() {
+            if m.role == Role::Assistant && !m.tool_calls.is_empty() {
+                let next = c.messages.get(i + 1);
+                assert!(
+                    matches!(next, Some(n) if n.role == Role::User
+                             && n.content.starts_with(TOOL_RESULT_PREFIX)),
+                    "assistant tool_calls at index {i} has no matching result; \
+                     history: {:?}",
+                    c.messages
+                );
+            }
+            if m.role == Role::User && m.content.starts_with(TOOL_RESULT_PREFIX) {
+                let prev = i.checked_sub(1).and_then(|p| c.messages.get(p));
+                assert!(
+                    matches!(prev, Some(p) if p.role == Role::Assistant
+                             && !p.tool_calls.is_empty()),
+                    "tool result at index {i} has no matching assistant; \
+                     history: {:?}",
+                    c.messages
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn summarize_preserves_tool_call_pair_boundary() {
+        let mut c = Conversation::new("sys".into());
+        // Stuff enough history to force summarization.
+        for i in 0..5 {
+            c.push_user(format!("turn {i} question with some filler text here"));
+            c.push_assistant(format!(
+                "turn {i} answer with some filler text here to blow budget"
+            ));
+        }
+        // A tool-call pair in the recent tail.
+        c.push_assistant_with_tool_calls(None, vec![mk_call("c-99", r#"{"command":"ls"}"#)]);
+        c.push_user_with_attachments("[tool:run]\nfoo\nbar\n".into(), Vec::new());
+        c.push_user("latest".into());
+
+        let fake = FakeSummarizer::new("summary");
+        c.ensure_budget(&fake, &spec(60, 2, 10_000)).await.unwrap();
+
+        // Post-summarize, the preserved tail must not have a dangling
+        // tool_calls or tool-result.
+        for (i, m) in c.messages.iter().enumerate() {
+            if m.role == Role::User && m.content.starts_with(TOOL_RESULT_PREFIX) {
+                let prev = i.checked_sub(1).and_then(|p| c.messages.get(p));
+                assert!(
+                    matches!(prev, Some(p) if p.role == Role::Assistant
+                             && !p.tool_calls.is_empty()),
+                    "orphaned tool result at {i}"
+                );
+            }
+        }
     }
 }

--- a/crates/assistd-llm/src/chat/wire.rs
+++ b/crates/assistd-llm/src/chat/wire.rs
@@ -6,8 +6,14 @@
 //! multimodal turns render as an array of content parts. llama.cpp
 //! accepts both shapes; a vision-capable model + mmproj is required for
 //! the `image_url` parts to actually reach the projector.
+//!
+//! Tool-calling shape: when an assistant message carries `tool_calls`, the
+//! `content` field must be absent (`None`). Some llama.cpp Jinja templates
+//! reject `"content": null` but accept an omitted key — `skip_serializing_if`
+//! takes care of that.
 
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 /// Outgoing chat request. Uses borrowed strings so history can be rendered
 /// into wire messages without copying.
@@ -18,12 +24,35 @@ pub struct ChatRequest<'a> {
     pub stream: bool,
     pub temperature: f32,
     pub max_tokens: u32,
+    /// OpenAI-compatible tool schemas: `[{"type": "function", "function": {...}}]`.
+    /// Only emitted when non-None so requests without tool use remain
+    /// byte-identical to the pre-agent-loop format.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tools: Option<Vec<Value>>,
+    /// Controls whether the model is allowed/required to call tools.
+    /// `"auto"` lets the model decide; `"none"` forces a text reply.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_choice: Option<&'a str>,
 }
 
 #[derive(Debug, Clone, Serialize)]
 pub struct ChatMessage<'a> {
     pub role: &'a str,
-    pub content: ContentBody<'a>,
+    /// Message text. `None` for assistant messages that carry only
+    /// `tool_calls` — the OpenAI spec allows (and many servers require)
+    /// the field to be omitted entirely in that case.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content: Option<ContentBody<'a>>,
+    /// Tool calls the assistant is requesting. Set on assistant turns
+    /// that finish with `finish_reason: "tool_calls"`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_calls: Option<Vec<ToolCallSpec<'a>>>,
+    /// Only set on messages with `role: "tool"`. We currently route tool
+    /// results back through synthetic user messages instead, so this is
+    /// usually absent — but keeping the field on the wire type lets the
+    /// client interop if a future change flips back.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_call_id: Option<&'a str>,
 }
 
 /// Wire shape of a message's `content` field.
@@ -51,6 +80,23 @@ pub enum ContentPart<'a> {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct ImageUrl {
     pub url: String,
+}
+
+/// One entry in an outgoing `tool_calls` array on an assistant message.
+#[derive(Debug, Clone, Serialize)]
+pub struct ToolCallSpec<'a> {
+    pub id: &'a str,
+    #[serde(rename = "type")]
+    pub kind: &'static str,
+    pub function: FunctionCallSpec<'a>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct FunctionCallSpec<'a> {
+    pub name: &'a str,
+    /// OpenAI's spec is explicit: `arguments` is a JSON-encoded **string**,
+    /// not a JSON object. Strict parsers reject the object form.
+    pub arguments: &'a str,
 }
 
 /// Non-streaming response shape — used only for the summarization call.
@@ -84,7 +130,6 @@ pub struct ChatCompletionChunk {
 pub struct ChatChunkChoice {
     pub delta: ChatChunkDelta,
     #[serde(default)]
-    #[allow(dead_code)]
     pub finish_reason: Option<String>,
 }
 
@@ -95,6 +140,36 @@ pub struct ChatChunkDelta {
     pub role: Option<String>,
     #[serde(default)]
     pub content: Option<String>,
+    /// When the model calls a tool, llama.cpp streams call fragments across
+    /// multiple chunks. Each fragment carries a stable `index` so the
+    /// receiver can accumulate by slot.
+    #[serde(default)]
+    pub tool_calls: Option<Vec<ToolCallDelta>>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub struct ToolCallDelta {
+    /// Stable across chunks for the same call. Required to reassemble
+    /// arguments that stream in pieces.
+    #[serde(default)]
+    pub index: u32,
+    #[serde(default)]
+    pub id: Option<String>,
+    #[serde(default, rename = "type")]
+    #[allow(dead_code)]
+    pub kind: Option<String>,
+    #[serde(default)]
+    pub function: Option<FunctionCallDelta>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub struct FunctionCallDelta {
+    #[serde(default)]
+    pub name: Option<String>,
+    /// JSON-encoded arguments string, chunked. Concatenate across deltas
+    /// keyed by the same `index`.
+    #[serde(default)]
+    pub arguments: Option<String>,
 }
 
 #[cfg(test)]
@@ -108,16 +183,22 @@ mod tests {
             messages: vec![
                 ChatMessage {
                     role: "system",
-                    content: ContentBody::Text("you are helpful"),
+                    content: Some(ContentBody::Text("you are helpful")),
+                    tool_calls: None,
+                    tool_call_id: None,
                 },
                 ChatMessage {
                     role: "user",
-                    content: ContentBody::Text("hi"),
+                    content: Some(ContentBody::Text("hi")),
+                    tool_calls: None,
+                    tool_call_id: None,
                 },
             ],
             stream: true,
             temperature: 0.5,
             max_tokens: 128,
+            tools: None,
+            tool_choice: None,
         };
         let json = serde_json::to_value(&req).unwrap();
         assert_eq!(json["model"], "local");
@@ -129,6 +210,12 @@ mod tests {
         assert_eq!(json["max_tokens"], 128);
         assert_eq!(json["messages"][0]["role"], "system");
         assert_eq!(json["messages"][1]["content"], "hi");
+        // Absent tools/tool_choice must not appear on the wire.
+        assert!(json.get("tools").is_none());
+        assert!(json.get("tool_choice").is_none());
+        // Text-only messages must not carry tool_calls/tool_call_id keys.
+        assert!(json["messages"][0].get("tool_calls").is_none());
+        assert!(json["messages"][0].get("tool_call_id").is_none());
     }
 
     #[test]
@@ -137,7 +224,7 @@ mod tests {
             model: "local",
             messages: vec![ChatMessage {
                 role: "user",
-                content: ContentBody::Parts(vec![
+                content: Some(ContentBody::Parts(vec![
                     ContentPart::Text {
                         text: "what's in this image?",
                     },
@@ -146,11 +233,15 @@ mod tests {
                             url: "data:image/png;base64,AAAA".into(),
                         },
                     },
-                ]),
+                ])),
+                tool_calls: None,
+                tool_call_id: None,
             }],
             stream: false,
             temperature: 0.5,
             max_tokens: 64,
+            tools: None,
+            tool_choice: None,
         };
         let json = serde_json::to_value(&req).unwrap();
         let content = &json["messages"][0]["content"];
@@ -162,11 +253,69 @@ mod tests {
     }
 
     #[test]
+    fn serializes_tools_array_when_set() {
+        let tools = vec![serde_json::json!({
+            "type": "function",
+            "function": {
+                "name": "run",
+                "description": "run a command",
+                "parameters": {"type": "object"},
+                "strict": true,
+            }
+        })];
+        let req = ChatRequest {
+            model: "local",
+            messages: Vec::new(),
+            stream: true,
+            temperature: 0.5,
+            max_tokens: 64,
+            tools: Some(tools),
+            tool_choice: Some("auto"),
+        };
+        let json = serde_json::to_value(&req).unwrap();
+        assert_eq!(json["tool_choice"], "auto");
+        assert_eq!(json["tools"][0]["function"]["name"], "run");
+        assert_eq!(json["tools"][0]["function"]["strict"], true);
+    }
+
+    #[test]
+    fn serializes_assistant_with_tool_calls_omits_content() {
+        let msg = ChatMessage {
+            role: "assistant",
+            content: None,
+            tool_calls: Some(vec![ToolCallSpec {
+                id: "call-1",
+                kind: "function",
+                function: FunctionCallSpec {
+                    name: "run",
+                    arguments: r#"{"command":"ls /tmp"}"#,
+                },
+            }]),
+            tool_call_id: None,
+        };
+        let json = serde_json::to_value(&msg).unwrap();
+        assert_eq!(json["role"], "assistant");
+        // content must be absent (not null) so strict templates accept it.
+        assert!(
+            json.get("content").is_none(),
+            "content should be omitted, got {json}"
+        );
+        assert_eq!(json["tool_calls"][0]["id"], "call-1");
+        assert_eq!(json["tool_calls"][0]["type"], "function");
+        assert_eq!(json["tool_calls"][0]["function"]["name"], "run");
+        assert_eq!(
+            json["tool_calls"][0]["function"]["arguments"],
+            r#"{"command":"ls /tmp"}"#
+        );
+    }
+
+    #[test]
     fn deserializes_streaming_chunk_with_content_delta() {
         let payload = r#"{"id":"x","object":"chat.completion.chunk","created":1,"model":"local","choices":[{"index":0,"delta":{"content":"hello"},"finish_reason":null}]}"#;
         let parsed: ChatCompletionChunk = serde_json::from_str(payload).unwrap();
         assert_eq!(parsed.choices.len(), 1);
         assert_eq!(parsed.choices[0].delta.content.as_deref(), Some("hello"));
+        assert!(parsed.choices[0].delta.tool_calls.is_none());
     }
 
     #[test]
@@ -176,6 +325,31 @@ mod tests {
         let parsed: ChatCompletionChunk = serde_json::from_str(payload).unwrap();
         assert_eq!(parsed.choices[0].delta.role.as_deref(), Some("assistant"));
         assert!(parsed.choices[0].delta.content.is_none());
+    }
+
+    #[test]
+    fn deserializes_tool_call_delta_chunk() {
+        // llama.cpp's typical tool-call emission — id + name in one chunk,
+        // arguments streamed across subsequent chunks under the same index.
+        let payload = r#"{"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call-1","type":"function","function":{"name":"run","arguments":"{\"com"}}]},"finish_reason":null}]}"#;
+        let parsed: ChatCompletionChunk = serde_json::from_str(payload).unwrap();
+        let calls = parsed.choices[0].delta.tool_calls.as_ref().unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].index, 0);
+        assert_eq!(calls[0].id.as_deref(), Some("call-1"));
+        let fn_delta = calls[0].function.as_ref().unwrap();
+        assert_eq!(fn_delta.name.as_deref(), Some("run"));
+        assert_eq!(fn_delta.arguments.as_deref(), Some("{\"com"));
+    }
+
+    #[test]
+    fn deserializes_tool_calls_finish_reason() {
+        let payload = r#"{"choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}"#;
+        let parsed: ChatCompletionChunk = serde_json::from_str(payload).unwrap();
+        assert_eq!(
+            parsed.choices[0].finish_reason.as_deref(),
+            Some("tool_calls")
+        );
     }
 
     #[test]

--- a/crates/assistd-llm/src/lib.rs
+++ b/crates/assistd-llm/src/lib.rs
@@ -14,16 +14,76 @@ pub use llama_server::{
 };
 
 use anyhow::Result;
+use assistd_tools::Attachment;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
-use tokio::sync::mpsc;
+use serde_json::Value;
+use tokio::sync::{Mutex, mpsc};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum LlmEvent {
     /// A streamed chunk of model output.
     Delta { text: String },
+    /// The model asked to invoke a tool. Emitted by the agent loop just
+    /// before the tool executes so clients can surface the call in-flight.
+    ToolCall {
+        id: String,
+        name: String,
+        arguments: Value,
+    },
+    /// The tool finished. Emitted by the agent loop after the tool's
+    /// result has been passed back to the model. `result` is the raw
+    /// JSON the tool returned (LLM-facing shape, matches `RunTool`'s
+    /// output).
+    ToolResult {
+        id: String,
+        name: String,
+        result: Value,
+    },
     /// The model has finished generating.
     Done,
+}
+
+/// One tool call the model requested during a `step`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolCall {
+    /// Server-assigned call ID. Used on the replayed wire payload to
+    /// match results back to calls.
+    pub id: String,
+    pub name: String,
+    /// Arguments parsed as a JSON value. Tools see this directly via
+    /// their `invoke(args)` implementation.
+    pub arguments: Value,
+}
+
+/// Result of executing one [`ToolCall`]. The agent loop builds these
+/// from tool-invoke output and hands them to
+/// [`LlmBackend::push_tool_results`] so the model sees them on its next
+/// `step`.
+#[derive(Debug, Clone)]
+pub struct ToolResultPayload {
+    /// The matching `id` from the [`ToolCall`] that produced this result.
+    pub call_id: String,
+    pub name: String,
+    /// The LLM-facing body: typically `RunTool`'s `output` field, which
+    /// already carries the `[exit:N | Xms]` footer and any navigational
+    /// error hints.
+    pub content: String,
+    /// Images the tool produced (e.g. from `see`). Carried forward into
+    /// the model's next turn as a multimodal user message.
+    pub attachments: Vec<Attachment>,
+}
+
+/// Outcome of a single [`LlmBackend::step`] call.
+#[derive(Debug)]
+pub enum StepOutcome {
+    /// The model emitted plain text; the turn is complete. Any deltas
+    /// were already streamed via the `tx` channel.
+    Final,
+    /// The model requested one or more tool calls. The caller must
+    /// dispatch them and feed the results back via
+    /// [`LlmBackend::push_tool_results`] before the next `step`.
+    ToolCalls(Vec<ToolCall>),
 }
 
 #[async_trait]
@@ -34,11 +94,50 @@ pub trait LlmBackend: Send + Sync + 'static {
     /// an error) when generation completes. The channel is a bounded
     /// `mpsc`; if `send` fails it means the consumer has disconnected and
     /// the implementation should stop generating and return `Ok(())`.
+    ///
+    /// This is the legacy single-turn API used by code paths that don't
+    /// want the agent loop's tool-dispatch machinery.
     async fn generate(&self, prompt: String, tx: mpsc::Sender<LlmEvent>) -> Result<()>;
+
+    /// Append a user message to the conversation. Does not invoke the
+    /// model. Used by the agent loop at the start of each turn.
+    async fn push_user(&self, text: String) -> Result<()>;
+
+    /// Append the results of the most recent `tool_calls` request. The
+    /// backend should commit these as messages the model will see on its
+    /// next `step` (our implementation renders them as synthetic user
+    /// messages with a `[tool:<name>]\n` prefix, plus attachments).
+    async fn push_tool_results(&self, results: Vec<ToolResultPayload>) -> Result<()>;
+
+    /// Run one model invocation with the current conversation + the given
+    /// tool schemas. Streams any text deltas through `tx`. Returns
+    /// [`StepOutcome::Final`] when the model emitted text, or
+    /// [`StepOutcome::ToolCalls`] when the model wants to invoke tools.
+    ///
+    /// Implementations that do not support tool use may return
+    /// `StepOutcome::Final` and ignore `tools`.
+    async fn step(&self, tools: Vec<Value>, tx: mpsc::Sender<LlmEvent>) -> Result<StepOutcome>;
 }
 
-/// Trivial backend that echoes the prompt back as a single delta.
-pub struct EchoBackend;
+/// Trivial backend that echoes the user's most recent push as a single
+/// delta on the next `step`. Tool calls are never emitted.
+pub struct EchoBackend {
+    last_user: Mutex<String>,
+}
+
+impl Default for EchoBackend {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl EchoBackend {
+    pub fn new() -> Self {
+        Self {
+            last_user: Mutex::new(String::new()),
+        }
+    }
+}
 
 #[async_trait]
 impl LlmBackend for EchoBackend {
@@ -46,6 +145,23 @@ impl LlmBackend for EchoBackend {
         let _ = tx.send(LlmEvent::Delta { text: prompt }).await;
         let _ = tx.send(LlmEvent::Done).await;
         Ok(())
+    }
+
+    async fn push_user(&self, text: String) -> Result<()> {
+        *self.last_user.lock().await = text;
+        Ok(())
+    }
+
+    async fn push_tool_results(&self, _results: Vec<ToolResultPayload>) -> Result<()> {
+        Ok(())
+    }
+
+    async fn step(&self, _tools: Vec<Value>, tx: mpsc::Sender<LlmEvent>) -> Result<StepOutcome> {
+        let text = std::mem::take(&mut *self.last_user.lock().await);
+        if !text.is_empty() {
+            let _ = tx.send(LlmEvent::Delta { text }).await;
+        }
+        Ok(StepOutcome::Final)
     }
 }
 
@@ -68,6 +184,18 @@ impl LlmBackend for FailedBackend {
     async fn generate(&self, _prompt: String, _tx: mpsc::Sender<LlmEvent>) -> Result<()> {
         anyhow::bail!("{}", self.reason)
     }
+
+    async fn push_user(&self, _text: String) -> Result<()> {
+        anyhow::bail!("{}", self.reason)
+    }
+
+    async fn push_tool_results(&self, _results: Vec<ToolResultPayload>) -> Result<()> {
+        anyhow::bail!("{}", self.reason)
+    }
+
+    async fn step(&self, _tools: Vec<Value>, _tx: mpsc::Sender<LlmEvent>) -> Result<StepOutcome> {
+        anyhow::bail!("{}", self.reason)
+    }
 }
 
 pub fn version() -> &'static str {
@@ -80,7 +208,7 @@ mod tests {
 
     #[tokio::test]
     async fn echo_backend_streams_delta_then_done() {
-        let backend = EchoBackend;
+        let backend = EchoBackend::new();
         let (tx, mut rx) = mpsc::channel(8);
         backend.generate("hello".into(), tx).await.unwrap();
         let first = rx.recv().await.unwrap();
@@ -96,6 +224,19 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn echo_backend_step_echoes_last_pushed_user() {
+        let backend = EchoBackend::new();
+        backend.push_user("what is 2+2?".into()).await.unwrap();
+        let (tx, mut rx) = mpsc::channel(8);
+        let outcome = backend.step(Vec::new(), tx).await.unwrap();
+        assert!(matches!(outcome, StepOutcome::Final));
+        match rx.recv().await.unwrap() {
+            LlmEvent::Delta { text } => assert_eq!(text, "what is 2+2?"),
+            other => panic!("expected Delta, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
     async fn failed_backend_returns_error() {
         let backend = FailedBackend::new("server exploded".into());
         let (tx, _rx) = mpsc::channel(8);
@@ -103,8 +244,28 @@ mod tests {
         assert!(err.to_string().contains("server exploded"));
     }
 
+    #[tokio::test]
+    async fn failed_backend_step_returns_error() {
+        let backend = FailedBackend::new("down".into());
+        let (tx, _rx) = mpsc::channel(8);
+        let err = backend.step(Vec::new(), tx).await.unwrap_err();
+        assert!(err.to_string().contains("down"));
+    }
+
     #[test]
     fn version_is_not_empty() {
         assert!(!version().is_empty());
+    }
+
+    #[test]
+    fn llm_event_tool_call_roundtrips() {
+        let evt = LlmEvent::ToolCall {
+            id: "c-1".into(),
+            name: "run".into(),
+            arguments: serde_json::json!({"command": "ls"}),
+        };
+        let json = serde_json::to_string(&evt).unwrap();
+        let parsed: LlmEvent = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, evt);
     }
 }

--- a/crates/assistd-llm/tests/chat_client.rs
+++ b/crates/assistd-llm/tests/chat_client.rs
@@ -10,7 +10,7 @@ use std::collections::VecDeque;
 use std::sync::Arc;
 use std::time::Duration;
 
-use assistd_llm::{ChatSpec, LlamaChatClient, LlmBackend, LlmEvent};
+use assistd_llm::{ChatSpec, LlamaChatClient, LlmBackend, LlmEvent, StepOutcome};
 use serde_json::Value;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
@@ -610,6 +610,203 @@ async fn summarize_failure_falls_back_to_truncation_and_still_responds() {
     assert!(
         captured.iter().any(|r| !r.stream),
         "summarize endpoint should have been attempted"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Agent-loop step API
+// ---------------------------------------------------------------------------
+
+/// Frame the `tool_calls` path as a sequence of SSE payloads suitable for
+/// `StreamResponse::RawFrames`. Matches llama.cpp's typical shape: role
+/// first, then one or more tool_call deltas with accumulating `arguments`,
+/// terminated by a finish_reason chunk.
+fn tool_call_frames(call_id: &str, name: &str, arg_chunks: &[&str]) -> Vec<String> {
+    let mut frames = Vec::new();
+    frames.push("data: {\"choices\":[{\"delta\":{\"role\":\"assistant\"}}]}\n\n".to_string());
+    let head = format!(
+        "data: {{\"choices\":[{{\"delta\":{{\"tool_calls\":[{{\"index\":0,\"id\":{},\"type\":\"function\",\"function\":{{\"name\":{},\"arguments\":\"\"}}}}]}}}}]}}\n\n",
+        serde_json::to_string(call_id).unwrap(),
+        serde_json::to_string(name).unwrap()
+    );
+    frames.push(head);
+    for chunk in arg_chunks {
+        let encoded = serde_json::to_string(chunk).unwrap();
+        frames.push(format!(
+            "data: {{\"choices\":[{{\"delta\":{{\"tool_calls\":[{{\"index\":0,\"function\":{{\"arguments\":{}}}}}]}}}}]}}\n\n",
+            encoded
+        ));
+    }
+    frames.push(
+        "data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"tool_calls\"}]}\n\n".to_string(),
+    );
+    frames.push("data: [DONE]\n\n".to_string());
+    frames
+}
+
+#[tokio::test]
+async fn step_with_stop_finish_reason_returns_final() {
+    let script = Script::new();
+    script
+        .push_stream(StreamResponse::Deltas(vec!["answer".into()]))
+        .await;
+    let (port, _server) = spawn_fake(script.clone()).await;
+
+    let client = LlamaChatClient::new(chat_spec(port)).unwrap();
+    client.push_user("what is 2+2?".into()).await.unwrap();
+    let (tx, mut rx) = mpsc::channel(32);
+    let outcome = client.step(Vec::new(), tx).await.unwrap();
+    assert!(matches!(outcome, StepOutcome::Final));
+    let events = drain(&mut rx).await;
+    assert_eq!(
+        events,
+        vec![LlmEvent::Delta {
+            text: "answer".into()
+        }]
+    );
+    // No tools were passed — request should omit the `tools` key entirely.
+    let captured = script.captured().await;
+    assert_eq!(captured.len(), 1);
+    assert!(
+        captured[0].body.get("tools").is_none(),
+        "request should not carry tools when argument is empty"
+    );
+}
+
+#[tokio::test]
+async fn step_parses_tool_call_across_argument_chunks() {
+    let script = Script::new();
+    script
+        .push_stream(StreamResponse::RawFrames(tool_call_frames(
+            "call-42",
+            "run",
+            &[r#"{"com"#, r#"mand":"ls "#, r#"/tmp"}"#],
+        )))
+        .await;
+    let (port, _server) = spawn_fake(script.clone()).await;
+
+    let client = LlamaChatClient::new(chat_spec(port)).unwrap();
+    client.push_user("list /tmp".into()).await.unwrap();
+    let (tx, mut rx) = mpsc::channel(32);
+    let tools = vec![serde_json::json!({
+        "type": "function",
+        "function": {
+            "name": "run",
+            "description": "run a command",
+            "parameters": {"type":"object","properties":{"command":{"type":"string"}}},
+            "strict": true
+        }
+    })];
+    let outcome = client.step(tools, tx).await.unwrap();
+    let calls = match outcome {
+        StepOutcome::ToolCalls(c) => c,
+        other => panic!("expected ToolCalls, got {other:?}"),
+    };
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].id, "call-42");
+    assert_eq!(calls[0].name, "run");
+    assert_eq!(calls[0].arguments["command"], "ls /tmp");
+
+    // No visible text deltas for a tool-calls-only step — Qwen3-style
+    // <think> blocks would have been emitted via `content`, but none
+    // appeared in our scripted frames.
+    let events = drain(&mut rx).await;
+    assert!(
+        !events.iter().any(|e| matches!(e, LlmEvent::Delta { .. })),
+        "tool-call-only step should emit no text deltas, got {events:?}"
+    );
+
+    let captured = script.captured().await;
+    assert_eq!(captured[0].body["tool_choice"], "auto");
+    let tools_arr = captured[0].body["tools"].as_array().unwrap();
+    assert_eq!(tools_arr[0]["function"]["name"], "run");
+}
+
+#[tokio::test]
+async fn agent_round_trip_commits_tool_calls_and_result_to_history() {
+    let script = Script::new();
+    // Turn 1: model asks for a tool call.
+    script
+        .push_stream(StreamResponse::RawFrames(tool_call_frames(
+            "call-7",
+            "run",
+            &[r#"{"command":"echo hi"}"#],
+        )))
+        .await;
+    // Turn 2 (after we push_tool_results): plain text answer.
+    script
+        .push_stream(StreamResponse::Deltas(vec!["done".into()]))
+        .await;
+    let (port, _server) = spawn_fake(script.clone()).await;
+
+    let client = LlamaChatClient::new(chat_spec(port)).unwrap();
+    client.push_user("please echo hi".into()).await.unwrap();
+
+    let tools = vec![serde_json::json!({
+        "type": "function",
+        "function": {"name":"run","parameters":{"type":"object"},"strict":true}
+    })];
+    let (tx1, mut rx1) = mpsc::channel(32);
+    let outcome1 = client.step(tools.clone(), tx1).await.unwrap();
+    let calls = match outcome1 {
+        StepOutcome::ToolCalls(c) => c,
+        _ => panic!("expected ToolCalls"),
+    };
+    drain(&mut rx1).await;
+
+    // Simulate the agent-loop side of things: feed a result back.
+    let result = assistd_llm::ToolResultPayload {
+        call_id: calls[0].id.clone(),
+        name: "run".into(),
+        content: "hi\n[exit:0 | 2ms]".into(),
+        attachments: Vec::new(),
+    };
+    client.push_tool_results(vec![result]).await.unwrap();
+
+    let (tx2, mut rx2) = mpsc::channel(32);
+    let outcome2 = client.step(tools, tx2).await.unwrap();
+    assert!(matches!(outcome2, StepOutcome::Final));
+    drain(&mut rx2).await;
+
+    // Inspect the wire shape of the second request — it must carry the
+    // assistant tool_calls message AND the tool-result user message.
+    let captured = script.captured().await;
+    assert_eq!(captured.len(), 2);
+    let messages = captured[1].body["messages"].as_array().unwrap();
+
+    let assistant_with_calls = messages
+        .iter()
+        .find(|m| m["role"] == "assistant" && m.get("tool_calls").is_some())
+        .expect("assistant message with tool_calls");
+    assert!(
+        assistant_with_calls.get("content").is_none(),
+        "content key must be absent on tool-call assistant message"
+    );
+    let tool_calls = assistant_with_calls["tool_calls"].as_array().unwrap();
+    assert_eq!(tool_calls[0]["id"], "call-7");
+    assert_eq!(tool_calls[0]["function"]["name"], "run");
+
+    // The tool result should be routed as a user message with the
+    // [tool:run] prefix (per the design: user-role routing for tool
+    // results instead of the OpenAI tool role).
+    let tool_result_user = messages
+        .iter()
+        .rev()
+        .find(|m| {
+            m["role"] == "user"
+                && m["content"]
+                    .as_str()
+                    .map(|s| s.starts_with("[tool:run]"))
+                    .unwrap_or(false)
+        })
+        .expect("tool result user message");
+    assert!(
+        tool_result_user["content"]
+            .as_str()
+            .unwrap()
+            .contains("[exit:0 | 2ms]"),
+        "expected footer: {:?}",
+        tool_result_user["content"]
     );
 }
 

--- a/crates/assistd-llm/tests/presence.rs
+++ b/crates/assistd-llm/tests/presence.rs
@@ -282,7 +282,7 @@ async fn query_during_sleeping_triggers_auto_wake() {
     // handle_query, not the llama chat path.
     let state = Arc::new(AppState::new(
         Config::default(),
-        Arc::new(EchoBackend),
+        Arc::new(EchoBackend::new()),
         m.clone(),
         Arc::new(ToolRegistry::default()),
     ));
@@ -357,6 +357,7 @@ async fn query_during_sleeping_triggers_auto_wake() {
 /// `sleep()` blocks through the gap rather than killing the generator.
 struct DelayBackend {
     delay: Duration,
+    last_user: tokio::sync::Mutex<String>,
 }
 
 #[async_trait]
@@ -366,6 +367,29 @@ impl LlmBackend for DelayBackend {
         tokio::time::sleep(self.delay).await;
         let _ = tx.send(LlmEvent::Done).await;
         Ok(())
+    }
+
+    async fn push_user(&self, text: String) -> anyhow::Result<()> {
+        *self.last_user.lock().await = text;
+        Ok(())
+    }
+
+    async fn push_tool_results(
+        &self,
+        _results: Vec<assistd_llm::ToolResultPayload>,
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn step(
+        &self,
+        _tools: Vec<serde_json::Value>,
+        tx: mpsc::Sender<LlmEvent>,
+    ) -> anyhow::Result<assistd_llm::StepOutcome> {
+        let text = self.last_user.lock().await.clone();
+        let _ = tx.send(LlmEvent::Delta { text }).await;
+        tokio::time::sleep(self.delay).await;
+        Ok(assistd_llm::StepOutcome::Final)
     }
 }
 
@@ -406,6 +430,7 @@ async fn sleep_defers_until_inflight_query_done() {
         Config::default(),
         Arc::new(DelayBackend {
             delay: Duration::from_millis(500),
+            last_user: tokio::sync::Mutex::new(String::new()),
         }),
         m.clone(),
         Arc::new(ToolRegistry::default()),
@@ -490,7 +515,7 @@ async fn multiple_queries_during_wake_complete_in_order() {
 
     let state = Arc::new(AppState::new(
         Config::default(),
-        Arc::new(EchoBackend),
+        Arc::new(EchoBackend::new()),
         m.clone(),
         Arc::new(ToolRegistry::default()),
     ));

--- a/crates/assistd/src/chat/app.rs
+++ b/crates/assistd/src/chat/app.rs
@@ -7,7 +7,7 @@
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use assistd_core::{PresenceManager, PresenceState, SleepConfig};
+use assistd_core::{PresenceManager, PresenceState, SleepConfig, ToolRegistry};
 use assistd_llm::{LlmBackend, LlmEvent};
 use crossterm::event::{KeyCode, KeyEvent};
 use tokio::sync::mpsc;
@@ -41,12 +41,16 @@ pub struct App {
     pub sleep_cfg: SleepConfig,
     pub presence: Option<Arc<PresenceManager>>,
     client: Arc<dyn LlmBackend>,
+    tools: Arc<ToolRegistry>,
+    max_iterations: u32,
     chat_tx: mpsc::Sender<ChatEvent>,
 }
 
 impl App {
     pub fn new(
         client: Arc<dyn LlmBackend>,
+        tools: Arc<ToolRegistry>,
+        max_iterations: u32,
         chat_tx: mpsc::Sender<ChatEvent>,
         model_name: String,
         sleep_cfg: SleepConfig,
@@ -68,6 +72,8 @@ impl App {
             sleep_cfg,
             presence,
             client,
+            tools,
+            max_iterations,
             chat_tx,
         }
     }
@@ -144,6 +150,28 @@ impl App {
                 self.throughput.on_delta(now);
                 self.output.append_assistant(&text);
             }
+            ChatEvent::Llm(LlmEvent::ToolCall { arguments, .. }) => {
+                let cmd = arguments
+                    .get("command")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("<?>");
+                self.output.push_tool_call(cmd);
+            }
+            ChatEvent::Llm(LlmEvent::ToolResult { result, .. }) => {
+                let body = result
+                    .get("output")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_default();
+                let exit_code = result
+                    .get("exit_code")
+                    .and_then(|v| v.as_i64())
+                    .unwrap_or(0) as i32;
+                let truncated = result
+                    .get("truncated")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+                self.output.push_tool_result(body, exit_code, truncated);
+            }
             ChatEvent::Llm(LlmEvent::Done) => {
                 self.throughput.on_done(now);
                 self.output.finish_assistant();
@@ -190,6 +218,8 @@ impl App {
 
     fn spawn_generation(&self, text: String) {
         let client = self.client.clone();
+        let tools = self.tools.clone();
+        let max_iterations = self.max_iterations;
         let tx = self.chat_tx.clone();
         let presence = self.presence.clone();
         tokio::spawn(async move {
@@ -221,7 +251,8 @@ impl App {
                     }
                 }
             });
-            let result = client.generate(text, llm_tx).await;
+            let result =
+                assistd_core::run_agent_turn(client, tools, max_iterations, text, llm_tx).await;
             let _ = forwarder.await;
             if let Err(e) = result {
                 let _ = tx.send(ChatEvent::LlmError(e.to_string())).await;
@@ -253,8 +284,17 @@ mod tests {
 
     fn test_app() -> (App, mpsc::Receiver<ChatEvent>) {
         let (tx, rx) = mpsc::channel::<ChatEvent>(16);
-        let client: Arc<dyn LlmBackend> = Arc::new(EchoBackend);
-        let app = App::new(client, tx, "test-model".into(), test_sleep_cfg(), None);
+        let client: Arc<dyn LlmBackend> = Arc::new(EchoBackend::new());
+        let tools = Arc::new(ToolRegistry::default());
+        let app = App::new(
+            client,
+            tools,
+            20,
+            tx,
+            "test-model".into(),
+            test_sleep_cfg(),
+            None,
+        );
         (app, rx)
     }
 
@@ -366,7 +406,16 @@ mod tests {
     async fn failed_backend_spawn_yields_llm_error() {
         let (tx, mut rx) = mpsc::channel::<ChatEvent>(16);
         let client: Arc<dyn LlmBackend> = Arc::new(FailedBackend::new("server down".into()));
-        let app = App::new(client, tx, "test-model".into(), test_sleep_cfg(), None);
+        let tools = Arc::new(ToolRegistry::default());
+        let app = App::new(
+            client,
+            tools,
+            20,
+            tx,
+            "test-model".into(),
+            test_sleep_cfg(),
+            None,
+        );
         app.spawn_generation("hello".into());
         let ev = rx.recv().await.expect("error event");
         match ev {

--- a/crates/assistd/src/chat/mod.rs
+++ b/crates/assistd/src/chat/mod.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
-use assistd_core::{Config, PresenceManager, SleepConfig};
+use assistd_core::{Config, PresenceManager, SleepConfig, ToolRegistry};
 use assistd_llm::{FailedBackend, LlamaChatClient, LlmBackend};
 
 use crate::idle_monitor;
@@ -56,6 +56,17 @@ pub async fn run(args: ChatArgs) -> Result<()> {
 
     let (shutdown_tx, _) = watch::channel(false);
     install_signal_handler(shutdown_tx.clone());
+
+    // Process-scoped overflow dir: the chat TUI and the daemon must not
+    // share a path, otherwise their startup resets race each other.
+    let tui_overflow_dir =
+        std::env::temp_dir().join(format!("assistd-chat-{}", std::process::id()));
+    let tools = assistd_core::build_tools(&config, tui_overflow_dir.clone())?;
+    info!(
+        "tools: registered {} (overflow dir {})",
+        tools.len(),
+        tui_overflow_dir.display()
+    );
 
     println!("loading model {} ...", config.model.name);
 
@@ -99,6 +110,8 @@ pub async fn run(args: ChatArgs) -> Result<()> {
 
     let run_result = run_tui(
         client,
+        tools,
+        config.agent.max_iterations,
         model_name,
         config.sleep.clone(),
         presence.clone(),
@@ -121,8 +134,11 @@ pub async fn run(args: ChatArgs) -> Result<()> {
     run_result
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn run_tui(
     client: Arc<dyn LlmBackend>,
+    tools: Arc<ToolRegistry>,
+    max_iterations: u32,
     model_name: String,
     sleep_cfg: SleepConfig,
     presence: Option<Arc<PresenceManager>>,
@@ -151,7 +167,15 @@ async fn run_tui(
     let mut terminal = Terminal::new(backend).context("Terminal::new")?;
 
     let (chat_tx, mut chat_rx) = mpsc::channel::<ChatEvent>(64);
-    let mut app = App::new(client, chat_tx, model_name, sleep_cfg, presence.clone());
+    let mut app = App::new(
+        client,
+        tools,
+        max_iterations,
+        chat_tx,
+        model_name,
+        sleep_cfg,
+        presence.clone(),
+    );
 
     if let Some(err) = startup_error {
         app.output

--- a/crates/assistd/src/chat/output.rs
+++ b/crates/assistd/src/chat/output.rs
@@ -79,6 +79,56 @@ impl OutputPane {
         self.dirty = true;
     }
 
+    /// Append a command the model is about to execute via the `run` tool.
+    /// Rendered in a dim style with a `$ ` prefix so it visually reads as
+    /// a shell command separate from the chat transcript.
+    pub fn push_tool_call(&mut self, command: &str) {
+        self.close_open_assistant();
+        self.lines
+            .push(single_span_line(format!("$ {command}"), tool_call_style()));
+        self.dirty = true;
+    }
+
+    /// Append the result of a tool invocation. Shows up to the first
+    /// `TOOL_RESULT_MAX_LINES` of `output`, indented and dimmed. A
+    /// trailing marker indicates additional lines beyond the visible cap
+    /// or a server-side truncation flag.
+    pub fn push_tool_result(&mut self, output: &str, exit_code: i32, truncated: bool) {
+        self.close_open_assistant();
+        let mut emitted = 0usize;
+        let mut remainder = 0usize;
+        for (i, line) in output.lines().enumerate() {
+            if i < TOOL_RESULT_MAX_LINES {
+                self.lines
+                    .push(single_span_line(format!("  {line}"), tool_result_style()));
+                emitted += 1;
+            } else {
+                remainder += 1;
+            }
+        }
+        if remainder > 0 {
+            self.lines.push(single_span_line(
+                format!("  … ({remainder} more lines)"),
+                tool_result_style(),
+            ));
+        }
+        if truncated && remainder == 0 {
+            self.lines.push(single_span_line(
+                "  … (output truncated; full body in spill file)".to_string(),
+                tool_result_style(),
+            ));
+        }
+        // Short footer so the user can scan exit status without opening
+        // the output. Only shown when any content was emitted.
+        if emitted > 0 || remainder > 0 {
+            self.lines.push(single_span_line(
+                format!("  [exit:{exit_code}]"),
+                tool_result_style(),
+            ));
+        }
+        self.dirty = true;
+    }
+
     pub fn scroll_page_up(&mut self, viewport_height: u16) {
         let step = (viewport_height / 2).max(1);
         self.scroll_offset = self.scroll_offset.saturating_add(step);
@@ -191,6 +241,19 @@ fn error_style() -> Style {
     Style::default().fg(Color::Red).add_modifier(Modifier::BOLD)
 }
 
+fn tool_call_style() -> Style {
+    Style::default().fg(Color::Blue).add_modifier(Modifier::DIM)
+}
+
+fn tool_result_style() -> Style {
+    Style::default().fg(Color::DarkGray)
+}
+
+/// Cap on the number of raw `output` lines surfaced per tool result.
+/// The full body is still present in the LLM's conversation context —
+/// this is purely visual compression for the scrollback pane.
+const TOOL_RESULT_MAX_LINES: usize = 12;
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -276,6 +339,76 @@ mod tests {
         let mut p = OutputPane::new();
         p.push_error("boom");
         assert_eq!(line_text(&p.lines[0]), "!! boom");
+    }
+
+    #[test]
+    fn push_tool_call_prefixes_dollar_sign() {
+        let mut p = OutputPane::new();
+        p.push_tool_call("cat log.txt | grep ERROR");
+        assert_eq!(line_text(&p.lines[0]), "$ cat log.txt | grep ERROR");
+    }
+
+    #[test]
+    fn push_tool_call_closes_open_assistant_first() {
+        let mut p = OutputPane::new();
+        p.append_assistant("partial answer");
+        p.push_tool_call("ls");
+        // Expect: ["partial answer", "", "$ ls"]
+        assert_eq!(p.lines.len(), 3);
+        assert_eq!(line_text(&p.lines[0]), "partial answer");
+        assert_eq!(line_text(&p.lines[1]), "");
+        assert_eq!(line_text(&p.lines[2]), "$ ls");
+    }
+
+    #[test]
+    fn push_tool_result_indents_lines_and_emits_footer() {
+        let mut p = OutputPane::new();
+        p.push_tool_result("hello\nworld\n", 0, false);
+        // Two indented output lines + exit footer.
+        assert_eq!(line_text(&p.lines[0]), "  hello");
+        assert_eq!(line_text(&p.lines[1]), "  world");
+        assert_eq!(line_text(&p.lines[2]), "  [exit:0]");
+    }
+
+    #[test]
+    fn push_tool_result_caps_at_max_lines_with_marker() {
+        let mut p = OutputPane::new();
+        let body: String = (0..20).map(|i| format!("line {i}\n")).collect();
+        p.push_tool_result(&body, 0, false);
+        // First TOOL_RESULT_MAX_LINES lines + an overflow marker + footer.
+        assert_eq!(
+            p.lines.len(),
+            TOOL_RESULT_MAX_LINES + 2,
+            "{:?}",
+            p.lines.iter().map(line_text).collect::<Vec<_>>()
+        );
+        assert!(line_text(&p.lines[TOOL_RESULT_MAX_LINES]).contains("more lines"));
+    }
+
+    #[test]
+    fn push_tool_result_shows_truncated_marker_when_flag_set_and_under_cap() {
+        let mut p = OutputPane::new();
+        p.push_tool_result("small body\n", 0, true);
+        // body + truncation marker + footer.
+        assert_eq!(p.lines.len(), 3);
+        assert_eq!(line_text(&p.lines[0]), "  small body");
+        assert!(line_text(&p.lines[1]).contains("truncated"));
+        assert_eq!(line_text(&p.lines[2]), "  [exit:0]");
+    }
+
+    #[test]
+    fn push_tool_result_nonzero_exit_in_footer() {
+        let mut p = OutputPane::new();
+        p.push_tool_result("oops\n", 1, false);
+        assert_eq!(line_text(&p.lines[1]), "  [exit:1]");
+    }
+
+    #[test]
+    fn push_tool_result_empty_output_emits_nothing() {
+        // Empty body and no truncation → no indented output, no footer.
+        let mut p = OutputPane::new();
+        p.push_tool_result("", 0, false);
+        assert_eq!(p.lines.len(), 0);
     }
 
     #[test]

--- a/crates/assistd/src/daemon.rs
+++ b/crates/assistd/src/daemon.rs
@@ -1,13 +1,6 @@
 use anyhow::Result;
 use assistd_core::{AppState, Config, PresenceManager};
 use assistd_llm::LlamaChatClient;
-use assistd_tools::{
-    CommandRegistry, PresentSpec, RunTool, ToolRegistry,
-    commands::{
-        BashCommand, CatCommand, EchoCommand, GrepCommand, LsCommand, SeeCommand, WcCommand,
-        WebCommand, WriteCommand,
-    },
-};
 use clap::Args;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -37,24 +30,7 @@ pub async fn run(args: DaemonArgs) -> Result<()> {
     gpu_monitor::validate(&config.sleep)?;
     idle_monitor::validate(&config.sleep)?;
 
-    // Reset the Layer 2 overflow directory on every startup. Clearing it
-    // means the per-daemon monotonic counter always starts at 1 with no
-    // stale `cmd-<n>.txt` files left over from a previous run.
     let overflow_dir = PathBuf::from(&config.tools.output.overflow_dir);
-    if overflow_dir.exists() {
-        std::fs::remove_dir_all(&overflow_dir).map_err(|e| {
-            anyhow::anyhow!(
-                "failed to clear tools.output.overflow_dir {}: {e}",
-                overflow_dir.display()
-            )
-        })?;
-    }
-    std::fs::create_dir_all(&overflow_dir).map_err(|e| {
-        anyhow::anyhow!(
-            "failed to create tools.output.overflow_dir {}: {e}",
-            overflow_dir.display()
-        )
-    })?;
 
     info!(
         "assistd v{} — local model agent OS assistant daemon",
@@ -112,30 +88,10 @@ pub async fn run(args: DaemonArgs) -> Result<()> {
     let idle_monitor_handle =
         idle_monitor::spawn_monitor(&config.sleep, presence.clone(), shutdown_tx.subscribe());
 
-    let mut commands = CommandRegistry::new();
-    commands.register(CatCommand);
-    commands.register(LsCommand);
-    commands.register(GrepCommand);
-    commands.register(WcCommand);
-    commands.register(EchoCommand);
-    commands.register(WriteCommand);
-    commands.register(SeeCommand);
-    commands.register(WebCommand::new());
-    commands.register(BashCommand::default());
-    let commands = Arc::new(commands);
-
-    let present_spec = PresentSpec {
-        max_lines: config.tools.output.max_lines as usize,
-        max_bytes: (config.tools.output.max_kb as usize) * 1024,
-        overflow_dir: overflow_dir.clone(),
-    };
-    let mut tools = ToolRegistry::new();
-    tools.register(RunTool::new(commands.clone(), present_spec));
-    let tools = Arc::new(tools);
+    let tools = assistd_core::build_tools(&config, overflow_dir.clone())?;
     info!(
-        "tools: registered {} ({} commands, overflow dir {})",
+        "tools: registered {} (overflow dir {})",
         tools.len(),
-        commands.len(),
         overflow_dir.display()
     );
 

--- a/crates/assistd/src/query.rs
+++ b/crates/assistd/src/query.rs
@@ -6,6 +6,21 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::UnixStream;
 use uuid::Uuid;
 
+/// Tool-call preview cap: long commands are truncated to keep the status
+/// line readable while still showing the shape of the call.
+const PREVIEW_MAX_CHARS: usize = 80;
+
+fn truncate_preview(s: &str) -> String {
+    let mut out = String::with_capacity(PREVIEW_MAX_CHARS + 1);
+    for ch in s.chars().take(PREVIEW_MAX_CHARS) {
+        out.push(ch);
+    }
+    if s.chars().count() > PREVIEW_MAX_CHARS {
+        out.push('…');
+    }
+    out
+}
+
 #[derive(Args)]
 pub struct QueryArgs {
     /// Text to send to the daemon
@@ -52,13 +67,28 @@ pub async fn run(args: QueryArgs) -> Result<()> {
                 stdout.flush()?;
                 wrote_anything = wrote_anything || !text.is_empty();
             }
-            Event::ToolCall { name, .. } => {
-                // Tool use is reserved for a future milestone; surface to
-                // the user so the stream is readable when it lands.
-                writeln!(stdout, "\n[tool call: {name}]")?;
+            Event::ToolCall { name, args, .. } => {
+                // Prefix tool calls with a line separator so the stream
+                // remains readable when they land mid-response. Extract
+                // the command preview so the user sees what the model
+                // is running, not just the tool name.
+                let preview = args
+                    .get("command")
+                    .and_then(|v| v.as_str())
+                    .map(truncate_preview)
+                    .unwrap_or_default();
+                if preview.is_empty() {
+                    writeln!(stdout, "\n[tool call: {name}]")?;
+                } else {
+                    writeln!(stdout, "\n[tool call: {name} {preview}]")?;
+                }
             }
-            Event::ToolResult { name, .. } => {
-                writeln!(stdout, "[tool result: {name}]")?;
+            Event::ToolResult { name, result, .. } => {
+                let exit = result
+                    .get("exit_code")
+                    .and_then(|v| v.as_i64())
+                    .unwrap_or(0);
+                writeln!(stdout, "[tool result: {name} exit:{exit}]")?;
             }
             Event::Presence { state, .. } => {
                 writeln!(stdout, "[presence: {state:?}]")?;


### PR DESCRIPTION
tool calling loop for agent.
- assistd-llm wire + conversation: ChatRequest now carries tools/tool_choice; ChatMessage has optional content plus tool_calls; streaming delta accumulates tool_calls across chunks. Conversation::Message has a tool_calls: Vec<ToolCallRecord> field and a push_assistant_with_tool_calls helper; the truncator drops tool-call/result pairs atomically.                                        
- LlmBackend trait: Added push_user, push_tool_results, step(tools, tx) -> StepOutcome. LlmEvent gained ToolCall and ToolResult variants. LlamaChatClient implements the new methods (tool results routed as [tool:<name>]\n… user messages to sidestep Jinja template inconsistencies around the tool role).                                                    
- assistd-core::agent::run_agent_turn: new orchestrator at crates/assistd-core/src/agent.rs. Loops push_user → step → dispatch → push_tool_results, emits ToolCall/ToolResult events, logs iteration/command/exit_code/output_size/duration_ms, bails on tx.is_closed() or max_iterations cap.                  
- Config: new [agent] section with max_iterations default 20; default system prompt mentions the run tool.                                      
- AppState: adds agent_turn_lock: Mutex<()> so concurrent queries' tool-call turns never interleave; handle_query maps LlmEvent::ToolCall/ToolResult → wire Event::ToolCall/ToolResult.
- assistd_core::build_tools: shared helper extracted so daemon and TUI build the registry identically, with process-scoped overflow dirs.        
- TUI: App takes tools: Arc<ToolRegistry> + max_iterations, spawn_generation runs run_agent_turn, OutputPane::push_tool_call push_tool_result render $ <command> and indented result bodies with an [exit:N] footer.                           
- assistd query CLI: prints [tool call: run <cmd>] with a truncated preview and [tool result: run exit:N].