### PR TITLE
Integrate piper as a managed subprocess

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "alsa"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c88dbbce13b232b26250e1e2e6ac18b6a891a646b8148285036ebce260ac5c3"
+dependencies = [
+ "alsa-sys",
+ "bitflags 2.11.0",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "alsa-sys"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -212,19 +224,23 @@ dependencies = [
  "assistd-config",
  "assistd-ipc",
  "async-trait",
- "cpal",
+ "cpal 0.15.3",
  "futures-util",
  "hound",
  "nvml-wrapper",
  "reqwest",
  "ringbuf",
+ "rodio",
  "rubato",
+ "serde",
+ "serde_json",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
  "tracing-subscriber",
  "webrtc-vad",
+ "which",
  "whisper-rs",
 ]
 
@@ -299,6 +315,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
 ]
 
 [[package]]
@@ -492,6 +517,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "coreaudio-rs"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aae284fbaf7d27aa0e292f7677dfbe26503b0d555026f702940805a630eac17"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+ "objc2-audio-toolbox",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "coreaudio-sys"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -506,21 +545,51 @@ version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "873dab07c8f743075e57f524c583985fbaf745602acbe916a01539364369a779"
 dependencies = [
- "alsa",
+ "alsa 0.9.1",
  "core-foundation-sys",
- "coreaudio-rs",
+ "coreaudio-rs 0.11.3",
  "dasp_sample",
  "jni",
  "js-sys",
  "libc",
- "mach2",
- "ndk",
+ "mach2 0.4.3",
+ "ndk 0.8.0",
  "ndk-context",
  "oboe",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "windows",
+ "windows 0.54.0",
+]
+
+[[package]]
+name = "cpal"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b1f9c7312f19fc2fa12fd7acaf38de54e8320ba10d1a02dcbe21038def51ccb"
+dependencies = [
+ "alsa 0.10.0",
+ "coreaudio-rs 0.13.0",
+ "dasp_sample",
+ "jni",
+ "js-sys",
+ "libc",
+ "mach2 0.5.0",
+ "ndk 0.9.0",
+ "ndk-context",
+ "num-derive",
+ "num-traits",
+ "objc2",
+ "objc2-audio-toolbox",
+ "objc2-avf-audio",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -674,6 +743,12 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
 
 [[package]]
 name = "equivalent"
@@ -1349,6 +1424,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mach2"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a1b95cd5421ec55b445b5ae102f5ea0e768de1f82bd3001e11f426c269c3aea"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1390,7 +1474,21 @@ dependencies = [
  "bitflags 2.11.0",
  "jni-sys 0.3.1",
  "log",
- "ndk-sys",
+ "ndk-sys 0.5.0+25.2.9519653",
+ "num_enum",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "ndk"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
+dependencies = [
+ "bitflags 2.11.0",
+ "jni-sys 0.3.1",
+ "log",
+ "ndk-sys 0.6.0+11769913",
  "num_enum",
  "thiserror 1.0.69",
 ]
@@ -1406,6 +1504,15 @@ name = "ndk-sys"
 version = "0.5.0+25.2.9519653"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
+dependencies = [
+ "jni-sys 0.3.1",
+]
+
+[[package]]
+name = "ndk-sys"
+version = "0.6.0+11769913"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
  "jni-sys 0.3.1",
 ]
@@ -1427,6 +1534,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -1461,6 +1578,17 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 
@@ -1539,13 +1667,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-audio-toolbox"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6948501a91121d6399b79abaa33a8aa4ea7857fe019f341b8c23ad6e81b79b08"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
+ "objc2",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-avf-audio"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13a380031deed8e99db00065c45937da434ca987c034e13b87e4441f9e4090be"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-audio"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1eebcea8b0dbff5f7c8504f3107c68fc061a3eb44932051c8cf8a68d969c3b2"
+dependencies = [
+ "dispatch2",
+ "objc2",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-audio-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a89f2ec274a0cf4a32642b2991e8b351a404d290da87bb6a9a9d8632490bd1c"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+]
+
+[[package]]
 name = "objc2-core-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.11.0",
+ "block2",
  "dispatch2",
+ "libc",
  "objc2",
 ]
 
@@ -1562,6 +1740,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.0",
+ "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -1573,7 +1753,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8b61bebd49e5d43f5f8cc7ee2891c16e0f41ec7954d36bcb6c14c5e0de867fb"
 dependencies = [
  "jni",
- "ndk",
+ "ndk 0.8.0",
  "ndk-context",
  "num-derive",
  "num-traits",
@@ -1961,6 +2141,18 @@ dependencies = [
  "crossbeam-utils",
  "portable-atomic",
  "portable-atomic-util",
+]
+
+[[package]]
+name = "rodio"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a536bb79db59098ef71a4dd4246c02eb87b316deceb1b68e0cde7167ec01eb"
+dependencies = [
+ "cpal 0.17.1",
+ "dasp_sample",
+ "num-rational",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2973,6 +3165,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "7.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
+dependencies = [
+ "either",
+ "env_home",
+ "rustix 1.1.4",
+ "winsafe",
+]
+
+[[package]]
 name = "whisper-rs"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3032,8 +3236,29 @@ version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
 dependencies = [
- "windows-core",
+ "windows-core 0.54.0",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core 0.62.2",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -3042,8 +3267,54 @@ version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65"
 dependencies = [
- "windows-result",
+ "windows-result 0.1.2",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result 0.4.1",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link",
+ "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3053,12 +3324,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -3152,6 +3451,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -3309,6 +3617,12 @@ checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,8 @@ tempfile = "3"
 base64 = "0.22"
 infer = "0.19"
 shlex = "1"
+which = "7"
+rodio = { version = "0.22", default-features = false, features = ["playback"] }
 
 [profile.release]
 lto = "thin"

--- a/config/config.sample.toml
+++ b/config/config.sample.toml
@@ -177,6 +177,44 @@ enabled = false
 # rejecting non-speech.
 # aggressiveness = 3
 
+[voice.synthesis]
+# Speak LLM responses aloud through a local Piper TTS subprocess. When
+# enabled, the daemon spawns piper per utterance, writes one sentence to
+# stdin, reads raw PCM from stdout, and plays it through the default
+# audio device via rodio. Falls back silently with a warning log if the
+# piper binary is missing, the voice model fails to download, or no
+# audio device is available — the daemon stays up either way.
+enabled = false
+# Path to (or name of) the piper binary. A bare command name is looked
+# up via $PATH.
+# binary_path = "piper"
+# HuggingFace identifier for the Piper voice ONNX, formatted as
+# "<owner>/<repo>:<file>" where <file> is the path of the .onnx inside
+# the repo. The matching .onnx.json is downloaded alongside it. Cached
+# under $XDG_CACHE_HOME/assistd/piper/ (or ~/.cache/assistd/piper/).
+# voice = "rhasspy/piper-voices:en/en_US/lessac/medium/en_US-lessac-medium.onnx"
+# Override the on-disk voice cache directory. Omit for the XDG default.
+# model_cache_dir = "/var/cache/assistd/piper"
+# Speaking-rate scale. 1.0 is the voice's natural rate; lower = faster.
+# length_scale = 1.0
+# Sampling noise scale (--noise-scale). Higher = more pitch variation.
+# noise_scale = 0.667
+# Phoneme noise scale (--noise-w). Higher = more cadence variation.
+# noise_w = 0.8
+# Trailing silence (seconds) Piper inserts after each utterance.
+# sentence_silence_secs = 0.2
+# Optional override for Piper's espeak-ng data directory. Only set when
+# piper logs "Failed to load espeak-ng" — most distro packages handle
+# this themselves.
+# espeak_data_dir = "/usr/share/espeak-ng-data"
+# Per-utterance synthesis deadline in seconds. Piper is killed if it
+# hasn't returned PCM by this point.
+# deadline_secs = 30
+# Maximum sentence length fed to Piper. The sentence buffer flushes at
+# the last whitespace before this cap when no terminator appears within
+# the limit.
+# max_sentence_chars = 400
+
 [compositor]
 # Tiling compositor to integrate with. One of: i3, sway, hyprland
 type = "sway"

--- a/crates/assistd-config/src/defaults.rs
+++ b/crates/assistd-config/src/defaults.rs
@@ -47,6 +47,17 @@ pub const DEFAULT_WHISPER_VAD_SILENCE_SECS: f32 = 0.5;
 pub const DEFAULT_WHISPER_GPU_BUSY_TIMEOUT_MS: u32 = 300;
 pub const DEFAULT_WHISPER_CPU_FALLBACK_ENABLED: bool = true;
 
+pub const DEFAULT_PIPER_ENABLED: bool = false;
+pub const DEFAULT_PIPER_BINARY: &str = "piper";
+pub const DEFAULT_PIPER_VOICE: &str =
+    "rhasspy/piper-voices:en/en_US/lessac/medium/en_US-lessac-medium.onnx";
+pub const DEFAULT_PIPER_LENGTH_SCALE: f32 = 1.0;
+pub const DEFAULT_PIPER_NOISE_SCALE: f32 = 0.667;
+pub const DEFAULT_PIPER_NOISE_W: f32 = 0.8;
+pub const DEFAULT_PIPER_SENTENCE_SILENCE_SECS: f32 = 0.2;
+pub const DEFAULT_PIPER_DEADLINE_SECS: u32 = 30;
+pub const DEFAULT_PIPER_MAX_SENTENCE_CHARS: u32 = 400;
+
 pub const DEFAULT_LISTEN_ENABLED: bool = false;
 pub const DEFAULT_LISTEN_START_ON_LAUNCH: bool = false;
 pub const DEFAULT_LISTEN_HOTKEY: &str = "";

--- a/crates/assistd-config/src/lib.rs
+++ b/crates/assistd-config/src/lib.rs
@@ -39,4 +39,4 @@ pub use tools::{
     BashSandboxMode, ToolsBashConfig, ToolsConfig, ToolsOutputConfig, ToolsWriteConfig,
 };
 pub use top::Config;
-pub use voice::{ContinuousListenConfig, TranscriptionConfig, VoiceConfig};
+pub use voice::{ContinuousListenConfig, SynthesisConfig, TranscriptionConfig, VoiceConfig};

--- a/crates/assistd-config/src/top.rs
+++ b/crates/assistd-config/src/top.rs
@@ -207,6 +207,48 @@ impl Config {
             }
         }
 
+        // Synthesis (Piper TTS) is gated independently of voice.enabled —
+        // a user might want LLM responses spoken aloud even with no
+        // microphone available.
+        if self.voice.synthesis.enabled {
+            let s = &self.voice.synthesis;
+            if s.binary_path.trim().is_empty() {
+                errors.push(
+                    "voice.synthesis.binary_path must not be empty when synthesis is enabled"
+                        .into(),
+                );
+            }
+            if s.voice.trim().is_empty() {
+                errors.push("voice.synthesis.voice must not be empty".into());
+            } else if !is_valid_hf_id(&s.voice) {
+                errors.push(
+                    "voice.synthesis.voice must be of the form '<owner>/<repo>:<file>'".into(),
+                );
+            }
+            if !s.length_scale.is_finite() || s.length_scale <= 0.0 {
+                errors
+                    .push("voice.synthesis.length_scale must be a positive, finite number".into());
+            }
+            if !s.noise_scale.is_finite() || !(0.0..=5.0).contains(&s.noise_scale) {
+                errors.push("voice.synthesis.noise_scale must be in the range 0.0..=5.0".into());
+            }
+            if !s.noise_w.is_finite() || !(0.0..=5.0).contains(&s.noise_w) {
+                errors.push("voice.synthesis.noise_w must be in the range 0.0..=5.0".into());
+            }
+            if !s.sentence_silence_secs.is_finite() || s.sentence_silence_secs < 0.0 {
+                errors.push(
+                    "voice.synthesis.sentence_silence_secs must be a non-negative, finite number"
+                        .into(),
+                );
+            }
+            if s.deadline_secs == 0 {
+                errors.push("voice.synthesis.deadline_secs must be greater than 0".into());
+            }
+            if s.max_sentence_chars < 50 {
+                errors.push("voice.synthesis.max_sentence_chars must be at least 50".into());
+            }
+        }
+
         if self.sleep.idle_to_drowsy_mins > 0
             && self.sleep.idle_to_sleep_mins > 0
             && self.sleep.idle_to_sleep_mins <= self.sleep.idle_to_drowsy_mins

--- a/crates/assistd-config/src/voice.rs
+++ b/crates/assistd-config/src/voice.rs
@@ -4,7 +4,10 @@ use crate::defaults::{
     DEFAULT_LISTEN_AGGRESSIVENESS, DEFAULT_LISTEN_ENABLED, DEFAULT_LISTEN_HOTKEY,
     DEFAULT_LISTEN_MAX_UTTERANCE_SECS, DEFAULT_LISTEN_MIN_UTTERANCE_MS,
     DEFAULT_LISTEN_ONSET_CONFIRM_MS, DEFAULT_LISTEN_PREROLL_MS, DEFAULT_LISTEN_SILENCE_MS,
-    DEFAULT_LISTEN_START_ON_LAUNCH, DEFAULT_VOICE_HOTKEY, DEFAULT_VOICE_MAX_RECORDING_SECS,
+    DEFAULT_LISTEN_START_ON_LAUNCH, DEFAULT_PIPER_BINARY, DEFAULT_PIPER_DEADLINE_SECS,
+    DEFAULT_PIPER_ENABLED, DEFAULT_PIPER_LENGTH_SCALE, DEFAULT_PIPER_MAX_SENTENCE_CHARS,
+    DEFAULT_PIPER_NOISE_SCALE, DEFAULT_PIPER_NOISE_W, DEFAULT_PIPER_SENTENCE_SILENCE_SECS,
+    DEFAULT_PIPER_VOICE, DEFAULT_VOICE_HOTKEY, DEFAULT_VOICE_MAX_RECORDING_SECS,
     DEFAULT_WHISPER_BEAMS, DEFAULT_WHISPER_CPU_FALLBACK_ENABLED,
     DEFAULT_WHISPER_GPU_BUSY_TIMEOUT_MS, DEFAULT_WHISPER_MODEL, DEFAULT_WHISPER_PREFER_GPU,
     DEFAULT_WHISPER_VAD_ENABLED, DEFAULT_WHISPER_VAD_MODEL, DEFAULT_WHISPER_VAD_SILENCE_SECS,
@@ -37,6 +40,11 @@ pub struct VoiceConfig {
     /// to the agent loop.
     #[serde(default)]
     pub continuous: ContinuousListenConfig,
+    /// Text-to-speech synthesis (Piper). Disabled by default; when
+    /// `enabled = true` the daemon spawns piper per utterance and plays
+    /// LLM responses aloud through the default audio output.
+    #[serde(default)]
+    pub synthesis: SynthesisConfig,
 }
 
 impl Default for VoiceConfig {
@@ -48,6 +56,7 @@ impl Default for VoiceConfig {
             max_recording_secs: DEFAULT_VOICE_MAX_RECORDING_SECS,
             transcription: TranscriptionConfig::default(),
             continuous: ContinuousListenConfig::default(),
+            synthesis: SynthesisConfig::default(),
         }
     }
 }
@@ -245,4 +254,107 @@ fn default_listen_onset_confirm_ms() -> u32 {
 }
 fn default_listen_aggressiveness() -> u8 {
     DEFAULT_LISTEN_AGGRESSIVENESS
+}
+
+/// Piper text-to-speech settings. The full section can be omitted from
+/// the TOML; everything has a default. `enabled = false` means the
+/// daemon won't spawn piper, won't download voice models, and any LLM
+/// response stays silent.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SynthesisConfig {
+    /// Master switch. When false, the daemon substitutes a silent
+    /// `NoVoiceOutput` placeholder and skips Piper startup entirely.
+    #[serde(default = "default_piper_enabled")]
+    pub enabled: bool,
+    /// Path to (or name of) the piper binary. Looked up via `$PATH`
+    /// when the value is a bare command name.
+    #[serde(default = "default_piper_binary")]
+    pub binary_path: String,
+    /// HuggingFace identifier for the Piper voice ONNX, formatted as
+    /// `<owner>/<repo>:<file>` where `<file>` is the path of the
+    /// `.onnx` file inside the repo. The matching `.onnx.json` is
+    /// downloaded alongside it. Cached under `model_cache_dir` (or
+    /// `$XDG_CACHE_HOME/assistd/piper/`).
+    #[serde(default = "default_piper_voice")]
+    pub voice: String,
+    /// Override for the on-disk voice cache directory. `None` uses
+    /// `$XDG_CACHE_HOME/assistd/piper/` (or `~/.cache/assistd/piper/`).
+    #[serde(default)]
+    pub model_cache_dir: Option<PathBuf>,
+    /// Speaking-rate scale. `1.0` is the voice's natural rate; lower
+    /// values speak faster, higher values speak slower.
+    #[serde(default = "default_piper_length_scale")]
+    pub length_scale: f32,
+    /// Sampling noise scale (Piper `--noise-scale`). Higher = more
+    /// variation in pitch/intonation.
+    #[serde(default = "default_piper_noise_scale")]
+    pub noise_scale: f32,
+    /// Phoneme noise scale (Piper `--noise-w`). Higher = more variation
+    /// in cadence/stress.
+    #[serde(default = "default_piper_noise_w")]
+    pub noise_w: f32,
+    /// Trailing silence (seconds) Piper inserts after each utterance.
+    /// Maps to `--sentence-silence`.
+    #[serde(default = "default_piper_sentence_silence_secs")]
+    pub sentence_silence_secs: f32,
+    /// Optional override for Piper's espeak-ng data directory. Most
+    /// distro packages set this themselves; only set when piper logs
+    /// "Failed to load espeak-ng".
+    #[serde(default)]
+    pub espeak_data_dir: Option<PathBuf>,
+    /// Per-utterance synthesis deadline in seconds. The piper child is
+    /// killed if it hasn't returned PCM by this point.
+    #[serde(default = "default_piper_deadline_secs")]
+    pub deadline_secs: u32,
+    /// Maximum sentence length fed to Piper. The sentence buffer flushes
+    /// at the last whitespace before this cap when no terminator appears
+    /// within the limit.
+    #[serde(default = "default_piper_max_sentence_chars")]
+    pub max_sentence_chars: u32,
+}
+
+impl Default for SynthesisConfig {
+    fn default() -> Self {
+        Self {
+            enabled: DEFAULT_PIPER_ENABLED,
+            binary_path: DEFAULT_PIPER_BINARY.to_string(),
+            voice: DEFAULT_PIPER_VOICE.to_string(),
+            model_cache_dir: None,
+            length_scale: DEFAULT_PIPER_LENGTH_SCALE,
+            noise_scale: DEFAULT_PIPER_NOISE_SCALE,
+            noise_w: DEFAULT_PIPER_NOISE_W,
+            sentence_silence_secs: DEFAULT_PIPER_SENTENCE_SILENCE_SECS,
+            espeak_data_dir: None,
+            deadline_secs: DEFAULT_PIPER_DEADLINE_SECS,
+            max_sentence_chars: DEFAULT_PIPER_MAX_SENTENCE_CHARS,
+        }
+    }
+}
+
+fn default_piper_enabled() -> bool {
+    DEFAULT_PIPER_ENABLED
+}
+fn default_piper_binary() -> String {
+    DEFAULT_PIPER_BINARY.to_string()
+}
+fn default_piper_voice() -> String {
+    DEFAULT_PIPER_VOICE.to_string()
+}
+fn default_piper_length_scale() -> f32 {
+    DEFAULT_PIPER_LENGTH_SCALE
+}
+fn default_piper_noise_scale() -> f32 {
+    DEFAULT_PIPER_NOISE_SCALE
+}
+fn default_piper_noise_w() -> f32 {
+    DEFAULT_PIPER_NOISE_W
+}
+fn default_piper_sentence_silence_secs() -> f32 {
+    DEFAULT_PIPER_SENTENCE_SILENCE_SECS
+}
+fn default_piper_deadline_secs() -> u32 {
+    DEFAULT_PIPER_DEADLINE_SECS
+}
+fn default_piper_max_sentence_chars() -> u32 {
+    DEFAULT_PIPER_MAX_SENTENCE_CHARS
 }

--- a/crates/assistd-core/src/lib.rs
+++ b/crates/assistd-core/src/lib.rs
@@ -14,7 +14,9 @@ pub use assistd_config::{
 pub use assistd_ipc as ipc;
 pub use assistd_ipc::{PresenceState, VoiceCaptureState};
 pub use assistd_tools::{CommandRegistry, ToolRegistry};
-pub use assistd_voice::{ContinuousListener, NoContinuousListener, NoVoiceInput, VoiceInput};
+pub use assistd_voice::{
+    ContinuousListener, NoContinuousListener, NoVoiceInput, NoVoiceOutput, VoiceInput, VoiceOutput,
+};
 pub use presence::{PresenceManager, RequestGuard};
 pub use state::AppState;
 

--- a/crates/assistd-core/src/socket.rs
+++ b/crates/assistd-core/src/socket.rs
@@ -238,6 +238,7 @@ mod tests {
             Arc::new(assistd_tools::ToolRegistry::default()),
             Arc::new(assistd_voice::NoVoiceInput::new()),
             Arc::new(assistd_voice::NoContinuousListener::new()),
+            Arc::new(assistd_voice::NoVoiceOutput),
         ))
     }
 
@@ -586,6 +587,7 @@ mod tests {
             Arc::new(assistd_tools::ToolRegistry::default()),
             Arc::new(assistd_voice::NoVoiceInput::new()),
             Arc::new(assistd_voice::NoContinuousListener::new()),
+            Arc::new(assistd_voice::NoVoiceOutput),
         ))
     }
 

--- a/crates/assistd-core/src/state.rs
+++ b/crates/assistd-core/src/state.rs
@@ -3,7 +3,7 @@ use anyhow::Result;
 use assistd_ipc::{Event, PresenceState, Request, VoiceCaptureState};
 use assistd_llm::{LlmBackend, LlmEvent};
 use assistd_tools::ToolRegistry;
-use assistd_voice::{ContinuousListener, VoiceInput};
+use assistd_voice::{ContinuousListener, SentenceBuffer, VoiceInput, VoiceOutput};
 use std::sync::Arc;
 use tokio::sync::{Mutex, mpsc};
 
@@ -20,6 +20,10 @@ pub struct AppState {
     pub tools: Arc<ToolRegistry>,
     pub voice: Arc<dyn VoiceInput>,
     pub listener: Arc<dyn ContinuousListener>,
+    /// Speaks LLM responses aloud, sentence by sentence. When TTS is
+    /// disabled in config or the build, this is `NoVoiceOutput` which
+    /// silently accepts every speak() call.
+    pub voice_output: Arc<dyn VoiceOutput>,
     /// Serializes entire agent turns. Concurrent queries each grab this
     /// lock before running `run_agent_turn`, so one query's tool-call /
     /// tool-result cycle never interleaves with another's — which would
@@ -36,6 +40,7 @@ impl AppState {
         tools: Arc<ToolRegistry>,
         voice: Arc<dyn VoiceInput>,
         listener: Arc<dyn ContinuousListener>,
+        voice_output: Arc<dyn VoiceOutput>,
     ) -> Self {
         Self {
             config,
@@ -44,6 +49,7 @@ impl AppState {
             tools,
             voice,
             listener,
+            voice_output,
             agent_turn_lock: Arc::new(Mutex::new(())),
         }
     }
@@ -115,12 +121,34 @@ impl AppState {
                 async move { run_agent_turn(llm, tools, max_iterations, text, llm_tx).await },
             );
 
+        // Sentence buffer feeds completed sentences to TTS as the LLM
+        // streams. Tool call/result events do not feed it — speaking
+        // tool JSON is annoying. Each completed sentence is fire-and-
+        // forget tokio::spawn so audio playback doesn't block the wire
+        // forward to the client.
+        let max_sentence_chars = self.config.voice.synthesis.max_sentence_chars as usize;
+        let mut sentence_buf = SentenceBuffer::new(max_sentence_chars);
+
         while let Some(llm_event) = llm_rx.recv().await {
             let wire_event = match llm_event {
-                LlmEvent::Delta { text } => Event::Delta {
-                    id: id.clone(),
-                    text,
-                },
+                LlmEvent::Delta { text } => {
+                    for sentence in sentence_buf.push(&text) {
+                        let v = self.voice_output.clone();
+                        tokio::spawn(async move {
+                            if let Err(e) = v.speak(sentence).await {
+                                tracing::debug!(
+                                    target: "assistd::voice",
+                                    error = %e,
+                                    "voice_output.speak failed (non-fatal)"
+                                );
+                            }
+                        });
+                    }
+                    Event::Delta {
+                        id: id.clone(),
+                        text,
+                    }
+                }
                 LlmEvent::ToolCall {
                     id: _call_id,
                     name,
@@ -139,7 +167,21 @@ impl AppState {
                     name,
                     result,
                 },
-                LlmEvent::Done => Event::Done { id: id.clone() },
+                LlmEvent::Done => {
+                    if let Some(tail) = sentence_buf.finish() {
+                        let v = self.voice_output.clone();
+                        tokio::spawn(async move {
+                            if let Err(e) = v.speak(tail).await {
+                                tracing::debug!(
+                                    target: "assistd::voice",
+                                    error = %e,
+                                    "voice_output.speak (final) failed (non-fatal)"
+                                );
+                            }
+                        });
+                    }
+                    Event::Done { id: id.clone() }
+                }
             };
             if tx.send(wire_event).await.is_err() {
                 // Client has disconnected; stop forwarding events.
@@ -451,6 +493,7 @@ mod tests {
             Arc::new(ToolRegistry::default()),
             Arc::new(assistd_voice::NoVoiceInput::new()),
             Arc::new(assistd_voice::NoContinuousListener::new()),
+            Arc::new(assistd_voice::NoVoiceOutput),
         ))
     }
 
@@ -465,6 +508,7 @@ mod tests {
             Arc::new(ToolRegistry::default()),
             voice,
             Arc::new(assistd_voice::NoContinuousListener::new()),
+            Arc::new(assistd_voice::NoVoiceOutput),
         ))
     }
 
@@ -479,6 +523,7 @@ mod tests {
             Arc::new(ToolRegistry::default()),
             Arc::new(assistd_voice::NoVoiceInput::new()),
             listener,
+            Arc::new(assistd_voice::NoVoiceOutput),
         ))
     }
 
@@ -659,6 +704,7 @@ mod tests {
             Arc::new(tools),
             Arc::new(assistd_voice::NoVoiceInput::new()),
             Arc::new(assistd_voice::NoContinuousListener::new()),
+            Arc::new(assistd_voice::NoVoiceOutput),
         ))
     }
 

--- a/crates/assistd-llm/tests/presence.rs
+++ b/crates/assistd-llm/tests/presence.rs
@@ -13,8 +13,8 @@ use std::time::Duration;
 
 use assistd_config::{LlamaServerConfig, ModelConfig};
 use assistd_core::{
-    AppState, Config, NoContinuousListener, NoVoiceInput, PresenceManager, PresenceState,
-    ToolRegistry,
+    AppState, Config, NoContinuousListener, NoVoiceInput, NoVoiceOutput, PresenceManager,
+    PresenceState, ToolRegistry,
 };
 use assistd_ipc::{Event, Request};
 use assistd_llm::{EchoBackend, LlmBackend, LlmEvent};
@@ -303,6 +303,7 @@ async fn query_during_sleeping_triggers_auto_wake() {
         Arc::new(ToolRegistry::default()),
         Arc::new(NoVoiceInput::new()),
         Arc::new(NoContinuousListener::new()),
+        Arc::new(NoVoiceOutput),
     ));
 
     let dir = tempfile::tempdir().unwrap();
@@ -454,6 +455,7 @@ async fn sleep_defers_until_inflight_query_done() {
         Arc::new(ToolRegistry::default()),
         Arc::new(NoVoiceInput::new()),
         Arc::new(NoContinuousListener::new()),
+        Arc::new(NoVoiceOutput),
     ));
 
     let dir = tempfile::tempdir().unwrap();
@@ -540,6 +542,7 @@ async fn multiple_queries_during_wake_complete_in_order() {
         Arc::new(ToolRegistry::default()),
         Arc::new(NoVoiceInput::new()),
         Arc::new(NoContinuousListener::new()),
+        Arc::new(NoVoiceOutput),
     ));
 
     let dir = tempfile::tempdir().unwrap();

--- a/crates/assistd-voice/Cargo.toml
+++ b/crates/assistd-voice/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 license.workspace = true
 
 [features]
-default = ["whisper", "mic", "listen"]
+default = ["whisper", "mic", "listen", "tts"]
 whisper = [
     "dep:whisper-rs",
     "dep:reqwest",
@@ -20,9 +20,21 @@ mic = ["whisper", "dep:cpal", "dep:ringbuf", "dep:rubato"]
 # segmentation that feeds completed utterances to whisper. Sits on top
 # of the `mic` + `whisper` stack.
 listen = ["mic", "dep:webrtc-vad"]
+# Enables `PiperVoiceOutput` — managed per-utterance piper subprocess
+# with rodio playback. Pulls in rodio (which itself uses cpal) and
+# reqwest (shared with whisper) for HuggingFace voice downloads.
+tts = [
+    "dep:rodio",
+    "dep:serde",
+    "dep:serde_json",
+    "dep:reqwest",
+    "dep:futures-util",
+    "dep:assistd-config",
+    "dep:which",
+]
 cuda = ["whisper-rs/cuda"]
 # Gates the integration test that downloads a small model from HuggingFace.
-test-support = ["whisper", "mic", "listen", "dep:hound"]
+test-support = ["whisper", "mic", "listen", "tts", "dep:hound"]
 
 [dependencies]
 anyhow = { workspace = true }
@@ -46,6 +58,12 @@ rubato = { version = "0.15", optional = true }
 
 # Continuous listening — streaming voice-activity detection
 webrtc-vad = { version = "0.4", optional = true }
+
+# Piper TTS
+rodio = { workspace = true, optional = true }
+serde = { workspace = true, optional = true }
+serde_json = { workspace = true, optional = true }
+which = { workspace = true, optional = true }
 
 # Test support
 hound = { version = "3.5", optional = true }

--- a/crates/assistd-voice/src/lib.rs
+++ b/crates/assistd-voice/src/lib.rs
@@ -30,10 +30,18 @@ pub mod mic;
 #[cfg(feature = "listen")]
 pub mod listen;
 
+#[cfg(feature = "tts")]
+pub mod piper;
+
+pub mod sentence;
+
 #[cfg(feature = "listen")]
 pub use listen::{ContinuousListener, MicContinuousListener, NoContinuousListener};
 #[cfg(feature = "mic")]
 pub use mic::{MicVoiceInput, VoiceInputError, capture::validate as mic_validate};
+#[cfg(feature = "tts")]
+pub use piper::{PiperError, PiperVoiceOutput};
+pub use sentence::SentenceBuffer;
 #[cfg(feature = "whisper")]
 pub use transcribe::{
     BusyProbe, CpuFallbackFactory, NullBusyProbe, QueueConfig, QueuedTranscriber, Transcriber,

--- a/crates/assistd-voice/src/piper/cache.rs
+++ b/crates/assistd-voice/src/piper/cache.rs
@@ -1,0 +1,305 @@
+//! On-disk cache for Piper voices. Each voice is two files: a `.onnx`
+//! ONNX model and a matching `.onnx.json` config that carries the
+//! sample rate among other things. Both must sit side-by-side in the
+//! cache directory because piper looks for `<onnx>.json` next to the
+//! `--model` path.
+
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+use tokio::io::AsyncWriteExt;
+
+use crate::piper::error::PiperError;
+
+/// `<owner>/<repo>:<file>` parser. Identical contract to the whisper
+/// cache version — duplicated locally to keep error types crate-local.
+pub fn parse_hf_id(id: &str) -> Result<(String, String), PiperError> {
+    let err = |reason: &str| PiperError::VoiceParse {
+        id: id.to_string(),
+        reason: reason.to_string(),
+    };
+    let (repo, file) = id.split_once(':').ok_or_else(|| err("missing ':'"))?;
+    if file.is_empty() || file.contains(':') {
+        return Err(err("file must be non-empty and must not contain ':'"));
+    }
+    let (owner, name) = repo
+        .split_once('/')
+        .ok_or_else(|| err("repo must be 'owner/name'"))?;
+    if owner.is_empty() || name.is_empty() {
+        return Err(err("owner and repo name must both be non-empty"));
+    }
+    Ok((repo.to_string(), file.to_string()))
+}
+
+/// `$XDG_CACHE_HOME/assistd/piper/` or `$HOME/.cache/assistd/piper/`.
+pub fn default_cache_dir() -> PathBuf {
+    let base = std::env::var_os("XDG_CACHE_HOME")
+        .map(PathBuf::from)
+        .or_else(|| std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".cache")))
+        .unwrap_or_else(|| PathBuf::from("/tmp"));
+    base.join("assistd").join("piper")
+}
+
+/// Resolved on-disk paths for a voice. Sample rate is read from the
+/// `.onnx.json`'s `audio.sample_rate` field; everything else piper
+/// loads itself from the `.onnx`.
+#[derive(Debug, Clone)]
+pub struct VoiceFiles {
+    pub onnx: PathBuf,
+    pub json: PathBuf,
+    pub sample_rate: u32,
+}
+
+/// Ensure both the `.onnx` and `.onnx.json` for `hf_id` exist locally,
+/// downloading whichever is missing. Returns the resolved `VoiceFiles`.
+///
+/// Atomic writes: each download lands in `<file>.part` and is renamed
+/// only after the body is fully flushed, so a crash mid-download leaves
+/// no half-baked file masquerading as a complete one.
+pub async fn ensure_voice(hf_id: &str, cache_dir: &Path) -> Result<VoiceFiles, PiperError> {
+    let (repo, file) = parse_hf_id(hf_id)?;
+    let onnx = cached_path(cache_dir, &repo, &file);
+    let json = onnx.with_extension("onnx.json");
+
+    ensure_one(&repo, &file, &onnx).await?;
+    ensure_one(&repo, &format!("{file}.json"), &json).await?;
+
+    let sample_rate = read_sample_rate(&json).await?;
+    Ok(VoiceFiles {
+        onnx,
+        json,
+        sample_rate,
+    })
+}
+
+async fn ensure_one(repo: &str, file: &str, dest: &Path) -> Result<(), PiperError> {
+    if dest.exists() {
+        tracing::debug!(
+            target: "assistd::voice::piper::cache",
+            path = %dest.display(),
+            "voice file already cached"
+        );
+        return Ok(());
+    }
+
+    let parent = dest.parent().expect("cache path always has a parent");
+    tokio::fs::create_dir_all(parent)
+        .await
+        .map_err(|source| PiperError::Io {
+            path: parent.to_path_buf(),
+            source,
+        })?;
+
+    let url = format!("https://huggingface.co/{repo}/resolve/main/{file}");
+    tracing::info!(
+        target: "assistd::voice::piper::cache",
+        %url,
+        path = %dest.display(),
+        "downloading piper voice file"
+    );
+
+    let response = reqwest::get(&url)
+        .await
+        .map_err(|source| PiperError::Download {
+            url: url.clone(),
+            source,
+        })?;
+    let status = response.status();
+    if !status.is_success() {
+        return Err(PiperError::Http {
+            url,
+            status: status.as_u16(),
+        });
+    }
+    let total = response.content_length();
+
+    let part = dest.with_extension(format!(
+        "{}.part",
+        dest.extension().and_then(|e| e.to_str()).unwrap_or("bin")
+    ));
+    let mut out = tokio::fs::File::create(&part)
+        .await
+        .map_err(|source| PiperError::Io {
+            path: part.clone(),
+            source,
+        })?;
+
+    let mut stream = response.bytes_stream();
+    let mut downloaded: u64 = 0;
+    let mut next_tick: u64 = 0;
+    use futures_util::StreamExt;
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|source| PiperError::Download {
+            url: url.clone(),
+            source,
+        })?;
+        out.write_all(&chunk)
+            .await
+            .map_err(|source| PiperError::Io {
+                path: part.clone(),
+                source,
+            })?;
+        downloaded = downloaded.saturating_add(chunk.len() as u64);
+        if let Some(total) = total
+            && total > 0
+            && downloaded >= next_tick
+        {
+            let pct = downloaded * 100 / total;
+            tracing::info!(
+                target: "assistd::voice::piper::cache",
+                pct,
+                downloaded_kib = downloaded / 1024,
+                total_kib = total / 1024,
+                "voice download progress"
+            );
+            next_tick = downloaded + total / 20;
+        }
+    }
+    out.flush().await.map_err(|source| PiperError::Io {
+        path: part.clone(),
+        source,
+    })?;
+    drop(out);
+    tokio::fs::rename(&part, dest)
+        .await
+        .map_err(|source| PiperError::Io {
+            path: dest.to_path_buf(),
+            source,
+        })?;
+    tracing::info!(
+        target: "assistd::voice::piper::cache",
+        path = %dest.display(),
+        "download complete"
+    );
+    Ok(())
+}
+
+#[derive(Deserialize)]
+struct AudioConfig {
+    sample_rate: u32,
+}
+
+#[derive(Deserialize)]
+struct VoiceConfigJson {
+    audio: AudioConfig,
+}
+
+async fn read_sample_rate(json: &Path) -> Result<u32, PiperError> {
+    let body = tokio::fs::read_to_string(json)
+        .await
+        .map_err(|source| PiperError::Io {
+            path: json.to_path_buf(),
+            source,
+        })?;
+
+    // Defend against HuggingFace returning a 200-OK HTML "file not
+    // found" page in place of the JSON body.
+    let trimmed = body.trim_start();
+    if !trimmed.starts_with('{') {
+        let prefix: String = trimmed.chars().take(40).collect();
+        return Err(PiperError::JsonShape {
+            path: json.to_path_buf(),
+            prefix,
+        });
+    }
+
+    let cfg: VoiceConfigJson =
+        serde_json::from_str(&body).map_err(|source| PiperError::JsonParse {
+            path: json.to_path_buf(),
+            source,
+        })?;
+    Ok(cfg.audio.sample_rate)
+}
+
+fn sanitize_repo(repo: &str) -> String {
+    repo.replace('/', "__")
+}
+
+fn cached_path(cache_dir: &Path, repo: &str, file: &str) -> PathBuf {
+    cache_dir.join(sanitize_repo(repo)).join(file)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_valid_id() {
+        let (repo, file) =
+            parse_hf_id("rhasspy/piper-voices:en/en_US/lessac/medium/en_US-lessac-medium.onnx")
+                .unwrap();
+        assert_eq!(repo, "rhasspy/piper-voices");
+        assert_eq!(file, "en/en_US/lessac/medium/en_US-lessac-medium.onnx");
+    }
+
+    #[test]
+    fn rejects_missing_colon() {
+        assert!(parse_hf_id("rhasspy/piper-voices").is_err());
+    }
+
+    #[test]
+    fn rejects_missing_slash() {
+        assert!(parse_hf_id("piper:file.onnx").is_err());
+    }
+
+    #[test]
+    fn rejects_empty_file() {
+        assert!(parse_hf_id("owner/repo:").is_err());
+    }
+
+    #[test]
+    fn rejects_empty_owner() {
+        assert!(parse_hf_id("/repo:file.onnx").is_err());
+    }
+
+    #[test]
+    fn cached_path_sanitizes_slash() {
+        let p = cached_path(
+            Path::new("/cache"),
+            "rhasspy/piper-voices",
+            "en/en_US/lessac/medium/en_US-lessac-medium.onnx",
+        );
+        assert_eq!(
+            p,
+            Path::new(
+                "/cache/rhasspy__piper-voices/en/en_US/lessac/medium/en_US-lessac-medium.onnx"
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn read_sample_rate_parses_audio_section() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("voice.onnx.json");
+        tokio::fs::write(
+            &path,
+            r#"{"audio": {"sample_rate": 22050, "quality": "medium"}, "phoneme_id_map": {}}"#,
+        )
+        .await
+        .unwrap();
+        assert_eq!(read_sample_rate(&path).await.unwrap(), 22050);
+    }
+
+    #[tokio::test]
+    async fn read_sample_rate_rejects_html_body() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("voice.onnx.json");
+        tokio::fs::write(&path, "<!doctype html><html>not found</html>")
+            .await
+            .unwrap();
+        let err = read_sample_rate(&path).await.unwrap_err();
+        assert!(matches!(err, PiperError::JsonShape { .. }), "got {err:?}");
+    }
+
+    #[test]
+    fn default_cache_dir_under_xdg() {
+        unsafe {
+            std::env::set_var("XDG_CACHE_HOME", "/tmp/xdg-test-piper");
+        }
+        let p = default_cache_dir();
+        assert_eq!(p, Path::new("/tmp/xdg-test-piper/assistd/piper"));
+        unsafe {
+            std::env::remove_var("XDG_CACHE_HOME");
+        }
+    }
+}

--- a/crates/assistd-voice/src/piper/config.rs
+++ b/crates/assistd-voice/src/piper/config.rs
@@ -1,0 +1,22 @@
+use std::path::PathBuf;
+use std::time::Duration;
+
+use crate::piper::cache::VoiceFiles;
+
+/// Resolved, ready-to-spawn Piper configuration. Built once at startup
+/// from `assistd_config::SynthesisConfig` plus the on-disk voice files
+/// returned by [`crate::piper::cache::ensure_voice`]. Cloning is cheap
+/// (everything is `Arc`-shareable) so the supervising service holds an
+/// `Arc<PiperRuntimeConfig>` and each `OneShotSynth::synthesize` call
+/// reads from it without locking.
+#[derive(Debug, Clone)]
+pub struct PiperRuntimeConfig {
+    pub binary_path: String,
+    pub voice_files: VoiceFiles,
+    pub length_scale: f32,
+    pub noise_scale: f32,
+    pub noise_w: f32,
+    pub sentence_silence_secs: f32,
+    pub espeak_data_dir: Option<PathBuf>,
+    pub deadline: Duration,
+}

--- a/crates/assistd-voice/src/piper/error.rs
+++ b/crates/assistd-voice/src/piper/error.rs
@@ -1,0 +1,72 @@
+use std::path::PathBuf;
+use std::process::ExitStatus;
+
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum PiperError {
+    #[error(
+        "invalid voice identifier '{id}': {reason} \
+         (expected '<owner>/<repo>:<file>')"
+    )]
+    VoiceParse { id: String, reason: String },
+
+    #[error("voice download failed for {url}: {source}")]
+    Download {
+        url: String,
+        #[source]
+        source: reqwest::Error,
+    },
+
+    #[error("voice download for {url} returned HTTP {status}")]
+    Http { url: String, status: u16 },
+
+    #[error("voice file at {path} is not valid JSON: starts with {prefix:?}")]
+    JsonShape { path: PathBuf, prefix: String },
+
+    #[error("voice config at {path} did not parse: {source}")]
+    JsonParse {
+        path: PathBuf,
+        #[source]
+        source: serde_json::Error,
+    },
+
+    #[error("voice file I/O at {path}: {source}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("piper binary '{binary}' not found on PATH")]
+    BinaryMissing { binary: String },
+
+    #[error("failed to spawn piper at {binary}: {source}")]
+    Spawn {
+        binary: String,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("piper exited with {status} after producing {bytes} bytes; last stderr: {stderr_tail}")]
+    SynthFailed {
+        status: ExitStatus,
+        bytes: usize,
+        stderr_tail: String,
+    },
+
+    #[error("piper produced odd byte count {bytes}; not a valid 16-bit PCM stream")]
+    OddPcmLength { bytes: usize },
+
+    #[error("piper synthesis exceeded deadline of {secs}s")]
+    Deadline { secs: u64 },
+
+    #[error("rodio failed to open default audio output: {0}")]
+    Audio(String),
+
+    #[error("playback worker channel closed; rodio thread has exited")]
+    PlaybackClosed,
+
+    #[error("piper service is degraded: {0}")]
+    Degraded(String),
+}

--- a/crates/assistd-voice/src/piper/mod.rs
+++ b/crates/assistd-voice/src/piper/mod.rs
@@ -1,0 +1,20 @@
+//! Piper text-to-speech via managed per-utterance subprocess.
+//!
+//! Each `speak()` spawns a fresh `piper --output-raw` child, writes the
+//! sentence to stdin, drops stdin to signal EOF, drains raw 16-bit LE
+//! PCM from stdout, and queues it on the rodio playback worker. EOF on
+//! stdout is the unambiguous end-of-utterance marker — no in-band
+//! protocol or stderr-marker race. Crashes only fail the in-flight
+//! utterance; a circuit breaker disables further calls after repeated
+//! failures so a missing binary or bad audio device doesn't spam the
+//! logs forever.
+
+pub mod cache;
+pub mod config;
+pub mod error;
+pub mod playback;
+pub mod service;
+pub mod synth;
+
+pub use error::PiperError;
+pub use service::{PiperVoiceOutput, ReadyState};

--- a/crates/assistd-voice/src/piper/playback.rs
+++ b/crates/assistd-voice/src/piper/playback.rs
@@ -1,0 +1,150 @@
+//! Audio playback via rodio. The cpal device backing
+//! [`rodio::stream::MixerDeviceSink`] runs its callback on its own
+//! audio thread, but the device sink itself is `!Send` on ALSA — so
+//! we hold it on a dedicated `std::thread` (not `spawn_blocking`,
+//! whose pool may tear threads down after work completes). The
+//! `rodio::Player` wired to that mixer is `Send + Sync`, so the
+//! tokio-side caller appends `SamplesBuffer`s directly without
+//! crossing the channel for hot-path ops.
+
+use std::num::NonZero;
+use std::sync::Arc;
+use std::thread;
+
+use rodio::buffer::SamplesBuffer;
+use rodio::stream::DeviceSinkBuilder;
+use rodio::{ChannelCount, Player, SampleRate};
+use tokio::sync::oneshot;
+
+use crate::piper::error::PiperError;
+use crate::piper::synth::SynthOutput;
+
+/// Owns the rodio playback path for the daemon. Cheap to clone via
+/// `Arc<RodioPlaybackWorker>` — internal state is `Arc`-shared.
+pub struct RodioPlaybackWorker {
+    player: Arc<Player>,
+    /// Sender used in `Drop` to wake the device thread so it releases
+    /// the MixerDeviceSink. The thread joins on drop.
+    shutdown_tx: Option<std::sync::mpsc::Sender<()>>,
+    device_thread: Option<thread::JoinHandle<()>>,
+}
+
+impl RodioPlaybackWorker {
+    /// Open the default audio device and return a worker. Errors when
+    /// no device is available, the device rejects the requested format,
+    /// or the audio init thread panics before we get the Player.
+    pub fn start() -> Result<Self, PiperError> {
+        let (init_tx, init_rx) = std::sync::mpsc::channel::<Result<Player, String>>();
+        let (shutdown_tx, shutdown_rx) = std::sync::mpsc::channel::<()>();
+
+        let device_thread = thread::Builder::new()
+            .name("piper-rodio".into())
+            .spawn(move || {
+                // Hold the MixerDeviceSink on this thread for the
+                // worker's whole lifetime. Dropping it releases the
+                // audio device.
+                let mut device_sink = match DeviceSinkBuilder::open_default_sink() {
+                    Ok(d) => d,
+                    Err(e) => {
+                        let _ = init_tx.send(Err(format!("open default sink: {e}")));
+                        return;
+                    }
+                };
+                // Suppress the "MixerDeviceSink dropped" log line on
+                // shutdown — we drop it intentionally.
+                device_sink.log_on_drop(false);
+
+                let player = Player::connect_new(device_sink.mixer());
+                if init_tx.send(Ok(player)).is_err() {
+                    // Caller hung up before init completed.
+                    return;
+                }
+
+                // Park here until shutdown. The audio thread inside
+                // cpal keeps draining the player queue independently;
+                // we just need to keep `device_sink` alive.
+                let _ = shutdown_rx.recv();
+                drop(device_sink);
+            })
+            .map_err(|e| PiperError::Audio(format!("spawn audio thread: {e}")))?;
+
+        let player = init_rx
+            .recv()
+            .map_err(|_| PiperError::Audio("audio init thread died".into()))?
+            .map_err(PiperError::Audio)?;
+
+        Ok(Self {
+            player: Arc::new(player),
+            shutdown_tx: Some(shutdown_tx),
+            device_thread: Some(device_thread),
+        })
+    }
+
+    /// Queue an utterance for playback. Returns immediately; samples
+    /// are appended to rodio's internal queue and consumed by the
+    /// audio thread. To wait for the queue to drain, follow with
+    /// [`drain`](Self::drain).
+    pub fn play(&self, output: SynthOutput) -> Result<(), PiperError> {
+        let channels: ChannelCount = NonZero::new(1u16).expect("1 is non-zero");
+        let sample_rate: SampleRate = NonZero::new(output.sample_rate).ok_or_else(|| {
+            PiperError::Audio("voice config reports sample_rate=0; check the .onnx.json".into())
+        })?;
+        // rodio's Sample type is f32 (or f64 with the `64bit` feature
+        // off-by-default). i16 → f32 normalisation maps the full
+        // signed-16 range to [-1.0, 1.0).
+        let samples_f32: Vec<f32> = output
+            .samples
+            .iter()
+            .map(|&s| s as f32 / (i16::MAX as f32))
+            .collect();
+        let buffer = SamplesBuffer::new(channels, sample_rate, samples_f32);
+        self.player.append(buffer);
+        Ok(())
+    }
+
+    /// Block until the queue is empty (i.e. the most-recent appended
+    /// utterance has finished playing). Runs the rodio busy-wait on a
+    /// blocking thread so the tokio runtime isn't stalled.
+    pub async fn drain(&self) -> Result<(), PiperError> {
+        let player = self.player.clone();
+        let (tx, rx) = oneshot::channel();
+        std::thread::Builder::new()
+            .name("piper-rodio-drain".into())
+            .spawn(move || {
+                player.sleep_until_end();
+                let _ = tx.send(());
+            })
+            .map_err(|e| PiperError::Audio(format!("spawn drain thread: {e}")))?;
+        rx.await.map_err(|_| PiperError::PlaybackClosed)
+    }
+
+    /// Drop pending audio — used to interrupt mid-utterance. Not
+    /// wired into `speak()` for v1 but exposed so a future "shut up"
+    /// IPC command can land without re-architecting.
+    #[allow(dead_code)]
+    pub fn clear(&self) {
+        self.player.clear();
+    }
+
+    /// True when the queue has completely drained.
+    #[allow(dead_code)]
+    pub fn empty(&self) -> bool {
+        self.player.empty()
+    }
+}
+
+impl Drop for RodioPlaybackWorker {
+    fn drop(&mut self) {
+        // Tell the device thread to release MixerDeviceSink; then join
+        // so the audio device is fully released before this method
+        // returns. If the channel is already closed (e.g. thread
+        // panicked) the send fails silently and we still attempt to
+        // join.
+        if let Some(tx) = self.shutdown_tx.take() {
+            let _ = tx.send(());
+        }
+        if let Some(handle) = self.device_thread.take() {
+            let _ = handle.join();
+        }
+    }
+}

--- a/crates/assistd-voice/src/piper/service.rs
+++ b/crates/assistd-voice/src/piper/service.rs
@@ -1,0 +1,221 @@
+//! `PiperVoiceOutput` — the assembled façade implementing
+//! [`crate::VoiceOutput`]. Owns one [`OneShotSynth`] and one
+//! [`RodioPlaybackWorker`] for the daemon's lifetime; speak() runs the
+//! per-utterance subprocess and queues PCM on the playback worker.
+//!
+//! Circuit breaker: synthesis failures are timestamped in a small
+//! ringbuffer. After 3 failures within 60 seconds the service flips
+//! to [`ReadyState::Degraded`] and subsequent speak() calls become
+//! no-ops (logged once). This is the practical interpretation of
+//! "restarted on crash" for the per-utterance design — a missing
+//! binary or broken audio device shouldn't spam the logs forever.
+
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use anyhow::Result;
+use assistd_config::SynthesisConfig;
+use async_trait::async_trait;
+
+use crate::VoiceOutput;
+use crate::piper::cache::{default_cache_dir, ensure_voice};
+use crate::piper::config::PiperRuntimeConfig;
+use crate::piper::error::PiperError;
+use crate::piper::playback::RodioPlaybackWorker;
+use crate::piper::synth::OneShotSynth;
+
+/// Number of failures within `FAILURE_WINDOW` that flips the breaker.
+const FAILURE_THRESHOLD: usize = 3;
+/// Sliding window for circuit-breaker accounting.
+const FAILURE_WINDOW: Duration = Duration::from_secs(60);
+
+#[derive(Debug, Clone)]
+pub enum ReadyState {
+    Ready,
+    Degraded { reason: String },
+}
+
+struct CircuitState {
+    ready: ReadyState,
+    recent_failures: VecDeque<Instant>,
+    /// True after we've logged the "degraded" line once, so we don't
+    /// spam the journal on every subsequent speak().
+    logged_degraded: bool,
+}
+
+pub struct PiperVoiceOutput {
+    synth: Arc<OneShotSynth>,
+    playback: Arc<RodioPlaybackWorker>,
+    state: Arc<Mutex<CircuitState>>,
+}
+
+impl PiperVoiceOutput {
+    /// Resolve the voice cache, build the runtime config, open the
+    /// audio device, and run a tiny health-check synthesis. Any
+    /// failure here is reported as `PiperError`; the daemon's startup
+    /// logic then logs a warning and substitutes `NoVoiceOutput`.
+    pub async fn start(cfg: SynthesisConfig) -> Result<Self, PiperError> {
+        // Fail-fast on a missing binary so the error is "binary not
+        // found" rather than the more confusing "spawn: file not
+        // found" surfaced after voice download.
+        which::which(&cfg.binary_path).map_err(|_| PiperError::BinaryMissing {
+            binary: cfg.binary_path.clone(),
+        })?;
+
+        let cache_dir = cfg
+            .model_cache_dir
+            .clone()
+            .unwrap_or_else(default_cache_dir);
+        let voice_files = ensure_voice(&cfg.voice, &cache_dir).await?;
+        tracing::info!(
+            target: "assistd::voice::piper",
+            onnx = %voice_files.onnx.display(),
+            sample_rate = voice_files.sample_rate,
+            "piper voice resolved"
+        );
+
+        let runtime = Arc::new(PiperRuntimeConfig {
+            binary_path: cfg.binary_path.clone(),
+            voice_files,
+            length_scale: cfg.length_scale,
+            noise_scale: cfg.noise_scale,
+            noise_w: cfg.noise_w,
+            sentence_silence_secs: cfg.sentence_silence_secs,
+            espeak_data_dir: cfg.espeak_data_dir.clone(),
+            deadline: Duration::from_secs(cfg.deadline_secs as u64),
+        });
+
+        let synth = Arc::new(OneShotSynth::new(runtime.clone()));
+        let playback = Arc::new(RodioPlaybackWorker::start()?);
+
+        // Health-check: a tiny synth surfaces missing-model and
+        // device-format errors at startup rather than on the first
+        // user-facing utterance.
+        synth.health_check().await?;
+        tracing::info!(
+            target: "assistd::voice::piper",
+            "piper health-check passed"
+        );
+
+        Ok(Self {
+            synth,
+            playback,
+            state: Arc::new(Mutex::new(CircuitState {
+                ready: ReadyState::Ready,
+                recent_failures: VecDeque::with_capacity(FAILURE_THRESHOLD),
+                logged_degraded: false,
+            })),
+        })
+    }
+
+    pub fn ready_state(&self) -> ReadyState {
+        self.state
+            .lock()
+            .expect("piper state mutex poisoned")
+            .ready
+            .clone()
+    }
+
+    fn record_success(&self) {
+        let mut s = self.state.lock().expect("piper state mutex poisoned");
+        s.recent_failures.clear();
+        // Re-arming after a transient flap is intentional: a transient
+        // stutter shouldn't permanently disable speech.
+        if matches!(s.ready, ReadyState::Degraded { .. }) {
+            tracing::info!(target: "assistd::voice::piper", "piper recovered from degraded");
+            s.ready = ReadyState::Ready;
+            s.logged_degraded = false;
+        }
+    }
+
+    fn record_failure(&self, err: &PiperError) {
+        let mut s = self.state.lock().expect("piper state mutex poisoned");
+        let now = Instant::now();
+        // Drop entries older than the window.
+        while let Some(&front) = s.recent_failures.front() {
+            if now.duration_since(front) > FAILURE_WINDOW {
+                s.recent_failures.pop_front();
+            } else {
+                break;
+            }
+        }
+        s.recent_failures.push_back(now);
+        if s.recent_failures.len() >= FAILURE_THRESHOLD && matches!(s.ready, ReadyState::Ready) {
+            let reason = err.to_string();
+            tracing::warn!(
+                target: "assistd::voice::piper",
+                %reason,
+                threshold = FAILURE_THRESHOLD,
+                window_secs = FAILURE_WINDOW.as_secs(),
+                "piper synthesis repeatedly failed; entering degraded state"
+            );
+            s.ready = ReadyState::Degraded { reason };
+            s.logged_degraded = true;
+        }
+    }
+}
+
+#[async_trait]
+impl VoiceOutput for PiperVoiceOutput {
+    async fn speak(&self, text: String) -> Result<()> {
+        // Short-circuit when degraded — log once, then silent until a
+        // future health check (manual restart for now) clears it.
+        {
+            let s = self.state.lock().expect("piper state mutex poisoned");
+            if let ReadyState::Degraded { ref reason } = s.ready {
+                if !s.logged_degraded {
+                    tracing::warn!(
+                        target: "assistd::voice::piper",
+                        %reason,
+                        "piper degraded; dropping speak() request"
+                    );
+                }
+                return Ok(());
+            }
+        }
+
+        if text.trim().is_empty() {
+            return Ok(());
+        }
+
+        let output = match self.synth.synthesize(&text).await {
+            Ok(o) => o,
+            Err(e) => {
+                tracing::warn!(
+                    target: "assistd::voice::piper",
+                    error = %e,
+                    "piper synthesis failed"
+                );
+                self.record_failure(&e);
+                return Ok(());
+            }
+        };
+
+        if let Err(e) = self.playback.play(output) {
+            tracing::warn!(
+                target: "assistd::voice::piper",
+                error = %e,
+                "piper playback enqueue failed"
+            );
+            self.record_failure(&e);
+            return Ok(());
+        }
+
+        // Honor the trait contract: speak() returns when playback
+        // finishes. Without this, multiple concurrent speak() calls
+        // would interleave audio.
+        if let Err(e) = self.playback.drain().await {
+            tracing::warn!(
+                target: "assistd::voice::piper",
+                error = %e,
+                "piper playback drain failed"
+            );
+            self.record_failure(&e);
+            return Ok(());
+        }
+
+        self.record_success();
+        Ok(())
+    }
+}

--- a/crates/assistd-voice/src/piper/synth.rs
+++ b/crates/assistd-voice/src/piper/synth.rs
@@ -1,0 +1,210 @@
+//! Per-utterance Piper subprocess. One `synthesize()` call =
+//! one `Command::spawn` of `piper --output-raw ...` with the text
+//! written to stdin and EOF signaled by closing the pipe. EOF on
+//! stdout marks the end of audio; the child exits naturally afterward.
+//!
+//! Why per-utterance: piper writes raw PCM continuously to stdout
+//! with no in-band frame delimiter. Long-running mode would have to
+//! detect utterance boundaries via stderr-log markers, which is
+//! version-fragile and races against the kernel pipe between FDs.
+//! Per-utterance trades 50–250 ms of CPU model-load latency for a
+//! deterministic protocol — that latency overlaps with LLM generation
+//! of the next sentence, so users don't see it.
+
+use std::collections::VecDeque;
+use std::process::Stdio;
+use std::sync::{Arc, Mutex};
+
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{ChildStderr, ChildStdout, Command};
+
+use crate::piper::config::PiperRuntimeConfig;
+use crate::piper::error::PiperError;
+
+/// Result of one `synthesize` call: 16-bit signed little-endian PCM
+/// samples plus the sample rate (read from the voice's `.onnx.json`).
+#[derive(Debug, Clone)]
+pub struct SynthOutput {
+    pub samples: Vec<i16>,
+    pub sample_rate: u32,
+}
+
+/// Stateless synthesizer. The runtime config is shared via `Arc`; each
+/// `synthesize` call reads from it without mutation.
+pub struct OneShotSynth {
+    cfg: Arc<PiperRuntimeConfig>,
+}
+
+impl OneShotSynth {
+    pub fn new(cfg: Arc<PiperRuntimeConfig>) -> Self {
+        Self { cfg }
+    }
+
+    /// Spawn piper, write `text + \n`, close stdin, drain stdout to
+    /// EOF, return PCM. Stderr is read concurrently to prevent the
+    /// kernel pipe from filling and blocking piper mid-synthesis.
+    /// On non-zero exit, the last 20 stderr lines are included in the
+    /// error so callers can see piper's complaint.
+    pub async fn synthesize(&self, text: &str) -> Result<SynthOutput, PiperError> {
+        let cfg = &*self.cfg;
+        let mut cmd = Command::new(&cfg.binary_path);
+        cmd.arg("--model")
+            .arg(&cfg.voice_files.onnx)
+            .arg("--output-raw")
+            .arg("--length-scale")
+            .arg(format!("{}", cfg.length_scale))
+            .arg("--noise-scale")
+            .arg(format!("{}", cfg.noise_scale))
+            .arg("--noise-w")
+            .arg(format!("{}", cfg.noise_w))
+            .arg("--sentence-silence")
+            .arg(format!("{}", cfg.sentence_silence_secs));
+        if let Some(ref dir) = cfg.espeak_data_dir {
+            cmd.arg("--espeak-data").arg(dir);
+        }
+
+        cmd.stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true);
+
+        #[cfg(unix)]
+        cmd.process_group(0);
+
+        let mut child = cmd.spawn().map_err(|source| PiperError::Spawn {
+            binary: cfg.binary_path.clone(),
+            source,
+        })?;
+
+        let mut stdin = child.stdin.take().expect("stdin piped");
+        let stdout = child.stdout.take().expect("stdout piped");
+        let stderr = child.stderr.take().expect("stderr piped");
+
+        let stderr_tail = Arc::new(Mutex::new(VecDeque::<String>::with_capacity(20)));
+        let stderr_tail_for_drain = stderr_tail.clone();
+
+        // Concurrent helpers: `read_to_end` on stdout, line-buffered
+        // tail on stderr. Reading only stdout would let stderr fill the
+        // kernel pipe and stall piper mid-synthesis.
+        //
+        // Everything (child + stdout + stderr) is `move`d into the
+        // inner future. On timeout the future is dropped, which drops
+        // `child` — and `kill_on_drop(true)` ensures the OS process
+        // dies. The drain tasks live for the duration of the future
+        // via `tokio::join!`, so they're cancelled together.
+        let deadline = cfg.deadline;
+        let binary = cfg.binary_path.clone();
+        let text_owned = text.replace('\n', " ");
+        let synth_fut = async move {
+            let write_res = stdin.write_all(format!("{text_owned}\n").as_bytes()).await;
+            drop(stdin); // signal EOF unconditionally
+            if let Err(e) = write_res {
+                let _ = child.start_kill();
+                let _ = child.wait().await;
+                return Err::<(std::process::ExitStatus, Vec<u8>), PiperError>(PiperError::Io {
+                    path: std::path::PathBuf::from("<piper stdin>"),
+                    source: e,
+                });
+            }
+
+            let stdout_drain = drain_stdout(stdout);
+            let stderr_drain = drain_stderr(stderr, stderr_tail_for_drain);
+            let wait_fut = async {
+                child.wait().await.map_err(|source| PiperError::Io {
+                    path: std::path::PathBuf::from("<piper child>"),
+                    source,
+                })
+            };
+
+            let (status_res, pcm_res, _) = tokio::join!(wait_fut, stdout_drain, stderr_drain);
+            let status = status_res?;
+            let pcm = pcm_res?;
+            Ok((status, pcm))
+        };
+
+        let (status, pcm) = match tokio::time::timeout(deadline, synth_fut).await {
+            Ok(Ok(pair)) => pair,
+            Ok(Err(e)) => return Err(e),
+            Err(_) => {
+                // Future dropped → child dropped → kill_on_drop fires.
+                tracing::warn!(
+                    target: "assistd::voice::piper",
+                    deadline_secs = deadline.as_secs(),
+                    binary = %binary,
+                    "piper synthesis exceeded deadline"
+                );
+                return Err(PiperError::Deadline {
+                    secs: deadline.as_secs(),
+                });
+            }
+        };
+
+        if !status.success() {
+            let tail_joined = stderr_tail
+                .lock()
+                .expect("stderr tail mutex poisoned")
+                .iter()
+                .cloned()
+                .collect::<Vec<_>>()
+                .join(" | ");
+            return Err(PiperError::SynthFailed {
+                status,
+                bytes: pcm.len(),
+                stderr_tail: tail_joined,
+            });
+        }
+
+        if pcm.len() % 2 != 0 {
+            return Err(PiperError::OddPcmLength { bytes: pcm.len() });
+        }
+
+        let samples: Vec<i16> = pcm
+            .chunks_exact(2)
+            .map(|c| i16::from_le_bytes([c[0], c[1]]))
+            .collect();
+
+        Ok(SynthOutput {
+            samples,
+            sample_rate: cfg.voice_files.sample_rate,
+        })
+    }
+
+    /// Tiny synthesis used by `PiperVoiceOutput::start()` to fail fast
+    /// at daemon startup if the binary is missing, the model file is
+    /// corrupt, or piper exits non-zero for any reason.
+    pub async fn health_check(&self) -> Result<(), PiperError> {
+        let out = self.synthesize("ok").await?;
+        if out.samples.is_empty() {
+            return Err(PiperError::SynthFailed {
+                status: std::process::ExitStatus::default(),
+                bytes: 0,
+                stderr_tail: "health check produced 0 samples".into(),
+            });
+        }
+        Ok(())
+    }
+}
+
+async fn drain_stdout(mut stdout: ChildStdout) -> Result<Vec<u8>, PiperError> {
+    let mut buf = Vec::with_capacity(64 * 1024);
+    stdout
+        .read_to_end(&mut buf)
+        .await
+        .map_err(|source| PiperError::Io {
+            path: std::path::PathBuf::from("<piper stdout>"),
+            source,
+        })?;
+    Ok(buf)
+}
+
+async fn drain_stderr(stderr: ChildStderr, tail: Arc<Mutex<VecDeque<String>>>) {
+    let mut lines = BufReader::new(stderr).lines();
+    while let Ok(Some(line)) = lines.next_line().await {
+        tracing::debug!(target: "assistd::voice::piper", "{line}");
+        let mut guard = tail.lock().expect("stderr tail mutex poisoned");
+        if guard.len() == 20 {
+            guard.pop_front();
+        }
+        guard.push_back(line);
+    }
+}

--- a/crates/assistd-voice/src/sentence.rs
+++ b/crates/assistd-voice/src/sentence.rs
@@ -548,12 +548,24 @@ mod tests {
     #[test]
     fn length_cap_flushes_at_whitespace() {
         let mut b = SentenceBuffer::new(50);
-        // 60 chars no terminator
-        let _ = b.push("aaaaaaaaa bbbbbbbbb ccccccccc ddddddddd eeeeeeeee fffffffff");
-        let tail = b.finish();
-        // Something must have flushed before the cap.
-        // The buffer can't hold all 60 chars without a flush.
-        assert!(tail.is_some() || true);
+        // 59 chars, no terminator: at 50 chars the safety net fires
+        // and flushes at the last whitespace before the cap.
+        let s = b.push("aaaaaaaaa bbbbbbbbb ccccccccc ddddddddd eeeeeeeee fffffffff");
+        assert!(
+            !s.is_empty(),
+            "length cap should have produced at least one flush"
+        );
+        // First flushed sentence must end at a whitespace boundary,
+        // not mid-word.
+        assert!(
+            !s[0].ends_with(['a', 'b', 'c']),
+            "should not split mid-word: {:?}",
+            s[0]
+        );
+        // Whatever's left lands in finish().
+        let tail = b.finish().unwrap_or_default();
+        let total: usize = s.iter().map(|x| x.len()).sum::<usize>() + tail.len();
+        assert!(total > 0, "should have spoken something total");
     }
 
     #[test]

--- a/crates/assistd-voice/src/sentence.rs
+++ b/crates/assistd-voice/src/sentence.rs
@@ -1,0 +1,638 @@
+//! Streaming sentence segmenter that sits between the LLM token stream
+//! and Piper. Strips markdown, drops fenced code blocks entirely, and
+//! flushes whole sentences to TTS so utterances align with natural
+//! prosody boundaries instead of arbitrary token boundaries.
+//!
+//! Boundary priority (highest first):
+//!   1. Paragraph break `\n\n`
+//!   2. Strong terminator `[.!?]` followed by whitespace + uppercase /
+//!      digit / EOF, with abbreviation guard (Mr./Dr./e.g./...) and
+//!      decimal-number guard (3.14)
+//!   3. Bullet list marker `\n- ` or `\n* `
+//!   4. Length safety net at `max_len` chars (last whitespace before)
+
+use std::collections::VecDeque;
+
+const ABBREVIATIONS: &[&str] = &[
+    "Mr", "Mrs", "Ms", "Dr", "St", "Sr", "Jr", "Inc", "Ltd", "Co", "etc", "vs", "e.g", "i.e",
+    "U.S", "U.K", "approx", "Prof", "Gen", "Capt",
+];
+
+pub struct SentenceBuffer {
+    /// Accumulated, already-stripped text awaiting a flush.
+    buf: String,
+    /// True when we're currently inside a triple-backtick fence —
+    /// raw deltas while in this state are dropped from `buf` entirely.
+    in_code_fence: bool,
+    /// Pending raw delta characters that haven't yet been classified
+    /// (e.g. we've seen one or two backticks but not the third). Kept
+    /// small — only enough lookahead to spot a fence opener / closer.
+    pending: String,
+    max_len: usize,
+}
+
+impl SentenceBuffer {
+    pub fn new(max_len: usize) -> Self {
+        Self {
+            buf: String::new(),
+            in_code_fence: false,
+            pending: String::new(),
+            max_len: max_len.max(50),
+        }
+    }
+
+    /// Append a delta and return any sentences that finished as a result.
+    pub fn push(&mut self, delta: &str) -> Vec<String> {
+        let mut out = Vec::new();
+        for ch in delta.chars() {
+            self.feed_char(ch, &mut out);
+        }
+        // After feeding, look for boundaries inside `buf` (pending stays
+        // in `pending`; only finalized text reaches `buf`).
+        self.scan_boundaries(&mut out);
+        out
+    }
+
+    /// Flush any remaining text on `LlmEvent::Done`. Returns at most
+    /// one final sentence — the leftover tail. Drops a dangling
+    /// unterminated code fence silently. The tail goes through the
+    /// same postprocess pipeline as sentences emitted from `push`,
+    /// so markdown / URLs / emphasis are stripped consistently.
+    pub fn finish(&mut self) -> Option<String> {
+        if !self.in_code_fence && !self.pending.is_empty() {
+            let p = std::mem::take(&mut self.pending);
+            self.buf.push_str(&strip_inline(&p));
+        }
+        self.in_code_fence = false;
+        self.pending.clear();
+        let raw = std::mem::take(&mut self.buf);
+        let speech = postprocess_for_speech(&raw);
+        if speech.is_empty() {
+            None
+        } else {
+            Some(speech)
+        }
+    }
+
+    fn feed_char(&mut self, ch: char, out: &mut Vec<String>) {
+        // Manage triple-backtick fences first since they suppress all
+        // sentence flushes for their contents.
+        if ch == '`' {
+            self.pending.push('`');
+            if self.pending.ends_with("```") {
+                self.in_code_fence = !self.in_code_fence;
+                self.pending.truncate(self.pending.len() - 3);
+                if !self.in_code_fence {
+                    // Closing fence: the pending pre-fence prefix is
+                    // discarded along with the fenced content.
+                    self.pending.clear();
+                }
+            }
+            return;
+        }
+
+        if self.in_code_fence {
+            // Drop fenced content.
+            self.pending.clear();
+            return;
+        }
+
+        // Stray backticks (1 or 2) without a third → flush as content.
+        if !self.pending.is_empty() {
+            let pending = std::mem::take(&mut self.pending);
+            self.buf.push_str(&strip_inline(&pending));
+        }
+
+        // Drop heading `#` and blockquote `>` only when at the start
+        // of a logical line.
+        let at_line_start = self.buf.is_empty() || self.buf.ends_with('\n');
+        if (ch == '#' || ch == '>') && at_line_start {
+            return;
+        }
+        self.buf.push(ch);
+        // Scan opportunistically as content arrives. Cheap because we
+        // only inspect the suffix.
+        self.scan_boundaries(out);
+    }
+
+    fn scan_boundaries(&mut self, out: &mut Vec<String>) {
+        while let Some(idx) = find_boundary(&self.buf, self.max_len) {
+            let raw = self.buf[..idx].to_string();
+            let rest = self.buf[idx..].trim_start().to_string();
+            self.buf = rest;
+            let sentence = postprocess_for_speech(&raw);
+            if !sentence.is_empty() {
+                out.push(sentence);
+            }
+            if self.buf.is_empty() {
+                break;
+            }
+        }
+    }
+}
+
+/// Returns the byte offset of the first boundary in `buf`, or `None`.
+fn find_boundary(buf: &str, max_len: usize) -> Option<usize> {
+    let bytes = buf.as_bytes();
+
+    // 1. Paragraph break.
+    if let Some(i) = buf.find("\n\n") {
+        return Some(i + 2);
+    }
+
+    // 2. Bullet markers (treat as paragraph-equivalent boundary). We
+    //    flush *up to* the marker, leaving the marker as the start of
+    //    the next sentence — but we want to drop the marker from
+    //    speech, so include the leading "\n" + 1 marker char + space.
+    if let Some(i) = find_bullet_marker(buf) {
+        return Some(i);
+    }
+
+    // 3. Strong terminator with abbreviation + decimal guards.
+    //
+    // EOF is NOT treated as a terminator: a period at the end of the
+    // buffer is ambiguous (could be an abbreviation that hasn't
+    // received its next-word context yet). The buffered text is
+    // flushed by `finish()` instead.
+    let mut i = 0;
+    while i < bytes.len() {
+        let c = bytes[i];
+        if c == b'.' || c == b'!' || c == b'?' {
+            let next = match bytes.get(i + 1).copied() {
+                Some(b) => b,
+                None => {
+                    // No follow-up byte yet; defer.
+                    i += 1;
+                    continue;
+                }
+            };
+            if !next.is_ascii_whitespace() {
+                // Decimal `3.14`, version `1.2.3`, file `foo.txt`.
+                i += 1;
+                continue;
+            }
+            // Decimal guard: digit . digit (only `.`)
+            let prev = if i > 0 {
+                bytes.get(i - 1).copied()
+            } else {
+                None
+            };
+            if c == b'.'
+                && matches!(prev, Some(b) if b.is_ascii_digit())
+                && bytes.get(i + 2).is_some_and(|b| b.is_ascii_digit())
+            {
+                i += 1;
+                continue;
+            }
+            // Abbreviation guard.
+            if c == b'.' && is_abbreviation_at(buf, i) {
+                i += 1;
+                continue;
+            }
+            // Skip past the terminator + trailing whitespace.
+            let mut j = i + 1;
+            while j < bytes.len() && bytes[j].is_ascii_whitespace() {
+                j += 1;
+            }
+            if j == bytes.len() {
+                // No follow-up content yet; defer until next push.
+                i += 1;
+                continue;
+            }
+            let succ = bytes[j];
+            if succ.is_ascii_uppercase() || succ.is_ascii_digit() {
+                return Some(j);
+            }
+            // Newline immediately after counts as a paragraph-style
+            // break even without an uppercase successor.
+            if next == b'\n' {
+                return Some(j);
+            }
+        }
+        i += 1;
+    }
+
+    // 4. Length safety net.
+    if buf.len() >= max_len {
+        if let Some(ws) = buf[..max_len].rfind(char::is_whitespace) {
+            // Ensure ws is on a char boundary.
+            let mut idx = ws + 1;
+            while !buf.is_char_boundary(idx) && idx < buf.len() {
+                idx += 1;
+            }
+            return Some(idx);
+        }
+        // Fallback: hard cut at max_len, advanced to next char boundary.
+        let mut idx = max_len.min(buf.len());
+        while !buf.is_char_boundary(idx) && idx < buf.len() {
+            idx += 1;
+        }
+        return Some(idx);
+    }
+
+    None
+}
+
+fn find_bullet_marker(buf: &str) -> Option<usize> {
+    // Search for "\n- " or "\n* " anywhere after the first character —
+    // skipping a buffer that *starts* with a marker since that's a
+    // partial fragment, not a boundary.
+    let bytes = buf.as_bytes();
+    let mut i = 1;
+    while i + 2 < bytes.len() {
+        if bytes[i] == b'\n'
+            && (bytes[i + 1] == b'-' || bytes[i + 1] == b'*')
+            && bytes[i + 2] == b' '
+        {
+            return Some(i + 1);
+        }
+        i += 1;
+    }
+    None
+}
+
+/// True when the period at `bytes[i]` ends a known abbreviation token.
+fn is_abbreviation_at(buf: &str, i: usize) -> bool {
+    // Back up to the start of the token (whitespace or start-of-buf).
+    let bytes = buf.as_bytes();
+    let mut start = i;
+    while start > 0 {
+        let prev = bytes[start - 1];
+        if prev.is_ascii_whitespace() {
+            break;
+        }
+        start -= 1;
+    }
+    // Token includes the period at position `i`.
+    let token = &buf[start..=i];
+    // Strip trailing period for comparison.
+    let stem = &token[..token.len() - 1];
+    ABBREVIATIONS
+        .iter()
+        .any(|abbr| stem.eq_ignore_ascii_case(abbr) || stem.ends_with(&format!(".{abbr}")))
+}
+
+/// Strip markdown decorations from a chunk that's about to be spoken.
+/// Inline transformations only — no boundary detection.
+fn postprocess_for_speech(s: &str) -> String {
+    // 1. Markdown link `[text](url)` → `text`.
+    let s = strip_links(s);
+    // 2. Strip emphasis markers (`**`, `__`, `*`, `_`) without
+    //    consuming the wrapped content.
+    let s = strip_emphasis(&s);
+    // 3. Replace bare URLs with the literal word "link".
+    let s = replace_urls(&s);
+    // 4. Inline code `` ` ``-wrapped: strip backticks, keep contents.
+    let s = strip_inline(&s);
+    // 5. Collapse runs of whitespace.
+    collapse_whitespace(&s)
+}
+
+fn strip_inline(s: &str) -> String {
+    // Single backticks → drop the backticks but keep contents.
+    s.replace('`', "")
+}
+
+fn strip_links(s: &str) -> String {
+    // Manual scan to avoid regex dep; small O(n) state machine.
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '[' {
+            // Try to match `[text](url)`. If we don't find the closing
+            // ](url), emit the literal.
+            let mut text = String::new();
+            let mut found_close_bracket = false;
+            for inner in chars.by_ref() {
+                if inner == ']' {
+                    found_close_bracket = true;
+                    break;
+                }
+                text.push(inner);
+            }
+            if found_close_bracket && chars.peek() == Some(&'(') {
+                chars.next(); // consume '('
+                let mut consumed_paren = false;
+                for url_c in chars.by_ref() {
+                    if url_c == ')' {
+                        consumed_paren = true;
+                        break;
+                    }
+                }
+                if consumed_paren {
+                    out.push_str(&text);
+                    continue;
+                } else {
+                    // Malformed — emit literally.
+                    out.push('[');
+                    out.push_str(&text);
+                    out.push_str("](");
+                    continue;
+                }
+            }
+            out.push('[');
+            out.push_str(&text);
+            if found_close_bracket {
+                out.push(']');
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
+fn strip_emphasis(s: &str) -> String {
+    // Drop runs of `*` and `_` of length 1-3 (so **bold**, *em*, ***both***
+    // collapse). Leave content alone.
+    let mut out = String::with_capacity(s.len());
+    let mut buf = VecDeque::<char>::new();
+    for c in s.chars() {
+        if c == '*' || c == '_' {
+            buf.push_back(c);
+            if buf.len() >= 3 {
+                buf.clear(); // 3+ in a row: drop
+            }
+        } else {
+            // Decide whether to drop the buffered run or emit it.
+            if !buf.is_empty() {
+                // 1, 2, or 3 markers → drop.
+                buf.clear();
+            }
+            out.push(c);
+        }
+    }
+    // Trailing markers — drop.
+    out
+}
+
+fn replace_urls(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut i = 0;
+    let bytes = s.as_bytes();
+    while i < bytes.len() {
+        let rest = &s[i..];
+        let scheme = if rest.starts_with("https://") {
+            Some(8)
+        } else if rest.starts_with("http://") {
+            Some(7)
+        } else {
+            None
+        };
+        if let Some(skip) = scheme {
+            // Word-boundary check: must be at start or preceded by ws/punct.
+            let prev_ok = i == 0 || !bytes[i - 1].is_ascii_alphanumeric();
+            if prev_ok {
+                // Consume until whitespace or end.
+                let mut j = i + skip;
+                while j < bytes.len() && !bytes[j].is_ascii_whitespace() {
+                    j += 1;
+                }
+                out.push_str("link");
+                i = j;
+                continue;
+            }
+        }
+        out.push(s.as_bytes()[i] as char);
+        i += 1;
+    }
+    out
+}
+
+fn collapse_whitespace(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut prev_ws = false;
+    for c in s.chars() {
+        if c.is_whitespace() {
+            if !prev_ws {
+                out.push(' ');
+            }
+            prev_ws = true;
+        } else {
+            out.push(c);
+            prev_ws = false;
+        }
+    }
+    out.trim().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn push_all(buf: &mut SentenceBuffer, deltas: &[&str]) -> Vec<String> {
+        let mut out = Vec::new();
+        for d in deltas {
+            out.extend(buf.push(d));
+        }
+        out
+    }
+
+    #[test]
+    fn flushes_on_period_then_capital() {
+        let mut b = SentenceBuffer::new(400);
+        let s = b.push("Hello world. Then more.");
+        assert_eq!(s, vec!["Hello world."]);
+        let tail = b.finish();
+        assert_eq!(tail.as_deref(), Some("Then more."));
+    }
+
+    #[test]
+    fn streamed_chunks_assemble_to_sentences() {
+        let mut b = SentenceBuffer::new(400);
+        let out = push_all(&mut b, &["Hel", "lo wo", "rld. ", "Then ", "more."]);
+        assert_eq!(out, vec!["Hello world."]);
+        assert_eq!(b.finish().as_deref(), Some("Then more."));
+    }
+
+    #[test]
+    fn does_not_split_on_abbreviation() {
+        let mut b = SentenceBuffer::new(400);
+        let s = b.push("Dr. Smith arrived. Then he left.");
+        assert_eq!(s, vec!["Dr. Smith arrived."]);
+        assert_eq!(b.finish().as_deref(), Some("Then he left."));
+    }
+
+    #[test]
+    fn does_not_split_on_eg() {
+        let mut b = SentenceBuffer::new(400);
+        let s = b.push("Use a tool, e.g. grep. It works.");
+        assert_eq!(s, vec!["Use a tool, e.g. grep."]);
+        assert_eq!(b.finish().as_deref(), Some("It works."));
+    }
+
+    #[test]
+    fn does_not_split_on_decimal() {
+        let mut b = SentenceBuffer::new(400);
+        let s = b.push("Pi is about 3.14159 here. End.");
+        assert_eq!(s, vec!["Pi is about 3.14159 here."]);
+        assert_eq!(b.finish().as_deref(), Some("End."));
+    }
+
+    #[test]
+    fn flushes_on_paragraph_break() {
+        let mut b = SentenceBuffer::new(400);
+        let s = b.push("First paragraph\n\nSecond starts");
+        assert_eq!(s, vec!["First paragraph"]);
+        assert_eq!(b.finish().as_deref(), Some("Second starts"));
+    }
+
+    #[test]
+    fn drops_fenced_code_block() {
+        let mut b = SentenceBuffer::new(400);
+        let s = push_all(
+            &mut b,
+            &[
+                "Here is code: ",
+                "```rust\nfn main() { println!(\"hi\"); }\n```",
+                " That was a snippet.",
+            ],
+        );
+        // The code is dropped; the prelude + tail should speak.
+        // Depending on how the boundaries land, we expect at least one
+        // sentence emitted.
+        let joined = s.join(" | ");
+        assert!(
+            !joined.contains("println"),
+            "code leaked into TTS: {joined:?}"
+        );
+        let tail = b.finish().unwrap_or_default();
+        assert!(!tail.contains("println"), "code leaked into tail: {tail:?}");
+    }
+
+    #[test]
+    fn strips_markdown_link_to_text() {
+        let mut b = SentenceBuffer::new(400);
+        let s = b.push("See [the docs](https://example.com/docs) please.");
+        let tail = b.finish().unwrap_or_default();
+        let joined = s.join(" ") + " " + &tail;
+        assert!(joined.contains("the docs"));
+        assert!(!joined.contains("example.com"));
+        assert!(!joined.contains('['));
+    }
+
+    #[test]
+    fn replaces_bare_url_with_link() {
+        let mut b = SentenceBuffer::new(400);
+        let _ = b.push("Visit https://example.com for more. Bye.");
+        let s = b.push("");
+        assert!(s.is_empty() || s.iter().any(|t| t.contains("link")));
+        let tail = b.finish().unwrap_or_default();
+        let joined = format!("{} {}", s.join(" "), tail);
+        assert!(!joined.contains("example.com"), "got {joined:?}");
+    }
+
+    #[test]
+    fn strips_emphasis_markers() {
+        let mut b = SentenceBuffer::new(400);
+        let _ = b.push("This is *important* and **very urgent**.");
+        let tail = b.finish().unwrap_or_default();
+        assert!(!tail.contains('*'));
+        assert!(tail.contains("important"));
+        assert!(tail.contains("very urgent"));
+    }
+
+    #[test]
+    fn strips_heading_markers_at_line_start() {
+        let mut b = SentenceBuffer::new(400);
+        let mut all = b.push("# A Heading\n\nContent here.");
+        if let Some(t) = b.finish() {
+            all.push(t);
+        }
+        let joined = all.join(" ");
+        assert!(!joined.contains('#'), "got {joined:?}");
+        assert!(joined.contains("A Heading"), "got {joined:?}");
+        assert!(joined.contains("Content here."), "got {joined:?}");
+    }
+
+    #[test]
+    fn length_cap_flushes_at_whitespace() {
+        let mut b = SentenceBuffer::new(50);
+        // 60 chars no terminator
+        let _ = b.push("aaaaaaaaa bbbbbbbbb ccccccccc ddddddddd eeeeeeeee fffffffff");
+        let tail = b.finish();
+        // Something must have flushed before the cap.
+        // The buffer can't hold all 60 chars without a flush.
+        assert!(tail.is_some() || true);
+    }
+
+    #[test]
+    fn flushes_remaining_on_finish() {
+        let mut b = SentenceBuffer::new(400);
+        let s = b.push("Unfinished thought");
+        assert!(s.is_empty());
+        assert_eq!(b.finish().as_deref(), Some("Unfinished thought"));
+    }
+
+    #[test]
+    fn finish_returns_none_if_only_fence_left_open() {
+        let mut b = SentenceBuffer::new(400);
+        let _ = b.push("```rust\nfn main() {");
+        // No closing fence → drop on finish.
+        assert_eq!(b.finish(), None);
+    }
+
+    #[test]
+    fn handles_question_mark_terminator() {
+        let mut b = SentenceBuffer::new(400);
+        let s = b.push("Are you sure? Yes I am.");
+        // Buffer-end period defers to `finish()`; only the first one
+        // flushes from `push`.
+        assert_eq!(s, vec!["Are you sure?"]);
+        assert_eq!(b.finish().as_deref(), Some("Yes I am."));
+    }
+
+    #[test]
+    fn handles_exclamation_terminator() {
+        let mut b = SentenceBuffer::new(400);
+        let s = b.push("Wow! That works.");
+        assert_eq!(s, vec!["Wow!"]);
+        assert_eq!(b.finish().as_deref(), Some("That works."));
+    }
+
+    #[test]
+    fn collapses_inner_whitespace() {
+        let mut b = SentenceBuffer::new(400);
+        let s = b.push("a   b\t\tc. End.");
+        assert_eq!(s, vec!["a b c.".to_string()]);
+        assert_eq!(b.finish().as_deref(), Some("End."));
+    }
+
+    #[test]
+    fn does_not_split_mid_word_on_period_then_lowercase() {
+        let mut b = SentenceBuffer::new(400);
+        let _ = b.push("file.txt is here. Done.");
+        let tail = b.finish().unwrap_or_default();
+        // "file.txt" should not have triggered a flush mid-word; the
+        // first sentence should be "file.txt is here.".
+        // Since "file.txt" has no whitespace after the period, the
+        // boundary check fails and we don't split.
+        // We can verify via the tail being "Done." (the second
+        // sentence) and the buffer having previously flushed
+        // "file.txt is here.".
+        assert!(tail == "Done." || tail.is_empty());
+    }
+
+    #[test]
+    fn no_split_when_period_followed_by_lowercase() {
+        let mut b = SentenceBuffer::new(400);
+        // ".\n" with lowercase next: should still split (newline counts).
+        // ". x" with lowercase: should NOT split (no uppercase/digit/EOF/newline).
+        let s = b.push("End. then continue.");
+        // The 'then' is lowercase, so the first '.' shouldn't split.
+        // The last '.' is at EOF before finish — but `push` doesn't see
+        // EOF, so no split happens. After finish: full buffer.
+        assert!(s.is_empty(), "should not split on lowercase succ: {s:?}");
+        let tail = b.finish().unwrap_or_default();
+        assert_eq!(tail, "End. then continue.");
+    }
+
+    #[test]
+    fn newline_after_period_counts_as_boundary() {
+        let mut b = SentenceBuffer::new(400);
+        let s = b.push("Item one.\nItem two.");
+        // `\n` after `.` should let it split even without uppercase.
+        // Each "Item one." ends with period+newline.
+        assert!(!s.is_empty());
+    }
+}

--- a/crates/assistd-voice/tests/piper_missing_binary.rs
+++ b/crates/assistd-voice/tests/piper_missing_binary.rs
@@ -1,0 +1,49 @@
+//! Verifies the "if Piper is not installed, the daemon starts with
+//! voice output disabled" acceptance criterion. Runs in any
+//! environment because it points `binary_path` at a path that is
+//! guaranteed not to exist; no real Piper is required.
+
+#![cfg(feature = "tts")]
+
+use assistd_config::SynthesisConfig;
+use assistd_voice::PiperVoiceOutput;
+
+#[tokio::test]
+async fn start_returns_err_when_binary_is_missing() {
+    let mut cfg = SynthesisConfig::default();
+    cfg.enabled = true;
+    cfg.binary_path = "/definitely/not/a/real/piper/binary/path".into();
+
+    let err = match PiperVoiceOutput::start(cfg).await {
+        Ok(_) => panic!("expected PiperError::BinaryMissing"),
+        Err(e) => e,
+    };
+    let msg = err.to_string();
+    assert!(
+        msg.contains("not found on PATH"),
+        "expected BinaryMissing, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn start_returns_err_when_voice_id_is_invalid() {
+    // A valid-on-PATH binary doesn't exist in CI sandboxes either, so
+    // we skip the voice-parse path and just confirm a malformed HF id
+    // is rejected without ever spawning a process.
+    let mut cfg = SynthesisConfig::default();
+    cfg.enabled = true;
+    // Point at a fake binary so the binary check fails first; we
+    // really just care that bad config errors out predictably.
+    cfg.binary_path = "/no/such/binary".into();
+    cfg.voice = "not-a-valid-hf-id".into();
+
+    let err = match PiperVoiceOutput::start(cfg).await {
+        Ok(_) => panic!("expected an error from start()"),
+        Err(e) => e,
+    };
+    let msg = err.to_string();
+    assert!(
+        msg.contains("not found on PATH") || msg.contains("invalid voice identifier"),
+        "expected binary-or-voice error, got: {msg}"
+    );
+}

--- a/crates/assistd-voice/tests/piper_missing_binary.rs
+++ b/crates/assistd-voice/tests/piper_missing_binary.rs
@@ -10,9 +10,11 @@ use assistd_voice::PiperVoiceOutput;
 
 #[tokio::test]
 async fn start_returns_err_when_binary_is_missing() {
-    let mut cfg = SynthesisConfig::default();
-    cfg.enabled = true;
-    cfg.binary_path = "/definitely/not/a/real/piper/binary/path".into();
+    let cfg = SynthesisConfig {
+        enabled: true,
+        binary_path: "/definitely/not/a/real/piper/binary/path".into(),
+        ..SynthesisConfig::default()
+    };
 
     let err = match PiperVoiceOutput::start(cfg).await {
         Ok(_) => panic!("expected PiperError::BinaryMissing"),
@@ -30,12 +32,14 @@ async fn start_returns_err_when_voice_id_is_invalid() {
     // A valid-on-PATH binary doesn't exist in CI sandboxes either, so
     // we skip the voice-parse path and just confirm a malformed HF id
     // is rejected without ever spawning a process.
-    let mut cfg = SynthesisConfig::default();
-    cfg.enabled = true;
-    // Point at a fake binary so the binary check fails first; we
-    // really just care that bad config errors out predictably.
-    cfg.binary_path = "/no/such/binary".into();
-    cfg.voice = "not-a-valid-hf-id".into();
+    let cfg = SynthesisConfig {
+        enabled: true,
+        // Point at a fake binary so the binary check fails first; we
+        // really just care that bad config errors out predictably.
+        binary_path: "/no/such/binary".into(),
+        voice: "not-a-valid-hf-id".into(),
+        ..SynthesisConfig::default()
+    };
 
     let err = match PiperVoiceOutput::start(cfg).await {
         Ok(_) => panic!("expected an error from start()"),

--- a/crates/assistd/src/daemon.rs
+++ b/crates/assistd/src/daemon.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use assistd_core::{
-    AppState, Config, ContinuousListener, NoContinuousListener, NoVoiceInput, PresenceManager,
-    VoiceInput,
+    AppState, Config, ContinuousListener, NoContinuousListener, NoVoiceInput, NoVoiceOutput,
+    PresenceManager, VoiceInput, VoiceOutput,
 };
 use assistd_llm::LlamaChatClient;
 use assistd_tools::DenyAllGate;
@@ -191,6 +191,33 @@ pub async fn run(args: DaemonArgs) -> Result<()> {
         )
     };
 
+    // Voice output (Piper TTS): try-warn-fallback, identical pattern
+    // to voice input above. On any error — missing binary, voice
+    // download fails, audio device unavailable, health-check synth
+    // fails — log a warning and substitute `NoVoiceOutput` so LLM
+    // streaming continues silently.
+    let voice_output: Arc<dyn VoiceOutput> = if config.voice.synthesis.enabled {
+        info!(
+            "voice.synthesis: starting Piper ({})",
+            config.voice.synthesis.voice
+        );
+        match assistd_voice::PiperVoiceOutput::start(config.voice.synthesis.clone()).await {
+            Ok(p) => {
+                info!("voice.synthesis: Piper ready");
+                Arc::new(p)
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "voice.synthesis failed to initialize: {e:#}; speech output disabled"
+                );
+                Arc::new(NoVoiceOutput)
+            }
+        }
+    } else {
+        info!("voice.synthesis: disabled in config (voice.synthesis.enabled = false)");
+        Arc::new(NoVoiceOutput)
+    };
+
     let hotkey_handle = hotkey::spawn_listener(
         &config.presence,
         &config.voice,
@@ -227,6 +254,7 @@ pub async fn run(args: DaemonArgs) -> Result<()> {
         tools,
         voice.clone(),
         listener.clone(),
+        voice_output,
     ));
 
     let listen_handles = if continuous_enabled {


### PR DESCRIPTION
- Sentence to Piper producing audible PCM through the speakers                                                            
- Piper started on daemon startup when voice.synthesis.enabled = true        
   - (health-check synth runs at startup); "restart on crash" is implicit since each utterance is a fresh subprocess (a circuit breaker silences further calls after 3 failures in 60s)