### PR TITLE
Add attach_image command in TUI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -123,10 +129,14 @@ dependencies = [
  "crossterm",
  "futures-util",
  "global-hotkey",
+ "image",
  "libc",
  "nvml-wrapper",
  "ratatui",
+ "ratatui-image",
  "serde_json",
+ "shlex",
+ "tempfile",
  "textwrap",
  "tokio",
  "tracing",
@@ -283,6 +293,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -333,10 +353,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
@@ -593,6 +625,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -773,10 +814,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -1149,6 +1209,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "icy_sixel"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccc0a9c4770bc47b0a933256a496cfb8b6531f753ea9bccb19c6dff0ff7273fc"
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1179,6 +1245,32 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "image-webp",
+ "moxcms",
+ "num-traits",
+ "png",
+ "zune-core",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
 ]
 
 [[package]]
@@ -1454,6 +1546,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1463,6 +1565,16 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
 ]
 
 [[package]]
@@ -1782,6 +1894,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1827,6 +1945,19 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.11.0",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -1905,6 +2036,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "pxfm"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1933,7 +2076,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.3",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1982,12 +2125,33 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1997,7 +2161,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -2028,6 +2201,22 @@ dependencies = [
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width 0.2.0",
+]
+
+[[package]]
+name = "ratatui-image"
+version = "8.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ecc67e9f7d0ac69e0f712f58b1a9d5a04d8daeeb3628f4d6b67580abb88b7cb"
+dependencies = [
+ "base64-simd",
+ "icy_sixel",
+ "image",
+ "rand 0.8.6",
+ "ratatui",
+ "rustix 0.38.44",
+ "thiserror 1.0.69",
+ "windows 0.58.0",
 ]
 
 [[package]]
@@ -2390,6 +2579,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "slab"
@@ -2982,6 +3177,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3242,6 +3443,16 @@ dependencies = [
 
 [[package]]
 name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core 0.58.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
@@ -3273,15 +3484,28 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link",
  "windows-result 0.4.1",
- "windows-strings",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -3297,9 +3521,31 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3344,11 +3590,30 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result 0.2.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3861,3 +4126,18 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,8 @@ infer = "0.19"
 shlex = "1"
 which = "7"
 rodio = { version = "0.22", default-features = false, features = ["playback"] }
+ratatui-image = { version = "8", default-features = false, features = ["crossterm"] }
+image = { version = "0.25", default-features = false, features = ["png", "jpeg", "webp"] }
 
 [profile.release]
 lto = "thin"

--- a/crates/assistd-core/src/agent.rs
+++ b/crates/assistd-core/src/agent.rs
@@ -44,9 +44,10 @@ pub async fn run_agent_turn(
     tools: Arc<ToolRegistry>,
     max_iterations: u32,
     user_text: String,
+    user_attachments: Vec<Attachment>,
     tx: mpsc::Sender<LlmEvent>,
 ) -> Result<()> {
-    backend.push_user(user_text).await?;
+    backend.push_user(user_text, user_attachments).await?;
     let schemas = tools.openai_schemas();
 
     for iteration in 0..max_iterations {
@@ -302,6 +303,7 @@ mod tests {
     struct MockBackend {
         outcomes: StdMutex<Vec<StepOutcome>>,
         pushed_users: StdMutex<Vec<String>>,
+        pushed_attachments: StdMutex<Vec<Vec<Attachment>>>,
         pushed_results: StdMutex<Vec<Vec<ToolResultPayload>>>,
     }
 
@@ -310,6 +312,7 @@ mod tests {
             Arc::new(Self {
                 outcomes: StdMutex::new(outcomes),
                 pushed_users: StdMutex::new(Vec::new()),
+                pushed_attachments: StdMutex::new(Vec::new()),
                 pushed_results: StdMutex::new(Vec::new()),
             })
         }
@@ -325,8 +328,13 @@ mod tests {
             unimplemented!("mock uses step path only")
         }
 
-        async fn push_user(&self, text: String) -> anyhow::Result<()> {
+        async fn push_user(
+            &self,
+            text: String,
+            attachments: Vec<Attachment>,
+        ) -> anyhow::Result<()> {
             self.pushed_users.lock().unwrap().push(text);
+            self.pushed_attachments.lock().unwrap().push(attachments);
             Ok(())
         }
 
@@ -391,7 +399,7 @@ mod tests {
         let backend = MockBackend::with(vec![StepOutcome::Final]);
         let tools = tools_with_echo();
         let (tx, mut rx) = mpsc::channel(16);
-        run_agent_turn(backend.clone(), tools, 10, "what is 2+2?".into(), tx)
+        run_agent_turn(backend.clone(), tools, 10, "what is 2+2?".into(), Vec::new(), tx)
             .await
             .unwrap();
         let events = collect(&mut rx).await;
@@ -409,7 +417,7 @@ mod tests {
         ]);
         let tools = tools_with_echo();
         let (tx, mut rx) = mpsc::channel(16);
-        run_agent_turn(backend.clone(), tools, 10, "say hello".into(), tx)
+        run_agent_turn(backend.clone(), tools, 10, "say hello".into(), Vec::new(), tx)
             .await
             .unwrap();
         let events = collect(&mut rx).await;
@@ -464,7 +472,7 @@ mod tests {
         let tools = Arc::new(tools);
 
         let (tx, mut rx) = mpsc::channel(16);
-        run_agent_turn(backend.clone(), tools, 10, "how many?".into(), tx)
+        run_agent_turn(backend.clone(), tools, 10, "how many?".into(), Vec::new(), tx)
             .await
             .unwrap();
         let events = collect(&mut rx).await;
@@ -499,7 +507,7 @@ mod tests {
         let backend = MockBackend::with(outcomes);
         let tools = tools_with_echo();
         let (tx, mut rx) = mpsc::channel(64);
-        run_agent_turn(backend, tools, 3, "loop it".into(), tx)
+        run_agent_turn(backend, tools, 3, "loop it".into(), Vec::new(), tx)
             .await
             .unwrap();
         let events = collect(&mut rx).await;
@@ -532,7 +540,7 @@ mod tests {
         ]);
         let tools = tools_with_echo();
         let (tx, mut rx) = mpsc::channel(16);
-        run_agent_turn(backend.clone(), tools, 10, "go".into(), tx)
+        run_agent_turn(backend.clone(), tools, 10, "go".into(), Vec::new(), tx)
             .await
             .unwrap();
         drop(collect(&mut rx).await);
@@ -577,7 +585,7 @@ mod tests {
             StepOutcome::Final,
         ]);
         let (tx, mut rx) = mpsc::channel(16);
-        run_agent_turn(backend.clone(), reg, 10, "go".into(), tx)
+        run_agent_turn(backend.clone(), reg, 10, "go".into(), Vec::new(), tx)
             .await
             .unwrap();
         drop(collect(&mut rx).await);
@@ -604,7 +612,7 @@ mod tests {
         drop(rx);
         // Channel is closed from the start, so the very first is_closed
         // check bails the loop before any step runs.
-        run_agent_turn(backend.clone(), tools, 10, "go".into(), tx)
+        run_agent_turn(backend.clone(), tools, 10, "go".into(), Vec::new(), tx)
             .await
             .unwrap();
         // With the receiver already dropped, no step was called.

--- a/crates/assistd-core/src/agent.rs
+++ b/crates/assistd-core/src/agent.rs
@@ -399,9 +399,16 @@ mod tests {
         let backend = MockBackend::with(vec![StepOutcome::Final]);
         let tools = tools_with_echo();
         let (tx, mut rx) = mpsc::channel(16);
-        run_agent_turn(backend.clone(), tools, 10, "what is 2+2?".into(), Vec::new(), tx)
-            .await
-            .unwrap();
+        run_agent_turn(
+            backend.clone(),
+            tools,
+            10,
+            "what is 2+2?".into(),
+            Vec::new(),
+            tx,
+        )
+        .await
+        .unwrap();
         let events = collect(&mut rx).await;
         assert!(matches!(events.last(), Some(LlmEvent::Done)));
         assert_eq!(backend.pushed_users.lock().unwrap().len(), 1);
@@ -417,9 +424,16 @@ mod tests {
         ]);
         let tools = tools_with_echo();
         let (tx, mut rx) = mpsc::channel(16);
-        run_agent_turn(backend.clone(), tools, 10, "say hello".into(), Vec::new(), tx)
-            .await
-            .unwrap();
+        run_agent_turn(
+            backend.clone(),
+            tools,
+            10,
+            "say hello".into(),
+            Vec::new(),
+            tx,
+        )
+        .await
+        .unwrap();
         let events = collect(&mut rx).await;
 
         // Expected event sequence (intermixed with deltas):
@@ -472,9 +486,16 @@ mod tests {
         let tools = Arc::new(tools);
 
         let (tx, mut rx) = mpsc::channel(16);
-        run_agent_turn(backend.clone(), tools, 10, "how many?".into(), Vec::new(), tx)
-            .await
-            .unwrap();
+        run_agent_turn(
+            backend.clone(),
+            tools,
+            10,
+            "how many?".into(),
+            Vec::new(),
+            tx,
+        )
+        .await
+        .unwrap();
         let events = collect(&mut rx).await;
         // Exactly one ToolCall/ToolResult pair.
         let calls = events

--- a/crates/assistd-core/src/socket.rs
+++ b/crates/assistd-core/src/socket.rs
@@ -506,7 +506,7 @@ mod tests {
             Ok(())
         }
 
-        async fn push_user(&self, _text: String) -> anyhow::Result<()> {
+        async fn push_user(&self, _text: String, _attachments: Vec<assistd_tools::Attachment>) -> anyhow::Result<()> {
             Ok(())
         }
 
@@ -556,7 +556,7 @@ mod tests {
             Ok(())
         }
 
-        async fn push_user(&self, _text: String) -> anyhow::Result<()> {
+        async fn push_user(&self, _text: String, _attachments: Vec<assistd_tools::Attachment>) -> anyhow::Result<()> {
             Ok(())
         }
 

--- a/crates/assistd-core/src/socket.rs
+++ b/crates/assistd-core/src/socket.rs
@@ -506,7 +506,11 @@ mod tests {
             Ok(())
         }
 
-        async fn push_user(&self, _text: String, _attachments: Vec<assistd_tools::Attachment>) -> anyhow::Result<()> {
+        async fn push_user(
+            &self,
+            _text: String,
+            _attachments: Vec<assistd_tools::Attachment>,
+        ) -> anyhow::Result<()> {
             Ok(())
         }
 
@@ -556,7 +560,11 @@ mod tests {
             Ok(())
         }
 
-        async fn push_user(&self, _text: String, _attachments: Vec<assistd_tools::Attachment>) -> anyhow::Result<()> {
+        async fn push_user(
+            &self,
+            _text: String,
+            _attachments: Vec<assistd_tools::Attachment>,
+        ) -> anyhow::Result<()> {
             Ok(())
         }
 

--- a/crates/assistd-core/src/state.rs
+++ b/crates/assistd-core/src/state.rs
@@ -124,12 +124,13 @@ impl AppState {
         let llm = self.llm.clone();
         let tools = self.tools.clone();
         let max_iterations = self.config.agent.max_iterations;
-        let generator = tokio::spawn(
-            async move {
-                run_agent_turn(llm, tools, max_iterations, text, Vec::new(), llm_tx).await
-            }
-            .in_current_span(),
-        );
+        let generator =
+            tokio::spawn(
+                async move {
+                    run_agent_turn(llm, tools, max_iterations, text, Vec::new(), llm_tx).await
+                }
+                .in_current_span(),
+            );
 
         // Sentence buffer + speech worker. Each completed sentence is
         // sent to a per-query worker task that calls voice_output.speak
@@ -853,7 +854,11 @@ mod tests {
         ) -> anyhow::Result<()> {
             unimplemented!("uses step path")
         }
-        async fn push_user(&self, _text: String, _attachments: Vec<assistd_tools::Attachment>) -> anyhow::Result<()> {
+        async fn push_user(
+            &self,
+            _text: String,
+            _attachments: Vec<assistd_tools::Attachment>,
+        ) -> anyhow::Result<()> {
             Ok(())
         }
         async fn push_tool_results(&self, _results: Vec<ToolResultPayload>) -> anyhow::Result<()> {
@@ -1467,7 +1472,11 @@ mod tests {
         ) -> anyhow::Result<()> {
             unimplemented!("uses step path")
         }
-        async fn push_user(&self, _text: String, _attachments: Vec<assistd_tools::Attachment>) -> anyhow::Result<()> {
+        async fn push_user(
+            &self,
+            _text: String,
+            _attachments: Vec<assistd_tools::Attachment>,
+        ) -> anyhow::Result<()> {
             Ok(())
         }
         async fn push_tool_results(&self, _results: Vec<ToolResultPayload>) -> anyhow::Result<()> {
@@ -1603,7 +1612,11 @@ mod tests {
         ) -> anyhow::Result<()> {
             unimplemented!("uses step path")
         }
-        async fn push_user(&self, _text: String, _attachments: Vec<assistd_tools::Attachment>) -> anyhow::Result<()> {
+        async fn push_user(
+            &self,
+            _text: String,
+            _attachments: Vec<assistd_tools::Attachment>,
+        ) -> anyhow::Result<()> {
             Ok(())
         }
         async fn push_tool_results(&self, _results: Vec<ToolResultPayload>) -> anyhow::Result<()> {

--- a/crates/assistd-core/src/state.rs
+++ b/crates/assistd-core/src/state.rs
@@ -125,8 +125,10 @@ impl AppState {
         let tools = self.tools.clone();
         let max_iterations = self.config.agent.max_iterations;
         let generator = tokio::spawn(
-            async move { run_agent_turn(llm, tools, max_iterations, text, llm_tx).await }
-                .in_current_span(),
+            async move {
+                run_agent_turn(llm, tools, max_iterations, text, Vec::new(), llm_tx).await
+            }
+            .in_current_span(),
         );
 
         // Sentence buffer + speech worker. Each completed sentence is
@@ -851,7 +853,7 @@ mod tests {
         ) -> anyhow::Result<()> {
             unimplemented!("uses step path")
         }
-        async fn push_user(&self, _text: String) -> anyhow::Result<()> {
+        async fn push_user(&self, _text: String, _attachments: Vec<assistd_tools::Attachment>) -> anyhow::Result<()> {
             Ok(())
         }
         async fn push_tool_results(&self, _results: Vec<ToolResultPayload>) -> anyhow::Result<()> {
@@ -1465,7 +1467,7 @@ mod tests {
         ) -> anyhow::Result<()> {
             unimplemented!("uses step path")
         }
-        async fn push_user(&self, _text: String) -> anyhow::Result<()> {
+        async fn push_user(&self, _text: String, _attachments: Vec<assistd_tools::Attachment>) -> anyhow::Result<()> {
             Ok(())
         }
         async fn push_tool_results(&self, _results: Vec<ToolResultPayload>) -> anyhow::Result<()> {
@@ -1601,7 +1603,7 @@ mod tests {
         ) -> anyhow::Result<()> {
             unimplemented!("uses step path")
         }
-        async fn push_user(&self, _text: String) -> anyhow::Result<()> {
+        async fn push_user(&self, _text: String, _attachments: Vec<assistd_tools::Attachment>) -> anyhow::Result<()> {
             Ok(())
         }
         async fn push_tool_results(&self, _results: Vec<ToolResultPayload>) -> anyhow::Result<()> {

--- a/crates/assistd-llm/src/chat/client.rs
+++ b/crates/assistd-llm/src/chat/client.rs
@@ -18,6 +18,7 @@ use std::time::Duration;
 
 use anyhow::Result;
 use assistd_config::{ChatConfig, LlamaServerConfig, ModelConfig};
+use assistd_tools::Attachment;
 use async_trait::async_trait;
 use serde_json::Value;
 use tokio::sync::{Mutex, mpsc};
@@ -235,9 +236,13 @@ impl LlmBackend for LlamaChatClient {
         }
     }
 
-    async fn push_user(&self, text: String) -> Result<()> {
+    async fn push_user(&self, text: String, attachments: Vec<Attachment>) -> Result<()> {
         let mut conv = self.conv.lock().await;
-        conv.push_user(text);
+        if attachments.is_empty() {
+            conv.push_user(text);
+        } else {
+            conv.push_user_with_attachments(text, attachments);
+        }
         Ok(())
     }
 

--- a/crates/assistd-llm/src/lib.rs
+++ b/crates/assistd-llm/src/lib.rs
@@ -99,7 +99,12 @@ pub trait LlmBackend: Send + Sync + 'static {
 
     /// Append a user message to the conversation. Does not invoke the
     /// model. Used by the agent loop at the start of each turn.
-    async fn push_user(&self, text: String) -> Result<()>;
+    ///
+    /// `attachments` carries any images the user wants the model to see
+    /// on its next turn. Pass an empty `Vec` for plain-text turns.
+    /// Backends without vision support are expected to ignore the
+    /// attachments rather than error.
+    async fn push_user(&self, text: String, attachments: Vec<Attachment>) -> Result<()>;
 
     /// Append the results of the most recent `tool_calls` request. The
     /// backend should commit these as messages the model will see on its
@@ -145,7 +150,7 @@ impl LlmBackend for EchoBackend {
         Ok(())
     }
 
-    async fn push_user(&self, text: String) -> Result<()> {
+    async fn push_user(&self, text: String, _attachments: Vec<Attachment>) -> Result<()> {
         *self.last_user.lock().await = text;
         Ok(())
     }
@@ -183,7 +188,7 @@ impl LlmBackend for FailedBackend {
         anyhow::bail!("{}", self.reason)
     }
 
-    async fn push_user(&self, _text: String) -> Result<()> {
+    async fn push_user(&self, _text: String, _attachments: Vec<Attachment>) -> Result<()> {
         anyhow::bail!("{}", self.reason)
     }
 
@@ -224,7 +229,10 @@ mod tests {
     #[tokio::test]
     async fn echo_backend_step_echoes_last_pushed_user() {
         let backend = EchoBackend::new();
-        backend.push_user("what is 2+2?".into()).await.unwrap();
+        backend
+            .push_user("what is 2+2?".into(), Vec::new())
+            .await
+            .unwrap();
         let (tx, mut rx) = mpsc::channel(8);
         let outcome = backend.step(Vec::new(), tx).await.unwrap();
         assert!(matches!(outcome, StepOutcome::Final));

--- a/crates/assistd-llm/tests/chat_client.rs
+++ b/crates/assistd-llm/tests/chat_client.rs
@@ -691,7 +691,7 @@ async fn step_with_stop_finish_reason_returns_final() {
     let (port, _server) = spawn_fake(script.clone()).await;
 
     let client = build_client(&chat_spec(port));
-    client.push_user("what is 2+2?".into()).await.unwrap();
+    client.push_user("what is 2+2?".into(), Vec::new()).await.unwrap();
     let (tx, mut rx) = mpsc::channel(32);
     let outcome = client.step(Vec::new(), tx).await.unwrap();
     assert!(matches!(outcome, StepOutcome::Final));
@@ -724,7 +724,7 @@ async fn step_parses_tool_call_across_argument_chunks() {
     let (port, _server) = spawn_fake(script.clone()).await;
 
     let client = build_client(&chat_spec(port));
-    client.push_user("list /tmp".into()).await.unwrap();
+    client.push_user("list /tmp".into(), Vec::new()).await.unwrap();
     let (tx, mut rx) = mpsc::channel(32);
     let tools = vec![serde_json::json!({
         "type": "function",
@@ -778,7 +778,7 @@ async fn agent_round_trip_commits_tool_calls_and_result_to_history() {
     let (port, _server) = spawn_fake(script.clone()).await;
 
     let client = build_client(&chat_spec(port));
-    client.push_user("please echo hi".into()).await.unwrap();
+    client.push_user("please echo hi".into(), Vec::new()).await.unwrap();
 
     let tools = vec![serde_json::json!({
         "type": "function",

--- a/crates/assistd-llm/tests/chat_client.rs
+++ b/crates/assistd-llm/tests/chat_client.rs
@@ -691,7 +691,10 @@ async fn step_with_stop_finish_reason_returns_final() {
     let (port, _server) = spawn_fake(script.clone()).await;
 
     let client = build_client(&chat_spec(port));
-    client.push_user("what is 2+2?".into(), Vec::new()).await.unwrap();
+    client
+        .push_user("what is 2+2?".into(), Vec::new())
+        .await
+        .unwrap();
     let (tx, mut rx) = mpsc::channel(32);
     let outcome = client.step(Vec::new(), tx).await.unwrap();
     assert!(matches!(outcome, StepOutcome::Final));
@@ -724,7 +727,10 @@ async fn step_parses_tool_call_across_argument_chunks() {
     let (port, _server) = spawn_fake(script.clone()).await;
 
     let client = build_client(&chat_spec(port));
-    client.push_user("list /tmp".into(), Vec::new()).await.unwrap();
+    client
+        .push_user("list /tmp".into(), Vec::new())
+        .await
+        .unwrap();
     let (tx, mut rx) = mpsc::channel(32);
     let tools = vec![serde_json::json!({
         "type": "function",
@@ -778,7 +784,10 @@ async fn agent_round_trip_commits_tool_calls_and_result_to_history() {
     let (port, _server) = spawn_fake(script.clone()).await;
 
     let client = build_client(&chat_spec(port));
-    client.push_user("please echo hi".into(), Vec::new()).await.unwrap();
+    client
+        .push_user("please echo hi".into(), Vec::new())
+        .await
+        .unwrap();
 
     let tools = vec![serde_json::json!({
         "type": "function",

--- a/crates/assistd-llm/tests/presence.rs
+++ b/crates/assistd-llm/tests/presence.rs
@@ -388,7 +388,11 @@ impl LlmBackend for DelayBackend {
         Ok(())
     }
 
-    async fn push_user(&self, text: String) -> anyhow::Result<()> {
+    async fn push_user(
+        &self,
+        text: String,
+        _attachments: Vec<assistd_tools::Attachment>,
+    ) -> anyhow::Result<()> {
         *self.last_user.lock().await = text;
         Ok(())
     }

--- a/crates/assistd-tools/src/attachment.rs
+++ b/crates/assistd-tools/src/attachment.rs
@@ -1,0 +1,159 @@
+//! Shared image-attachment loading. Used by:
+//! - `SeeCommand` (LLM-invoked `see PATH` tool call)
+//! - The TUI's `/attach` slash command
+//!
+//! Both call paths need identical validation so error messages match
+//! and the allowlisted MIME types stay in sync.
+
+use std::path::Path;
+
+use crate::command::Attachment;
+
+/// Image MIME types accepted by llama.cpp's vision adapters today.
+/// `infer::is_image` is too permissive (accepts GIF, BMP, TIFF, HEIC) so
+/// we filter explicitly.
+const SUPPORTED_MIMES: &[&str] = &["image/png", "image/jpeg", "image/webp"];
+
+#[derive(Debug)]
+pub enum LoadImageError {
+    /// File missing, unreadable, or other I/O failure.
+    Io { path: String, source: std::io::Error },
+    /// `infer` couldn't identify the file type from its magic bytes.
+    Unrecognized { path: String },
+    /// `infer` identified a non-image type.
+    NotAnImage { path: String, detected: String },
+    /// `infer` identified an image, but it's not in [`SUPPORTED_MIMES`].
+    UnsupportedFormat { path: String, mime: String },
+}
+
+impl LoadImageError {
+    /// One-line user-facing message. Caller decorates with a prefix like
+    /// `[error] /attach: ` or `[error] see: ` as appropriate.
+    pub fn user_message(&self) -> String {
+        match self {
+            LoadImageError::Io { path, source } => match source.kind() {
+                std::io::ErrorKind::NotFound => format!("file not found: {path}"),
+                std::io::ErrorKind::PermissionDenied => format!("permission denied: {path}"),
+                _ => format!("{path}: {source}"),
+            },
+            LoadImageError::Unrecognized { path } => {
+                format!("not a recognized image file: {path}")
+            }
+            LoadImageError::NotAnImage { path, detected } => {
+                format!("not an image file: {path} (detected {detected})")
+            }
+            LoadImageError::UnsupportedFormat { path, mime } => format!(
+                "unsupported image format: {path} ({mime}). Supported: {}",
+                SUPPORTED_MIMES.join(", ")
+            ),
+        }
+    }
+}
+
+/// Read `path` from disk and validate it's a supported image format.
+///
+/// On success returns the [`Attachment`] (ready to hand to the LLM
+/// conversation layer) plus the file size in bytes (so the caller can
+/// render a "12 KB" annotation without re-stat-ing).
+pub async fn load_image_attachment(
+    path: &Path,
+) -> Result<(Attachment, usize), LoadImageError> {
+    let bytes = tokio::fs::read(path).await.map_err(|e| LoadImageError::Io {
+        path: path.display().to_string(),
+        source: e,
+    })?;
+    let Some(t) = infer::get(&bytes) else {
+        return Err(LoadImageError::Unrecognized {
+            path: path.display().to_string(),
+        });
+    };
+    if !infer::is_image(&bytes) {
+        return Err(LoadImageError::NotAnImage {
+            path: path.display().to_string(),
+            detected: t.mime_type().to_string(),
+        });
+    }
+    let mime = t.mime_type();
+    if !SUPPORTED_MIMES.contains(&mime) {
+        return Err(LoadImageError::UnsupportedFormat {
+            path: path.display().to_string(),
+            mime: mime.to_string(),
+        });
+    }
+    let size = bytes.len();
+    Ok((
+        Attachment::Image {
+            mime: mime.to_string(),
+            bytes,
+        },
+        size,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    const PNG_BYTES: &[u8] = &[
+        0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44,
+        0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00, 0x1F,
+        0x15, 0xC4, 0x89, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9C, 0x63, 0x00,
+        0x01, 0x00, 0x00, 0x05, 0x00, 0x01, 0x0D, 0x0A, 0x2D, 0xB4, 0x00, 0x00, 0x00, 0x00, 0x49,
+        0x45, 0x4E, 0x44, 0xAE, 0x42, 0x60, 0x82,
+    ];
+
+    // Minimal GIF89a header → infer reports image/gif → must be rejected
+    // by the supported-format allowlist.
+    const GIF_BYTES: &[u8] = &[
+        0x47, 0x49, 0x46, 0x38, 0x39, 0x61, 0x01, 0x00, 0x01, 0x00, 0x80, 0x00, 0x00, 0xFF, 0xFF,
+        0xFF, 0x00, 0x00, 0x00, 0x21, 0xF9, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x2C, 0x00, 0x00,
+        0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x02, 0x02, 0x44, 0x01, 0x00, 0x3B,
+    ];
+
+    #[tokio::test]
+    async fn loads_png() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("shot.png");
+        tokio::fs::write(&path, PNG_BYTES).await.unwrap();
+        let (att, size) = load_image_attachment(&path).await.unwrap();
+        assert_eq!(size, PNG_BYTES.len());
+        match att {
+            Attachment::Image { mime, bytes } => {
+                assert_eq!(mime, "image/png");
+                assert_eq!(bytes, PNG_BYTES);
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn missing_file_is_io_error() {
+        let err = load_image_attachment(Path::new("/nonexistent/x.png"))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, LoadImageError::Io { .. }));
+        assert!(err.user_message().starts_with("file not found:"));
+    }
+
+    #[tokio::test]
+    async fn text_file_is_unrecognized() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("notes.txt");
+        tokio::fs::write(&path, b"just some text").await.unwrap();
+        let err = load_image_attachment(&path).await.unwrap_err();
+        assert!(matches!(err, LoadImageError::Unrecognized { .. }));
+        assert!(err.user_message().contains("not a recognized image"));
+    }
+
+    #[tokio::test]
+    async fn gif_is_rejected_by_allowlist() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("anim.gif");
+        tokio::fs::write(&path, GIF_BYTES).await.unwrap();
+        let err = load_image_attachment(&path).await.unwrap_err();
+        match err {
+            LoadImageError::UnsupportedFormat { mime, .. } => assert_eq!(mime, "image/gif"),
+            other => panic!("expected UnsupportedFormat, got {other:?}"),
+        }
+    }
+}

--- a/crates/assistd-tools/src/attachment.rs
+++ b/crates/assistd-tools/src/attachment.rs
@@ -17,7 +17,10 @@ const SUPPORTED_MIMES: &[&str] = &["image/png", "image/jpeg", "image/webp"];
 #[derive(Debug)]
 pub enum LoadImageError {
     /// File missing, unreadable, or other I/O failure.
-    Io { path: String, source: std::io::Error },
+    Io {
+        path: String,
+        source: std::io::Error,
+    },
     /// `infer` couldn't identify the file type from its magic bytes.
     Unrecognized { path: String },
     /// `infer` identified a non-image type.
@@ -55,13 +58,13 @@ impl LoadImageError {
 /// On success returns the [`Attachment`] (ready to hand to the LLM
 /// conversation layer) plus the file size in bytes (so the caller can
 /// render a "12 KB" annotation without re-stat-ing).
-pub async fn load_image_attachment(
-    path: &Path,
-) -> Result<(Attachment, usize), LoadImageError> {
-    let bytes = tokio::fs::read(path).await.map_err(|e| LoadImageError::Io {
-        path: path.display().to_string(),
-        source: e,
-    })?;
+pub async fn load_image_attachment(path: &Path) -> Result<(Attachment, usize), LoadImageError> {
+    let bytes = tokio::fs::read(path)
+        .await
+        .map_err(|e| LoadImageError::Io {
+            path: path.display().to_string(),
+            source: e,
+        })?;
     let Some(t) = infer::get(&bytes) else {
         return Err(LoadImageError::Unrecognized {
             path: path.display().to_string(),

--- a/crates/assistd-tools/src/commands/see.rs
+++ b/crates/assistd-tools/src/commands/see.rs
@@ -5,9 +5,12 @@
 //! responsible for turning that into a vision input on the model's
 //! next turn.
 
+use std::path::Path;
+
 use anyhow::Result;
 use async_trait::async_trait;
 
+use crate::attachment::{LoadImageError, load_image_attachment};
 use crate::command::{Attachment, Command, CommandInput, CommandOutput, error_line, io_error_nav};
 use crate::commands::cat::human_size;
 
@@ -57,17 +60,24 @@ impl Command for SeeCommand {
             ));
         }
         let path = &input.args[0];
-        let bytes = match tokio::fs::read(path).await {
-            Ok(b) => b,
-            Err(e) => {
-                return Ok(CommandOutput::failed(
-                    1,
-                    io_error_nav("see", path, &e).into_bytes(),
-                ));
+        match load_image_attachment(Path::new(path)).await {
+            Ok((attachment, size)) => {
+                let mime = match &attachment {
+                    Attachment::Image { mime, .. } => mime.clone(),
+                };
+                let stdout = format!("attached {mime} ({}) from {path}\n", human_size(size));
+                Ok(CommandOutput {
+                    stdout: stdout.into_bytes(),
+                    stderr: Vec::new(),
+                    exit_code: 0,
+                    attachments: vec![attachment],
+                })
             }
-        };
-        let Some(t) = infer::get(&bytes) else {
-            return Ok(CommandOutput::failed(
+            Err(LoadImageError::Io { source, .. }) => Ok(CommandOutput::failed(
+                1,
+                io_error_nav("see", path, &source).into_bytes(),
+            )),
+            Err(LoadImageError::Unrecognized { .. }) => Ok(CommandOutput::failed(
                 1,
                 error_line(
                     "see",
@@ -76,29 +86,28 @@ impl Command for SeeCommand {
                     format_args!("cat {path}"),
                 )
                 .into_bytes(),
-            ));
-        };
-        if !infer::is_image(&bytes) {
-            return Ok(CommandOutput::failed(
+            )),
+            Err(LoadImageError::NotAnImage { detected, .. }) => Ok(CommandOutput::failed(
                 1,
                 error_line(
                     "see",
-                    format_args!("not an image file: {path} (detected {})", t.mime_type()),
+                    format_args!("not an image file: {path} (detected {detected})"),
                     "Use",
                     format_args!("cat {path}"),
                 )
                 .into_bytes(),
-            ));
+            )),
+            Err(LoadImageError::UnsupportedFormat { mime, .. }) => Ok(CommandOutput::failed(
+                1,
+                error_line(
+                    "see",
+                    format_args!("unsupported image format: {path} ({mime})"),
+                    "Use",
+                    "PNG, JPEG, or WebP",
+                )
+                .into_bytes(),
+            )),
         }
-        let mime = t.mime_type().to_string();
-        let size = bytes.len();
-        let stdout = format!("attached {mime} ({}) from {path}\n", human_size(size));
-        Ok(CommandOutput {
-            stdout: stdout.into_bytes(),
-            stderr: Vec::new(),
-            exit_code: 0,
-            attachments: vec![Attachment::Image { mime, bytes }],
-        })
     }
 }
 

--- a/crates/assistd-tools/src/lib.rs
+++ b/crates/assistd-tools/src/lib.rs
@@ -8,6 +8,7 @@
 //! is what the LLM sees (JSON-in/JSON-out); `Command` is what executes
 //! bytes-in/bytes-out with a Unix exit code.
 
+pub mod attachment;
 pub mod chain;
 pub mod command;
 pub mod commands;
@@ -15,6 +16,7 @@ pub mod policy;
 pub mod presentation;
 pub mod run;
 
+pub use attachment::{LoadImageError, load_image_attachment};
 pub use chain::{Chain, ParseError, execute, parse_chain};
 pub use command::{Attachment, Command, CommandInput, CommandOutput, CommandRegistry};
 pub use policy::{

--- a/crates/assistd/Cargo.toml
+++ b/crates/assistd/Cargo.toml
@@ -32,6 +32,9 @@ chat = [
     "dep:textwrap",
     "dep:async-trait",
     "dep:libc",
+    "dep:shlex",
+    "dep:ratatui-image",
+    "dep:image",
 ]
 
 [dependencies]
@@ -64,3 +67,9 @@ tracing-appender = { workspace = true, optional = true }
 textwrap         = { workspace = true, optional = true }
 async-trait      = { workspace = true, optional = true }
 libc             = { workspace = true, optional = true }
+shlex            = { workspace = true, optional = true }
+ratatui-image    = { workspace = true, optional = true }
+image            = { workspace = true, optional = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/assistd/src/chat/app.rs
+++ b/crates/assistd/src/chat/app.rs
@@ -91,7 +91,10 @@ pub enum ChatEvent {
         protocol: Option<StatefulProtocol>,
     },
     /// `/attach <path>` failed (missing file, unsupported format, etc.).
-    AttachFailed { path: String, message: String },
+    AttachFailed {
+        path: String,
+        message: String,
+    },
 }
 
 // Manual Debug because `StatefulProtocol` (inside `AttachLoaded.protocol`)
@@ -428,8 +431,7 @@ impl App {
                 protocol,
                 ..
             } => {
-                let label =
-                    format!("📎 attached: {name} ({mime}, {})", human_size_short(size));
+                let label = format!("📎 attached: {name} ({mime}, {})", human_size_short(size));
                 self.output.push_info(&label);
                 self.set_notice(&format!("📎 {name} attached"));
                 self.pending_attachments.push(PendingAttachment {
@@ -506,7 +508,8 @@ impl App {
         if attachment_names.is_empty() {
             self.output.push_user(text);
         } else {
-            self.output.push_user_with_attachments(text, attachment_names);
+            self.output
+                .push_user_with_attachments(text, attachment_names);
         }
         self.output.reset_scroll();
         self.output.begin_assistant();
@@ -550,15 +553,13 @@ impl App {
                     // 16-bit PNGs the `image` crate doesn't enable by
                     // default) — fall back to filename-only display in
                     // that case rather than failing the whole attach.
-                    let protocol = picker.and_then(|p| {
-                        match image::load_from_memory(&bytes) {
-                            Ok(img) => Some(p.new_resize_protocol(img)),
-                            Err(e) => {
-                                tracing::warn!(
-                                    "/attach: thumbnail decode failed for {path_for_load}: {e}"
-                                );
-                                None
-                            }
+                    let protocol = picker.and_then(|p| match image::load_from_memory(&bytes) {
+                        Ok(img) => Some(p.new_resize_protocol(img)),
+                        Err(e) => {
+                            tracing::warn!(
+                                "/attach: thumbnail decode failed for {path_for_load}: {e}"
+                            );
+                            None
                         }
                     });
                     let _ = tx
@@ -1088,7 +1089,9 @@ mod tests {
         assert!(app.pending_attachments.is_empty());
         let rendered = rendered_text(&mut app);
         assert!(
-            rendered.iter().any(|l| l.contains("not a recognized image")),
+            rendered
+                .iter()
+                .any(|l| l.contains("not a recognized image")),
             "expected unrecognized-image error: {rendered:?}"
         );
     }
@@ -1186,9 +1189,7 @@ mod tests {
         assert!(app.pending_attachments.is_empty());
         let rendered = rendered_text(&mut app);
         assert!(
-            rendered
-                .iter()
-                .any(|l| l.contains("> /attach foo.png")),
+            rendered.iter().any(|l| l.contains("> /attach foo.png")),
             "voice transcription starting with /attach must render as plain user text: {rendered:?}"
         );
     }

--- a/crates/assistd/src/chat/app.rs
+++ b/crates/assistd/src/chat/app.rs
@@ -4,13 +4,16 @@
 //! and a handle to an `LlmBackend` for spawning generation tasks. The
 //! `on_*` methods are pure reducers; I/O is confined to `spawn_generation`.
 
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use assistd_core::{PresenceManager, PresenceState, SleepConfig, ToolRegistry, VoiceCaptureState};
 use assistd_llm::{LlmBackend, LlmEvent};
-use assistd_tools::ConfirmationRequest;
+use assistd_tools::{Attachment, ConfirmationRequest, load_image_attachment};
 use crossterm::event::{KeyCode, KeyEvent};
+use ratatui_image::picker::Picker;
+use ratatui_image::protocol::StatefulProtocol;
 use tokio::sync::{mpsc, oneshot};
 
 use super::gate::PendingConfirmation;
@@ -22,10 +25,105 @@ use super::vram::ResourceState;
 const SPINNER_CHARS: &[char] = &['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
 const NOTICE_HOLD: Duration = Duration::from_secs(3);
 
-#[derive(Debug)]
+/// One image staged by `/attach`, waiting to ride along with the user's
+/// next text submission.
+pub struct PendingAttachment {
+    /// Display name (file basename) shown in the `📎×N` indicator and
+    /// the user-prompt tag.
+    pub name: String,
+    pub mime: String,
+    /// Reserved for future use (token-budget hints) — held alongside the
+    /// bytes so we don't have to rescan on display.
+    #[allow(dead_code)]
+    pub size: usize,
+    pub bytes: Vec<u8>,
+    /// Pre-built terminal-graphics protocol for inline thumbnail
+    /// rendering. `None` on terminals without graphics support — the
+    /// `📎 attached: ...` info line still appears either way.
+    pub protocol: Option<StatefulProtocol>,
+}
+
+impl PendingAttachment {
+    fn into_parts(self) -> (Attachment, Option<StatefulProtocol>, String) {
+        (
+            Attachment::Image {
+                mime: self.mime,
+                bytes: self.bytes,
+            },
+            self.protocol,
+            self.name,
+        )
+    }
+}
+
+/// Where a `submit` was triggered from. Slash-command parsing only fires
+/// for `Typed` submissions so a voice transcription that happens to
+/// contain "/attach foo" goes to the model as plain text.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SubmitOrigin {
+    Typed,
+    Voice,
+}
+
+// `AttachLoaded`'s `bytes: Vec<u8>` and `protocol` push its size well
+// past the other variants — but it's a one-shot transient event flowing
+// through a bounded mpsc, so the size asymmetry is fine. Boxing the
+// payload would just trade one heap alloc per attach for two.
+#[allow(clippy::large_enum_variant)]
 pub enum ChatEvent {
     Llm(LlmEvent),
     LlmError(String),
+    /// `/attach <path>` finished reading + validating the file. Carries
+    /// everything the App needs to update the UI.
+    AttachLoaded {
+        /// Original path the user typed — kept for diagnostics; the
+        /// reducer only uses `name` for the visible label.
+        #[allow(dead_code)]
+        path: String,
+        name: String,
+        mime: String,
+        size: usize,
+        bytes: Vec<u8>,
+        /// Pre-built graphics-protocol state for the inline thumbnail.
+        /// `None` when the terminal doesn't support a graphics protocol
+        /// or image decoding failed (the bytes still get sent to the
+        /// LLM — only the local rendering fallback differs).
+        protocol: Option<StatefulProtocol>,
+    },
+    /// `/attach <path>` failed (missing file, unsupported format, etc.).
+    AttachFailed { path: String, message: String },
+}
+
+// Manual Debug because `StatefulProtocol` (inside `AttachLoaded.protocol`)
+// does not implement Debug. Hides the protocol blob behind a placeholder
+// so the rest of the variant fields stay debuggable.
+impl std::fmt::Debug for ChatEvent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ChatEvent::Llm(ev) => f.debug_tuple("Llm").field(ev).finish(),
+            ChatEvent::LlmError(msg) => f.debug_tuple("LlmError").field(msg).finish(),
+            ChatEvent::AttachLoaded {
+                path,
+                name,
+                mime,
+                size,
+                protocol,
+                ..
+            } => f
+                .debug_struct("AttachLoaded")
+                .field("path", path)
+                .field("name", name)
+                .field("mime", mime)
+                .field("size", size)
+                .field("has_thumbnail", &protocol.is_some())
+                .finish(),
+            ChatEvent::AttachFailed { path, message } => f
+                .debug_struct("AttachFailed")
+                .field("path", path)
+                .field("message", message)
+                .finish(),
+        }
+    }
 }
 
 /// Pending destructive-command prompt displayed as an overlay. Only one is
@@ -60,6 +158,16 @@ pub struct App {
     /// call+result pair becomes one `ToolBlock`. The agent loop is strictly
     /// serial — only one tool runs at a time — so a single slot suffices.
     pending_tool_call: Option<(String, String)>,
+    /// Images staged by `/attach`, drained into the user's next
+    /// submission. Persists across multiple `/attach` invocations so a
+    /// user can attach several images before sending a query.
+    pub pending_attachments: Vec<PendingAttachment>,
+    /// Terminal graphics-protocol picker, probed once at TUI startup.
+    /// `None` on terminals without Kitty / Sixel / iTerm2 support — in
+    /// that case `/attach` falls back to filename-only display.
+    /// Cloned into the spawned attach-load task so the worker can build
+    /// `StatefulProtocol`s without holding a lock back to the UI loop.
+    picker: Option<Picker>,
     client: Arc<dyn LlmBackend>,
     tools: Arc<ToolRegistry>,
     max_iterations: u32,
@@ -67,6 +175,7 @@ pub struct App {
 }
 
 impl App {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         client: Arc<dyn LlmBackend>,
         tools: Arc<ToolRegistry>,
@@ -75,6 +184,7 @@ impl App {
         model_name: String,
         sleep_cfg: SleepConfig,
         presence: Option<Arc<PresenceManager>>,
+        picker: Option<Picker>,
     ) -> Self {
         let presence_state = presence.as_ref().map(|p| p.state());
         Self {
@@ -94,6 +204,8 @@ impl App {
             modal: None,
             listening: VoiceCaptureState::Idle,
             pending_tool_call: None,
+            pending_attachments: Vec::new(),
+            picker,
             client,
             tools,
             max_iterations,
@@ -180,11 +292,7 @@ impl App {
         match self.input.on_key(ev) {
             InputAction::None => {}
             InputAction::Submit(text) => {
-                if self.generating {
-                    self.set_notice("still generating — please wait");
-                } else {
-                    self.submit(text);
-                }
+                self.submit_with_origin(text, SubmitOrigin::Typed);
             }
             InputAction::Quit => {
                 // Closing during a pending modal isn't currently
@@ -226,7 +334,9 @@ impl App {
     /// Handle a completed transcription from the PTT pipeline. Empty
     /// strings (VAD trimmed everything) surface as a brief notice.
     /// Non-empty text is auto-submitted to the LLM via the same path
-    /// as typing into the input line.
+    /// as typing into the input line, but with `Voice` origin so a
+    /// transcription containing "/attach" is treated as plain text
+    /// rather than parsed as a slash command.
     pub fn on_transcription(&mut self, text: String) {
         if text.trim().is_empty() {
             self.set_notice("no speech detected");
@@ -236,7 +346,7 @@ impl App {
             self.set_notice("still generating — transcription dropped");
             return;
         }
-        self.submit(text);
+        self.submit_with_origin(text, SubmitOrigin::Voice);
     }
 
     /// Surface a non-fatal voice pipeline error as a TUI notice. The
@@ -310,6 +420,31 @@ impl App {
                 self.output.push_error(&msg);
                 self.generating = false;
             }
+            ChatEvent::AttachLoaded {
+                name,
+                mime,
+                size,
+                bytes,
+                protocol,
+                ..
+            } => {
+                let label =
+                    format!("📎 attached: {name} ({mime}, {})", human_size_short(size));
+                self.output.push_info(&label);
+                self.set_notice(&format!("📎 {name} attached"));
+                self.pending_attachments.push(PendingAttachment {
+                    name,
+                    mime,
+                    size,
+                    bytes,
+                    protocol,
+                });
+            }
+            ChatEvent::AttachFailed { path, message } => {
+                self.output
+                    .push_error(&format!("/attach {path}: {message}"));
+                self.set_notice(&format!("📎 {path}: {message}"));
+            }
         }
     }
 
@@ -330,20 +465,126 @@ impl App {
         self.notice = Some((text.to_string(), Instant::now()));
     }
 
-    fn submit(&mut self, text: String) {
-        self.begin_submit(&text);
-        self.spawn_generation(text);
+    fn submit_with_origin(&mut self, text: String, origin: SubmitOrigin) {
+        if origin == SubmitOrigin::Typed {
+            if let Some(rest) = text.strip_prefix("/attach ") {
+                self.handle_attach(rest.trim());
+                return;
+            }
+            // Reject a bare `/attach` (no path) early so we don't ship the
+            // literal string to the LLM and waste a turn.
+            if text.trim() == "/attach" {
+                self.output
+                    .push_error("/attach: expected a path. Usage: /attach <path>");
+                self.set_notice("/attach: missing path");
+                return;
+            }
+        }
+        if self.generating {
+            self.set_notice("still generating — please wait");
+            return;
+        }
+        let pending = std::mem::take(&mut self.pending_attachments);
+        let attachment_names: Vec<String> = pending.iter().map(|a| a.name.clone()).collect();
+        let mut attachments: Vec<Attachment> = Vec::with_capacity(pending.len());
+        let mut thumbnails: Vec<(String, StatefulProtocol)> = Vec::new();
+        for p in pending {
+            let (att, proto, name) = p.into_parts();
+            attachments.push(att);
+            if let Some(pr) = proto {
+                thumbnails.push((name, pr));
+            }
+        }
+        self.begin_submit(&text, &attachment_names);
+        for (name, protocol) in thumbnails {
+            self.output.push_thumbnail(name, protocol);
+        }
+        self.spawn_generation(text, attachments);
     }
 
-    fn begin_submit(&mut self, text: &str) {
-        self.output.push_user(text);
+    fn begin_submit(&mut self, text: &str, attachment_names: &[String]) {
+        if attachment_names.is_empty() {
+            self.output.push_user(text);
+        } else {
+            self.output.push_user_with_attachments(text, attachment_names);
+        }
         self.output.reset_scroll();
         self.output.begin_assistant();
         self.throughput.reset();
         self.generating = true;
     }
 
-    fn spawn_generation(&self, text: String) {
+    fn handle_attach(&mut self, raw: &str) {
+        let args = match shlex::split(raw) {
+            Some(v) => v,
+            None => {
+                self.output
+                    .push_error("/attach: unterminated quote in path");
+                self.set_notice("/attach: bad quoting");
+                return;
+            }
+        };
+        if args.len() != 1 {
+            self.output.push_error(&format!(
+                "/attach: expected exactly one path, got {}",
+                args.len()
+            ));
+            self.set_notice("/attach: need one path");
+            return;
+        }
+        let path = args.into_iter().next().expect("len == 1 checked above");
+        let name = PathBuf::from(&path)
+            .file_name()
+            .map(|f| f.to_string_lossy().into_owned())
+            .unwrap_or_else(|| path.clone());
+        self.set_notice(&format!("📎 reading {name}…"));
+        let tx = self.chat_tx.clone();
+        let picker = self.picker.clone();
+        let path_for_load = path.clone();
+        tokio::spawn(async move {
+            match load_image_attachment(std::path::Path::new(&path_for_load)).await {
+                Ok((Attachment::Image { mime, bytes }, size)) => {
+                    // Build the graphics-protocol thumbnail when the
+                    // terminal supports it. `image::load_from_memory`
+                    // can fail on rare valid-but-unusual encodings (e.g.
+                    // 16-bit PNGs the `image` crate doesn't enable by
+                    // default) — fall back to filename-only display in
+                    // that case rather than failing the whole attach.
+                    let protocol = picker.and_then(|p| {
+                        match image::load_from_memory(&bytes) {
+                            Ok(img) => Some(p.new_resize_protocol(img)),
+                            Err(e) => {
+                                tracing::warn!(
+                                    "/attach: thumbnail decode failed for {path_for_load}: {e}"
+                                );
+                                None
+                            }
+                        }
+                    });
+                    let _ = tx
+                        .send(ChatEvent::AttachLoaded {
+                            path: path_for_load,
+                            name,
+                            mime,
+                            size,
+                            bytes,
+                            protocol,
+                        })
+                        .await;
+                }
+                Err(e) => {
+                    let _ = tx
+                        .send(ChatEvent::AttachFailed {
+                            path: path_for_load,
+                            message: e.user_message(),
+                        })
+                        .await;
+                }
+            }
+        });
+    }
+
+    fn spawn_generation(&self, text: String, attachments: Vec<Attachment>) {
         let client = self.client.clone();
         let tools = self.tools.clone();
         let max_iterations = self.max_iterations;
@@ -378,8 +619,15 @@ impl App {
                     }
                 }
             });
-            let result =
-                assistd_core::run_agent_turn(client, tools, max_iterations, text, llm_tx).await;
+            let result = assistd_core::run_agent_turn(
+                client,
+                tools,
+                max_iterations,
+                text,
+                attachments,
+                llm_tx,
+            )
+            .await;
             let _ = forwarder.await;
             if let Err(e) = result {
                 let _ = tx.send(ChatEvent::LlmError(e.to_string())).await;
@@ -393,6 +641,24 @@ fn presence_label(s: PresenceState) -> &'static str {
         PresenceState::Active => "active",
         PresenceState::Drowsy => "drowsy",
         PresenceState::Sleeping => "sleeping",
+    }
+}
+
+/// Compact bytes-to-human formatter for the `📎 attached: ...` line.
+/// Mirrors `assistd_tools::commands::cat::human_size` but is duplicated
+/// here so the chat TUI doesn't depend on a `pub(crate)` helper.
+fn human_size_short(n: usize) -> String {
+    const KB: usize = 1024;
+    const MB: usize = KB * 1024;
+    const GB: usize = MB * 1024;
+    if n >= GB {
+        format!("{:.1}GB", n as f64 / GB as f64)
+    } else if n >= MB {
+        format!("{:.1}MB", n as f64 / MB as f64)
+    } else if n >= KB {
+        format!("{}KB", n / KB)
+    } else {
+        format!("{n}B")
     }
 }
 
@@ -420,6 +686,7 @@ mod tests {
             tx,
             "test-model".into(),
             test_sleep_cfg(),
+            None,
             None,
         );
         (app, rx)
@@ -615,7 +882,7 @@ mod tests {
     #[tokio::test]
     async fn echo_backend_spawn_yields_delta_then_done() {
         let (app, mut rx) = test_app();
-        app.spawn_generation("hello".into());
+        app.spawn_generation("hello".into(), Vec::new());
         let first = rx.recv().await.expect("delta");
         let second = rx.recv().await.expect("done");
         match first {
@@ -638,8 +905,9 @@ mod tests {
             "test-model".into(),
             test_sleep_cfg(),
             None,
+            None,
         );
-        app.spawn_generation("hello".into());
+        app.spawn_generation("hello".into(), Vec::new());
         let ev = rx.recv().await.expect("error event");
         match ev {
             ChatEvent::LlmError(msg) => assert!(msg.contains("server down")),
@@ -735,5 +1003,208 @@ mod tests {
         let (mut app, _rx) = test_app();
         app.on_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE));
         assert!(app.input.buffer().is_empty());
+    }
+
+    // --- /attach slash command -------------------------------------------
+
+    /// Minimal valid 1×1 PNG that `infer` recognizes as `image/png`.
+    /// Same bytes used by `assistd-tools::commands::see` tests so we
+    /// know the loader accepts them.
+    const PNG_BYTES: &[u8] = &[
+        0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44,
+        0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00, 0x1F,
+        0x15, 0xC4, 0x89, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9C, 0x63, 0x00,
+        0x01, 0x00, 0x00, 0x05, 0x00, 0x01, 0x0D, 0x0A, 0x2D, 0xB4, 0x00, 0x00, 0x00, 0x00, 0x49,
+        0x45, 0x4E, 0x44, 0xAE, 0x42, 0x60, 0x82,
+    ];
+
+    /// Drive an Enter on `text` then drain pending `AttachLoaded` /
+    /// `AttachFailed` events so the App applies them. Mirrors what the
+    /// real event loop does between `events.next()` and `chat_rx.recv`.
+    async fn attach_and_drain(app: &mut App, rx: &mut mpsc::Receiver<ChatEvent>, text: &str) {
+        for c in text.chars() {
+            app.on_key(typed(c));
+        }
+        app.on_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        // First event: either AttachLoaded or AttachFailed.
+        if let Some(ev) = rx.recv().await {
+            app.on_llm_event(ev);
+        }
+    }
+
+    #[tokio::test]
+    async fn attach_png_stages_attachment_and_renders_info_line() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("shot.png");
+        tokio::fs::write(&path, PNG_BYTES).await.unwrap();
+
+        let (mut app, mut rx) = test_app();
+        attach_and_drain(&mut app, &mut rx, &format!("/attach {}", path.display())).await;
+
+        assert_eq!(
+            app.pending_attachments.len(),
+            1,
+            "one image staged after /attach"
+        );
+        let staged = &app.pending_attachments[0];
+        assert_eq!(staged.name, "shot.png");
+        assert_eq!(staged.mime, "image/png");
+        let rendered = rendered_text(&mut app);
+        assert!(
+            rendered
+                .iter()
+                .any(|l| l.contains("📎 attached: shot.png") && l.contains("image/png")),
+            "info line missing in: {rendered:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn attach_missing_path_pushes_error_and_stages_nothing() {
+        let (mut app, mut rx) = test_app();
+        attach_and_drain(&mut app, &mut rx, "/attach /nonexistent/missing.png").await;
+
+        assert!(
+            app.pending_attachments.is_empty(),
+            "no attachment staged on error"
+        );
+        let rendered = rendered_text(&mut app);
+        assert!(
+            rendered
+                .iter()
+                .any(|l| l.contains("/attach") && l.contains("file not found")),
+            "expected error line, got: {rendered:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn attach_text_file_is_rejected_as_unrecognized() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("notes.txt");
+        tokio::fs::write(&path, b"not an image").await.unwrap();
+
+        let (mut app, mut rx) = test_app();
+        attach_and_drain(&mut app, &mut rx, &format!("/attach {}", path.display())).await;
+
+        assert!(app.pending_attachments.is_empty());
+        let rendered = rendered_text(&mut app);
+        assert!(
+            rendered.iter().any(|l| l.contains("not a recognized image")),
+            "expected unrecognized-image error: {rendered:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn attach_gif_is_rejected_by_format_allowlist() {
+        // GIF89a header — `infer` flags as image/gif; allowlist rejects.
+        const GIF_BYTES: &[u8] = &[
+            0x47, 0x49, 0x46, 0x38, 0x39, 0x61, 0x01, 0x00, 0x01, 0x00, 0x80, 0x00, 0x00, 0xFF,
+            0xFF, 0xFF, 0x00, 0x00, 0x00, 0x21, 0xF9, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x2C,
+            0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x02, 0x02, 0x44, 0x01, 0x00,
+            0x3B,
+        ];
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("anim.gif");
+        tokio::fs::write(&path, GIF_BYTES).await.unwrap();
+
+        let (mut app, mut rx) = test_app();
+        attach_and_drain(&mut app, &mut rx, &format!("/attach {}", path.display())).await;
+
+        assert!(app.pending_attachments.is_empty());
+        // Long error messages may wrap across multiple visual lines —
+        // join before searching so the test isn't sensitive to width.
+        let joined = rendered_text(&mut app).join(" ");
+        assert!(
+            joined.contains("unsupported image format") && joined.contains("image/gif"),
+            "expected unsupported-format error: {joined}"
+        );
+    }
+
+    #[tokio::test]
+    async fn attach_then_submit_drains_pending_and_passes_attachments() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("a.png");
+        tokio::fs::write(&path, PNG_BYTES).await.unwrap();
+
+        let (mut app, mut rx) = test_app();
+        attach_and_drain(&mut app, &mut rx, &format!("/attach {}", path.display())).await;
+        assert_eq!(app.pending_attachments.len(), 1);
+
+        // Submitting plain text now should drain the attachment.
+        for c in "hi".chars() {
+            app.on_key(typed(c));
+        }
+        app.on_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        assert!(
+            app.pending_attachments.is_empty(),
+            "submit must drain pending_attachments"
+        );
+        let rendered = rendered_text(&mut app);
+        assert!(
+            rendered
+                .iter()
+                .any(|l| l.contains("> hi") && l.contains("📎 a.png")),
+            "user prompt should include 📎 tag: {rendered:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn attach_twice_stages_both_then_drains_both() {
+        let dir = tempfile::tempdir().unwrap();
+        let p1 = dir.path().join("first.png");
+        let p2 = dir.path().join("second.png");
+        tokio::fs::write(&p1, PNG_BYTES).await.unwrap();
+        tokio::fs::write(&p2, PNG_BYTES).await.unwrap();
+
+        let (mut app, mut rx) = test_app();
+        attach_and_drain(&mut app, &mut rx, &format!("/attach {}", p1.display())).await;
+        attach_and_drain(&mut app, &mut rx, &format!("/attach {}", p2.display())).await;
+        assert_eq!(app.pending_attachments.len(), 2);
+
+        for c in "go".chars() {
+            app.on_key(typed(c));
+        }
+        app.on_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        assert!(app.pending_attachments.is_empty());
+        let rendered = rendered_text(&mut app);
+        // Multi-attachment tag mentions both filenames + count.
+        assert!(
+            rendered
+                .iter()
+                .any(|l| l.contains("first.png") && l.contains("second.png")),
+            "multi-attachment user tag missing names: {rendered:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn voice_transcription_with_slash_attach_is_treated_as_text() {
+        // A transcription that happens to start with "/attach" must
+        // NOT trigger file I/O — it's just spoken text. After
+        // submission we expect a regular user output line and no
+        // staged attachment.
+        let (mut app, _rx) = test_app();
+        app.on_transcription("/attach foo.png".into());
+        assert!(app.pending_attachments.is_empty());
+        let rendered = rendered_text(&mut app);
+        assert!(
+            rendered
+                .iter()
+                .any(|l| l.contains("> /attach foo.png")),
+            "voice transcription starting with /attach must render as plain user text: {rendered:?}"
+        );
+    }
+
+    #[test]
+    fn attach_with_no_path_pushes_error() {
+        let (mut app, _rx) = test_app();
+        for c in "/attach".chars() {
+            app.on_key(typed(c));
+        }
+        app.on_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        assert!(app.pending_attachments.is_empty());
+        let rendered = rendered_text(&mut app);
+        assert!(
+            rendered.iter().any(|l| l.contains("expected a path")),
+            "missing usage error: {rendered:?}"
+        );
     }
 }

--- a/crates/assistd/src/chat/mod.rs
+++ b/crates/assistd/src/chat/mod.rs
@@ -29,6 +29,7 @@ use crossterm::{cursor, execute, terminal};
 use futures_util::StreamExt;
 use ratatui::Terminal;
 use ratatui::backend::CrosstermBackend;
+use ratatui_image::picker::{Picker, ProtocolType};
 use tokio::signal::unix::{SignalKind, signal};
 use tokio::sync::{mpsc, watch};
 use tracing::info;
@@ -201,6 +202,39 @@ async fn run_tui(
     }));
     let _guard = TerminalGuard;
 
+    // Probe terminal graphics support immediately after entering the
+    // alternate screen and before reading any events (per
+    // `Picker::from_query_stdio` docs). Halfblocks is treated as "no
+    // graphics" so `/attach` falls back to filename-only display on
+    // non-graphics terminals — chunky ASCII thumbnails are gimmicky.
+    let picker = match Picker::from_query_stdio() {
+        Ok(p) if matches!(
+            p.protocol_type(),
+            ProtocolType::Kitty | ProtocolType::Sixel | ProtocolType::Iterm2
+        ) =>
+        {
+            tracing::info!(
+                "terminal graphics: {:?} (font_size {:?})",
+                p.protocol_type(),
+                p.font_size()
+            );
+            Some(p)
+        }
+        Ok(p) => {
+            tracing::info!(
+                "terminal graphics: {:?} → /attach will display filenames only",
+                p.protocol_type()
+            );
+            None
+        }
+        Err(e) => {
+            tracing::info!(
+                "terminal graphics probe failed ({e}); /attach will display filenames only"
+            );
+            None
+        }
+    };
+
     let backend = CrosstermBackend::new(std::io::stdout());
     let mut terminal = Terminal::new(backend).context("Terminal::new")?;
 
@@ -213,6 +247,7 @@ async fn run_tui(
         model_name,
         sleep_cfg,
         presence.clone(),
+        picker,
     );
 
     if let Some(err) = startup_error {

--- a/crates/assistd/src/chat/mod.rs
+++ b/crates/assistd/src/chat/mod.rs
@@ -208,10 +208,11 @@ async fn run_tui(
     // graphics" so `/attach` falls back to filename-only display on
     // non-graphics terminals — chunky ASCII thumbnails are gimmicky.
     let picker = match Picker::from_query_stdio() {
-        Ok(p) if matches!(
-            p.protocol_type(),
-            ProtocolType::Kitty | ProtocolType::Sixel | ProtocolType::Iterm2
-        ) =>
+        Ok(p)
+            if matches!(
+                p.protocol_type(),
+                ProtocolType::Kitty | ProtocolType::Sixel | ProtocolType::Iterm2
+            ) =>
         {
             tracing::info!(
                 "terminal graphics: {:?} (font_size {:?})",

--- a/crates/assistd/src/chat/output.rs
+++ b/crates/assistd/src/chat/output.rs
@@ -8,6 +8,12 @@
 
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
+use ratatui_image::protocol::StatefulProtocol;
+
+/// Reserved-row footprint for an inline `OutputItem::Thumbnail`. Picked
+/// to roughly match the height of an avatar-sized thumbnail without
+/// dominating the viewport.
+pub const THUMBNAIL_ROWS: u16 = 8;
 
 /// A single tool invocation displayed as a cohesive block: command,
 /// captured output (already condensed by Layer 2 to ≤200 lines / ≤50 KB),
@@ -27,13 +33,22 @@ pub struct ToolBlock {
     pub expanded: bool,
 }
 
-#[derive(Debug)]
+/// Inline thumbnail rendered via `ratatui-image`. The protocol is the
+/// pre-built per-image graphics state — its lifetime is the OutputPane.
+pub struct ThumbnailItem {
+    /// Filename shown in the placeholder line if the thumbnail's row
+    /// range is scrolled out of the viewport. Also used as the
+    /// `title` line above the image when rendered.
+    pub name: String,
+    pub protocol: StatefulProtocol,
+}
+
 enum OutputItem {
     Text(Line<'static>),
     Tool(ToolBlock),
+    Thumbnail(ThumbnailItem),
 }
 
-#[derive(Debug)]
 pub struct OutputPane {
     items: Vec<OutputItem>,
     open_assistant: Option<usize>,
@@ -64,6 +79,37 @@ impl OutputPane {
         self.items.push(OutputItem::Text(single_span_line(
             format!("> {text}"),
             user_style(),
+        )));
+        self.dirty = true;
+    }
+
+    /// Push the user's prompt line with a trailing 📎 tag listing every
+    /// attachment that rode along with the turn — so scrollback shows
+    /// which turn carried the image even after `pending_attachments` is
+    /// drained.
+    pub fn push_user_with_attachments(&mut self, text: &str, names: &[String]) {
+        self.close_open_assistant();
+        let tag = if names.len() == 1 {
+            format!("  📎 {}", names[0])
+        } else {
+            format!("  📎 {} ({} files)", names.join(", "), names.len())
+        };
+        self.items.push(OutputItem::Text(single_span_line(
+            format!("> {text}{tag}"),
+            user_style(),
+        )));
+        self.dirty = true;
+    }
+
+    /// Push a styled informational line — used by `/attach` to confirm
+    /// "📎 attached: name.png (image/png, 12 KB)" without polluting the
+    /// error stream. Distinct from `push_user` (no `> ` prefix) and
+    /// `push_error` (no `!! ` prefix or red color).
+    pub fn push_info(&mut self, text: &str) {
+        self.close_open_assistant();
+        self.items.push(OutputItem::Text(single_span_line(
+            text.to_string(),
+            info_style(),
         )));
         self.dirty = true;
     }
@@ -233,8 +279,9 @@ impl OutputPane {
     fn rewrap(&self, width: u16) -> Vec<Line<'static>> {
         if width == 0 {
             // Degraded path: render text items raw, tool blocks as a
-            // single unwrapped header line. Keeps the zero-width test
-            // green and avoids `textwrap` calls with width 0.
+            // single unwrapped header line, thumbnails as a one-line
+            // placeholder. Keeps the zero-width test green and avoids
+            // `textwrap` calls with width 0.
             return self
                 .items
                 .iter()
@@ -242,6 +289,9 @@ impl OutputPane {
                     OutputItem::Text(l) => l.clone(),
                     OutputItem::Tool(b) => {
                         single_span_line(format!("$ {}", b.command), tool_call_style())
+                    }
+                    OutputItem::Thumbnail(t) => {
+                        single_span_line(format!("📎 {}", t.name), info_style())
                     }
                 })
                 .collect();
@@ -251,6 +301,7 @@ impl OutputPane {
             match item {
                 OutputItem::Text(line) => wrap_line_into(&mut out, line, width),
                 OutputItem::Tool(b) => render_tool_block(&mut out, b, width),
+                OutputItem::Thumbnail(t) => render_thumbnail_placeholder(&mut out, t),
             }
         }
         out
@@ -266,9 +317,143 @@ impl OutputPane {
     fn text_at_mut(&mut self, idx: usize) -> Option<&mut Line<'static>> {
         match self.items.get_mut(idx)? {
             OutputItem::Text(line) => Some(line),
-            OutputItem::Tool(_) => None,
+            OutputItem::Tool(_) | OutputItem::Thumbnail(_) => None,
         }
     }
+
+    /// Append an inline image thumbnail. Reserves [`THUMBNAIL_ROWS`]
+    /// blank wrapped rows so layout math stays correct; the image
+    /// itself is drawn over those rows by the renderer.
+    pub fn push_thumbnail(&mut self, name: String, protocol: StatefulProtocol) {
+        self.close_open_assistant();
+        self.items
+            .push(OutputItem::Thumbnail(ThumbnailItem { name, protocol }));
+        self.dirty = true;
+    }
+
+    /// Walk the wrapped output once and collect, for each
+    /// `OutputItem::Thumbnail`, a `(start_row, item_idx)` pair. The
+    /// renderer uses this layout map to overlay
+    /// `ratatui_image::StatefulImage` widgets on the reserved rows.
+    pub fn thumbnail_layout(&mut self, width: u16) -> Vec<ThumbnailSlot> {
+        // Force the wrapped cache so `wrap_cache` reflects the current
+        // items; we walk items in their original order and accumulate
+        // the same per-item row counts that `rewrap` produced, so the
+        // returned `start_row` lines up with the wrapped output.
+        let _ = self.wrapped(width);
+        let mut slots = Vec::new();
+        let mut row: usize = 0;
+        for (idx, item) in self.items.iter().enumerate() {
+            let height = match item {
+                OutputItem::Text(line) => wrapped_text_rows(line, width),
+                OutputItem::Tool(b) => wrapped_tool_rows(b, width),
+                OutputItem::Thumbnail(_) => THUMBNAIL_ROWS as usize,
+            };
+            if matches!(item, OutputItem::Thumbnail(_)) {
+                slots.push(ThumbnailSlot {
+                    item_idx: idx,
+                    start_row: row,
+                    height,
+                });
+            }
+            row += height;
+        }
+        slots
+    }
+
+    /// Mutable access to a thumbnail's `StatefulProtocol`, indexed by
+    /// `OutputItem` position. The renderer needs `&mut StatefulProtocol`
+    /// to call `frame.render_stateful_widget`. Returns `None` if the
+    /// item at `idx` isn't a thumbnail.
+    pub fn thumbnail_protocol_mut(&mut self, idx: usize) -> Option<&mut StatefulProtocol> {
+        match self.items.get_mut(idx)? {
+            OutputItem::Thumbnail(t) => Some(&mut t.protocol),
+            _ => None,
+        }
+    }
+}
+
+/// Layout entry for one thumbnail in the wrapped output, returned by
+/// [`OutputPane::thumbnail_layout`] for the renderer to overlay images.
+#[derive(Debug, Clone, Copy)]
+pub struct ThumbnailSlot {
+    pub item_idx: usize,
+    /// Row index (0-based) in the full wrapped output where this
+    /// thumbnail's reserved area begins.
+    pub start_row: usize,
+    /// Number of wrapped rows the thumbnail reserves. Today this is
+    /// always [`THUMBNAIL_ROWS`] but kept as a field so future per-item
+    /// sizing doesn't change the API.
+    pub height: usize,
+}
+
+/// Reserve [`THUMBNAIL_ROWS`] blank lines so layout math stays correct.
+/// The first row carries a "📎 name" caption so non-graphics terminals
+/// (and the placeholder rows that show through if rendering is skipped)
+/// still tell the user what they're looking at.
+fn render_thumbnail_placeholder(out: &mut Vec<Line<'static>>, t: &ThumbnailItem) {
+    out.push(single_span_line(format!("📎 {}", t.name), info_style()));
+    for _ in 1..THUMBNAIL_ROWS {
+        out.push(Line::from(""));
+    }
+}
+
+fn wrapped_text_rows(line: &Line<'static>, width: u16) -> usize {
+    if width == 0 {
+        return 1;
+    }
+    let content: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+    if content.is_empty() {
+        return 1;
+    }
+    let n = textwrap::wrap(&content, width as usize).len();
+    n.max(1)
+}
+
+fn wrapped_tool_rows(b: &ToolBlock, width: u16) -> usize {
+    // Mirrors `render_tool_block` row accounting: header + body + footer
+    // + trailing blank, all wrapped to `inner_w = width - 2` (bar prefix).
+    if width == 0 {
+        return 1;
+    }
+    let inner_w = width.saturating_sub(2).max(1) as usize;
+    let mut rows: usize = 0;
+    rows += textwrap::wrap(&format!("$ {}", b.command), inner_w)
+        .len()
+        .max(1);
+    let body_lines = split_body(&b.output);
+    let collapsed = !b.expanded && body_lines.len() > COLLAPSE_THRESHOLD;
+    let stderr_idxs: Vec<usize> = body_lines
+        .iter()
+        .enumerate()
+        .filter(|(_, l)| l.starts_with("[stderr] "))
+        .map(|(i, _)| i)
+        .collect();
+    let visible_idxs: Vec<usize> = if collapsed {
+        let mut idxs: Vec<usize> = (0..COLLAPSED_HEAD_LINES.min(body_lines.len())).collect();
+        for &si in &stderr_idxs {
+            if !idxs.contains(&si) {
+                idxs.push(si);
+            }
+        }
+        idxs.sort_unstable();
+        idxs
+    } else {
+        (0..body_lines.len()).collect()
+    };
+    for i in &visible_idxs {
+        let n = textwrap::wrap(&body_lines[*i], inner_w).len().max(1);
+        rows += n;
+    }
+    if collapsed {
+        let hidden = body_lines.len() - visible_idxs.len();
+        if hidden > 0 {
+            // The collapsed-tail line is short; treat it as one row.
+            rows += 1;
+        }
+    }
+    // Footer + trailing blank.
+    rows + 2
 }
 
 fn wrap_line_into(out: &mut Vec<Line<'static>>, line: &Line<'static>, width: u16) {
@@ -450,6 +635,10 @@ fn error_style() -> Style {
     Style::default().fg(Color::Red).add_modifier(Modifier::BOLD)
 }
 
+fn info_style() -> Style {
+    Style::default().fg(Color::Cyan).add_modifier(Modifier::DIM)
+}
+
 fn tool_call_style() -> Style {
     Style::default().fg(Color::Blue).add_modifier(Modifier::DIM)
 }
@@ -487,6 +676,7 @@ mod tests {
         match it {
             OutputItem::Text(l) => line_text(l),
             OutputItem::Tool(b) => format!("[tool:{}]", b.command),
+            OutputItem::Thumbnail(t) => format!("[thumb:{}]", t.name),
         }
     }
 

--- a/crates/assistd/src/chat/ui.rs
+++ b/crates/assistd/src/chat/ui.rs
@@ -10,8 +10,10 @@ use ratatui::layout::{Constraint, Layout, Position, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span, Text};
 use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
+use ratatui_image::StatefulImage;
 
 use super::app::{App, ConfirmationModal};
+use super::output::THUMBNAIL_ROWS;
 use super::vram::{RamState, VramState};
 
 pub fn render(frame: &mut Frame, app: &mut App) {
@@ -95,10 +97,60 @@ fn render_output(frame: &mut Frame, area: Rect, app: &mut App) {
     if area.width == 0 || area.height == 0 {
         return;
     }
+    // Snapshot the wrapped layout (thumbnails reserve THUMBNAIL_ROWS
+    // blank lines under their captions). Computed once so the same
+    // start/scroll values feed both the text Paragraph and the
+    // thumbnail overlay below.
+    let slots = app.output.thumbnail_layout(area.width);
     let (lines, start) = app.output.render_view(area.width, area.height);
     let text = Text::from(lines.to_vec());
     let para = Paragraph::new(text).scroll((start, 0));
     frame.render_widget(para, area);
+
+    // Overlay one `StatefulImage` per fully-visible thumbnail slot.
+    // Skip thumbnails whose reserved rows are partially or fully
+    // scrolled out — the underlying placeholder line keeps the
+    // filename visible in those cases.
+    let viewport_top = start as usize;
+    let viewport_bottom = viewport_top.saturating_add(area.height as usize);
+    // The placeholder caption ("📎 name") sits on the first reserved
+    // row. Push the image down by one row so the caption stays legible
+    // and we don't overdraw it.
+    const CAPTION_ROWS: u16 = 1;
+    let image_height = THUMBNAIL_ROWS.saturating_sub(CAPTION_ROWS);
+    if image_height == 0 {
+        return;
+    }
+    for slot in slots {
+        let image_start = slot.start_row + CAPTION_ROWS as usize;
+        let image_end = slot.start_row + slot.height;
+        if image_start < viewport_top || image_end > viewport_bottom {
+            continue;
+        }
+        let local_row = (image_start - viewport_top) as u16;
+        if local_row >= area.height {
+            continue;
+        }
+        let avail = area.height - local_row;
+        let h = image_height.min(avail);
+        if h == 0 {
+            continue;
+        }
+        // Cap thumbnail width so a wide terminal doesn't render a
+        // billboard-sized image. 32 cells × image_height is roughly
+        // square-ish on typical font aspect ratios.
+        let w = area.width.min(32);
+        let rect = Rect {
+            x: area.x,
+            y: area.y + local_row,
+            width: w,
+            height: h,
+        };
+        let widget = StatefulImage::default();
+        if let Some(state) = app.output.thumbnail_protocol_mut(slot.item_idx) {
+            frame.render_stateful_widget(widget, rect, state);
+        }
+    }
 }
 
 fn render_status(frame: &mut Frame, area: Rect, app: &App) {
@@ -188,6 +240,25 @@ fn render_status(frame: &mut Frame, area: Rect, app: &App) {
             Style::default().fg(color).add_modifier(Modifier::BOLD),
         ));
         left_spans.push(Span::styled(format!(" {label}"), reversed));
+    }
+    // Persistent staged-attachment indicator. The 3-second `notice`
+    // pop is too ephemeral for state that gates the next submission —
+    // this stays visible until `submit` drains `pending_attachments`.
+    let pending_count = app.pending_attachments.len();
+    if pending_count > 0 {
+        left_spans.push(Span::raw(" "));
+        let label = if pending_count == 1 {
+            "📎×1".to_string()
+        } else {
+            format!("📎×{pending_count}")
+        };
+        left_spans.push(Span::styled(
+            label,
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD)
+                .add_modifier(Modifier::REVERSED),
+        ));
     }
     left_spans.push(Span::styled(format!(" │ {state}"), reversed));
     if let Some(r) = rate {


### PR DESCRIPTION
- load_image_attachment(path) shared helper with explicit PNG/JPEG/WebP allowlist + structured LoadImageError. SeeCommand refactored to call it.  
- LlmBackend::push_user(text, attachments) — trait signature unified to take attachments. LlamaChatClient branches to Conversation::push_user_with_attachments when non-empty                              
- run_agent_turn — accepts a Vec<Attachment> and forwards. IPC path passes empty (text-only Request::Query unchanged).                              
- TUI App — new pending_attachments, SubmitOrigin (slash-command parsing only fires on Typed), handle_attach spawns the load + decode task, ChatEvent::AttachLoaded/AttachFailed events, drained into the agent turn on submit.                                                                
- Thumbnails via ratatui-image — Picker::from_query_stdio() probes after entering the alt screen. On Kitty/Sixel/iTerm2 the bytes are decoded once into a StatefulProtocol; on other terminals the protocol is None and falls back to filename-only. OutputItem::Thumbnail reserves 8 rows; render_output overlays StatefulImage widgets on fully-visible thumbnailslots.
- Status bar — persistent 📎×N indicator (cyan/bold) shown until submit drains.                                                                   
- Output — info line 📎 attached: name.png (image/png, 12 KB), plus user-prompt tag > what is this?  📎 name.png. 