### PR TITLE
Validate vision model support at startup.

### DIFF
--- a/crates/assistd-core/src/lib.rs
+++ b/crates/assistd-core/src/lib.rs
@@ -95,10 +95,18 @@ use tracing::warn;
 /// `DenyAllGate` (headless path: no interactive confirmation available);
 /// the chat TUI passes a `TuiGate` that forwards prompts to the user via
 /// a modal overlay.
+///
+/// `vision_enabled` reflects a one-shot `/props` probe of the running
+/// llama-server (see [`assistd_llm::detect_vision_support`]). When `false`,
+/// the image-producing commands (`see`, `screenshot`) are still
+/// registered but their `run()` short-circuits to the convention
+/// `[error] …: vision not available …` line, and their `summary()` flips
+/// so the LLM sees the unavailability in its tool schema.
 pub fn build_tools(
     config: &Config,
     overflow_dir: PathBuf,
     gate: Arc<dyn ConfirmationGate>,
+    vision_enabled: bool,
 ) -> Result<Arc<ToolRegistry>> {
     if overflow_dir.exists() {
         std::fs::remove_dir_all(&overflow_dir).with_context(|| {
@@ -183,8 +191,8 @@ pub fn build_tools(
     commands.register(WcCommand);
     commands.register(EchoCommand);
     commands.register(WriteCommand::new(write_cfg));
-    commands.register(SeeCommand);
-    commands.register(ScreenshotCommand::new(screenshot_cfg));
+    commands.register(SeeCommand::new(vision_enabled));
+    commands.register(ScreenshotCommand::new(screenshot_cfg, vision_enabled));
     commands.register(WebCommand::new());
     commands.register(BashCommand::new(bash_cfg, sandbox, gate));
 

--- a/crates/assistd-llm/src/lib.rs
+++ b/crates/assistd-llm/src/lib.rs
@@ -9,7 +9,9 @@ pub mod chat;
 pub mod llama_server;
 
 pub use chat::{ChatClientError, LlamaChatClient};
-pub use llama_server::{LlamaServerControl, LlamaServerError, LlamaService, ReadyState};
+pub use llama_server::{
+    LlamaServerControl, LlamaServerError, LlamaService, ReadyState, detect_vision_support,
+};
 
 use anyhow::Result;
 use assistd_tools::Attachment;

--- a/crates/assistd-llm/src/llama_server/capabilities.rs
+++ b/crates/assistd-llm/src/llama_server/capabilities.rs
@@ -1,0 +1,184 @@
+//! Capability probe for the running llama-server.
+//!
+//! After [`super::LlamaService::start`] reports the child as ready
+//! (`/health` = 200), call [`detect_vision_support`] to decide whether
+//! the loaded model has a multimodal projector (mmproj) bundled.
+//! llama.cpp auto-loads the projector when the HF repo carries one
+//! alongside the text weights — there is no separate config flag to
+//! opt in. The only way to know is to ask the server.
+//!
+//! The probe intentionally fails-closed: any HTTP error, parse
+//! failure, or absent capability field collapses to
+//! `vision_enabled = false`. The image-producing tools (`see`,
+//! `screenshot`, `/attach`) refuse with a navigation-compliant
+//! `[error] …: vision not available …` line in that case, which is a
+//! safer default than silently sending image bytes the model will drop.
+//!
+//! Field-name spread: across the multimodal-merge era llama.cpp has
+//! exposed the capability under several different keys. We tolerate
+//! the spread by checking a small union: any of `has_multimodal`,
+//! `has_vision`, `multimodal`, or
+//! `default_generation_settings.multimodal` set to `true` enables
+//! vision. New names can be added here without touching call sites.
+
+use std::time::Duration;
+
+use serde_json::Value;
+use tracing::{debug, warn};
+
+const PROBE_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Returns `true` iff the running llama-server reports a loaded vision
+/// encoder. Returns `false` on any error (HTTP failure, non-200,
+/// malformed JSON) and logs at `warn` so the daemon's startup log
+/// captures the reason. The caller should treat a `false` result as
+/// "vision unavailable" and fall back accordingly.
+pub async fn detect_vision_support(host: &str, port: u16) -> bool {
+    let url = format!("http://{host}:{port}/props");
+    let client = match reqwest::Client::builder()
+        .no_proxy()
+        .timeout(PROBE_TIMEOUT)
+        .build()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            warn!(
+                target: "assistd::llama_server",
+                "vision capability probe: failed to build HTTP client: {e}; assuming no vision support"
+            );
+            return false;
+        }
+    };
+
+    let resp = match client.get(&url).send().await {
+        Ok(r) => r,
+        Err(e) => {
+            warn!(
+                target: "assistd::llama_server",
+                "vision capability probe: GET /props failed: {e}; assuming no vision support"
+            );
+            return false;
+        }
+    };
+    if !resp.status().is_success() {
+        warn!(
+            target: "assistd::llama_server",
+            "vision capability probe: GET /props returned {}; assuming no vision support",
+            resp.status()
+        );
+        return false;
+    }
+
+    let body: Value = match resp.json().await {
+        Ok(v) => v,
+        Err(e) => {
+            warn!(
+                target: "assistd::llama_server",
+                "vision capability probe: /props body was not JSON: {e}; assuming no vision support"
+            );
+            return false;
+        }
+    };
+
+    let supported = parse_vision_supported(&body);
+    debug!(
+        target: "assistd::llama_server",
+        "vision capability probe: /props parsed; vision_supported = {supported}"
+    );
+    supported
+}
+
+/// Inspect a parsed `/props` body for any field that signals
+/// multimodal/vision support. Tolerates the historical spread of
+/// field names in llama.cpp.
+fn parse_vision_supported(body: &Value) -> bool {
+    const TOP_LEVEL_KEYS: &[&str] = &["has_multimodal", "has_vision", "multimodal"];
+    for key in TOP_LEVEL_KEYS {
+        if body.get(*key).and_then(Value::as_bool) == Some(true) {
+            return true;
+        }
+    }
+    if let Some(settings) = body.get("default_generation_settings") {
+        if settings.get("multimodal").and_then(Value::as_bool) == Some(true) {
+            return true;
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn detects_top_level_has_multimodal_true() {
+        let body = json!({"has_multimodal": true, "total_slots": 1});
+        assert!(parse_vision_supported(&body));
+    }
+
+    #[test]
+    fn detects_top_level_has_vision_true() {
+        let body = json!({"has_vision": true});
+        assert!(parse_vision_supported(&body));
+    }
+
+    #[test]
+    fn detects_top_level_multimodal_true() {
+        let body = json!({"multimodal": true});
+        assert!(parse_vision_supported(&body));
+    }
+
+    #[test]
+    fn detects_nested_multimodal_under_default_generation_settings() {
+        let body = json!({
+            "default_generation_settings": {"multimodal": true, "temperature": 0.7},
+        });
+        assert!(parse_vision_supported(&body));
+    }
+
+    #[test]
+    fn ignores_field_when_explicitly_false() {
+        let body = json!({"has_multimodal": false, "has_vision": false});
+        assert!(!parse_vision_supported(&body));
+    }
+
+    #[test]
+    fn defaults_false_when_no_field_present() {
+        let body = json!({"total_slots": 1, "model_path": "/some/model.gguf"});
+        assert!(!parse_vision_supported(&body));
+    }
+
+    #[test]
+    fn nested_false_does_not_promote_to_true() {
+        let body = json!({
+            "default_generation_settings": {"multimodal": false},
+        });
+        assert!(!parse_vision_supported(&body));
+    }
+
+    #[test]
+    fn ignores_non_bool_field_value() {
+        // Future-proofing: a string "true" must NOT count. We require
+        // a JSON boolean to avoid accidentally enabling vision based on
+        // an unrelated string field that happens to share a name.
+        let body = json!({"has_multimodal": "true"});
+        assert!(!parse_vision_supported(&body));
+    }
+
+    #[test]
+    fn empty_object_is_not_vision_supported() {
+        let body = json!({});
+        assert!(!parse_vision_supported(&body));
+    }
+
+    #[test]
+    fn any_truthy_field_wins_even_if_others_false() {
+        let body = json!({
+            "has_multimodal": false,
+            "has_vision": true,
+            "multimodal": false,
+        });
+        assert!(parse_vision_supported(&body));
+    }
+}

--- a/crates/assistd-llm/src/llama_server/capabilities.rs
+++ b/crates/assistd-llm/src/llama_server/capabilities.rs
@@ -98,10 +98,10 @@ fn parse_vision_supported(body: &Value) -> bool {
             return true;
         }
     }
-    if let Some(settings) = body.get("default_generation_settings") {
-        if settings.get("multimodal").and_then(Value::as_bool) == Some(true) {
-            return true;
-        }
+    if let Some(settings) = body.get("default_generation_settings")
+        && settings.get("multimodal").and_then(Value::as_bool) == Some(true)
+    {
+        return true;
     }
     false
 }

--- a/crates/assistd-llm/src/llama_server/mod.rs
+++ b/crates/assistd-llm/src/llama_server/mod.rs
@@ -11,6 +11,7 @@
 //! managed server is a follow-up task.
 
 pub mod backoff;
+pub mod capabilities;
 pub mod control;
 pub mod error;
 pub mod health;
@@ -19,6 +20,7 @@ pub mod service;
 pub mod supervisor;
 
 pub use backoff::MAX_CONSECUTIVE_FAILURES;
+pub use capabilities::detect_vision_support;
 pub use control::LlamaServerControl;
 pub use error::LlamaServerError;
 pub use service::{LlamaService, ReadyState};

--- a/crates/assistd-tools/src/command.rs
+++ b/crates/assistd-tools/src/command.rs
@@ -309,7 +309,7 @@ mod tests {
             (
                 "see",
                 rt.block_on(run_cmd(
-                    SeeCommand,
+                    SeeCommand::default(),
                     vec!["/nonexistent/assistd-convention-test.png".into()],
                 )),
             ),
@@ -402,7 +402,7 @@ mod tests {
         reg.register(WcCommand);
         reg.register(EchoCommand);
         reg.register(WriteCommand::permissive_for_tests());
-        reg.register(SeeCommand);
+        reg.register(SeeCommand::default());
         reg.register(ScreenshotCommand::default());
         reg.register(WebCommand::new());
         reg.register(BashCommand::default());

--- a/crates/assistd-tools/src/commands/screenshot.rs
+++ b/crates/assistd-tools/src/commands/screenshot.rs
@@ -77,21 +77,28 @@ enum WaylandCompositor {
 
 pub struct ScreenshotCommand {
     cfg: Arc<ScreenshotPolicyCfg>,
+    /// Set at startup from a `/props` probe of the running llama-server.
+    /// When `false`, `run()` short-circuits to the vision-not-available
+    /// error without spawning the capture backend.
+    vision_enabled: bool,
 }
 
 impl ScreenshotCommand {
-    pub fn new(cfg: Arc<ScreenshotPolicyCfg>) -> Self {
-        Self { cfg }
+    pub fn new(cfg: Arc<ScreenshotPolicyCfg>, vision_enabled: bool) -> Self {
+        Self {
+            cfg,
+            vision_enabled,
+        }
     }
 }
 
 #[cfg(test)]
 impl Default for ScreenshotCommand {
-    /// Test-only default: auto-detect backend, 5-second timeout. Lets the
-    /// convention-compliance harness in `command.rs` construct an instance
-    /// without config plumbing.
+    /// Test-only default: auto-detect backend, 5-second timeout, vision
+    /// enabled. Lets the convention-compliance harness in `command.rs`
+    /// construct an instance without config plumbing.
     fn default() -> Self {
-        Self::new(Arc::new(ScreenshotPolicyCfg::default()))
+        Self::new(Arc::new(ScreenshotPolicyCfg::default()), true)
     }
 }
 
@@ -102,7 +109,11 @@ impl Command for ScreenshotCommand {
     }
 
     fn summary(&self) -> &'static str {
-        "capture the screen as a PNG and attach it for the next LLM turn"
+        if self.vision_enabled {
+            "capture the screen as a PNG and attach it for the next LLM turn"
+        } else {
+            "(unavailable: model has no vision encoder)"
+        }
     }
 
     fn help(&self) -> String {
@@ -134,6 +145,18 @@ impl Command for ScreenshotCommand {
     }
 
     async fn run(&self, input: CommandInput) -> Result<CommandOutput> {
+        if !self.vision_enabled {
+            return Ok(CommandOutput::failed(
+                1,
+                error_line(
+                    "screenshot",
+                    "vision not available: model does not support images",
+                    "Use",
+                    "a model with mmproj loaded",
+                )
+                .into_bytes(),
+            ));
+        }
         let target = match parse_args(&input.args) {
             Ok(t) => t,
             Err(msg) => {
@@ -869,6 +892,43 @@ mod tests {
     fn summary_under_80_chars() {
         let s = ScreenshotCommand::default().summary();
         assert!(s.len() <= 80, "summary is {} chars: {s:?}", s.len());
+    }
+
+    /// AC #3: when vision is disabled, `screenshot` short-circuits with
+    /// the exact wording "vision not available: model does not support
+    /// images" without spawning maim/grim.
+    #[tokio::test]
+    async fn vision_disabled_returns_exact_error() {
+        let cmd = ScreenshotCommand::new(Arc::new(ScreenshotPolicyCfg::default()), false);
+        let out = cmd
+            .run(CommandInput {
+                args: vec!["--full".into()],
+                stdin: Vec::new(),
+            })
+            .await
+            .unwrap();
+        assert_eq!(out.exit_code, 1);
+        assert!(out.stdout.is_empty());
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            stderr.contains(
+                "[error] screenshot: vision not available: model does not support images"
+            ),
+            "{stderr}"
+        );
+        assert!(
+            stderr.contains("Use: a model with mmproj loaded"),
+            "{stderr}"
+        );
+        assert!(out.attachments.is_empty());
+    }
+
+    #[test]
+    fn summary_changes_when_vision_disabled() {
+        let enabled = ScreenshotCommand::new(Arc::new(ScreenshotPolicyCfg::default()), true);
+        let disabled = ScreenshotCommand::new(Arc::new(ScreenshotPolicyCfg::default()), false);
+        assert!(enabled.summary().contains("capture the screen"));
+        assert!(disabled.summary().contains("unavailable"));
     }
 
     #[test]

--- a/crates/assistd-tools/src/commands/see.rs
+++ b/crates/assistd-tools/src/commands/see.rs
@@ -14,7 +14,29 @@ use crate::attachment::{LoadImageError, load_image_attachment};
 use crate::command::{Attachment, Command, CommandInput, CommandOutput, error_line, io_error_nav};
 use crate::commands::cat::human_size;
 
-pub struct SeeCommand;
+pub struct SeeCommand {
+    /// Set at startup from a `/props` probe of the running llama-server.
+    /// When `false`, `run()` short-circuits to the vision-not-available
+    /// error without touching the filesystem.
+    vision_enabled: bool,
+}
+
+impl SeeCommand {
+    pub fn new(vision_enabled: bool) -> Self {
+        Self { vision_enabled }
+    }
+}
+
+#[cfg(test)]
+impl Default for SeeCommand {
+    /// Test-only default: vision enabled. Lets the
+    /// convention-compliance harness in `command.rs` and the
+    /// per-command tests construct an instance without rethreading the
+    /// flag through every call site.
+    fn default() -> Self {
+        Self::new(true)
+    }
+}
 
 #[async_trait]
 impl Command for SeeCommand {
@@ -23,7 +45,11 @@ impl Command for SeeCommand {
     }
 
     fn summary(&self) -> &'static str {
-        "attach an image file as a vision input for the next LLM turn"
+        if self.vision_enabled {
+            "attach an image file as a vision input for the next LLM turn"
+        } else {
+            "(unavailable: model has no vision encoder)"
+        }
     }
 
     fn help(&self) -> String {
@@ -39,6 +65,18 @@ impl Command for SeeCommand {
     }
 
     async fn run(&self, input: CommandInput) -> Result<CommandOutput> {
+        if !self.vision_enabled {
+            return Ok(CommandOutput::failed(
+                1,
+                error_line(
+                    "see",
+                    "vision not available: model does not support images",
+                    "Use",
+                    "a model with mmproj loaded",
+                )
+                .into_bytes(),
+            ));
+        }
         if input.args.is_empty() {
             return Ok(CommandOutput {
                 stdout: self.help().into_bytes(),
@@ -129,7 +167,7 @@ mod tests {
         let dir = tempdir().unwrap();
         let path = dir.path().join("shot.png");
         tokio::fs::write(&path, PNG_BYTES).await.unwrap();
-        let out = SeeCommand
+        let out = SeeCommand::default()
             .run(CommandInput {
                 args: vec![path.to_string_lossy().into_owned()],
                 stdin: Vec::new(),
@@ -153,7 +191,7 @@ mod tests {
         let dir = tempdir().unwrap();
         let path = dir.path().join("notes.txt");
         tokio::fs::write(&path, b"not an image").await.unwrap();
-        let out = SeeCommand
+        let out = SeeCommand::default()
             .run(CommandInput {
                 args: vec![path.to_string_lossy().into_owned()],
                 stdin: Vec::new(),
@@ -172,7 +210,7 @@ mod tests {
 
     #[tokio::test]
     async fn missing_file_exits_1() {
-        let out = SeeCommand
+        let out = SeeCommand::default()
             .run(CommandInput {
                 args: vec!["/nonexistent/image.png".into()],
                 stdin: Vec::new(),
@@ -191,7 +229,7 @@ mod tests {
 
     #[tokio::test]
     async fn no_args_errors() {
-        let out = SeeCommand
+        let out = SeeCommand::default()
             .run(CommandInput {
                 args: Vec::new(),
                 stdin: Vec::new(),
@@ -203,7 +241,7 @@ mod tests {
 
     #[tokio::test]
     async fn too_many_args_errors() {
-        let out = SeeCommand
+        let out = SeeCommand::default()
             .run(CommandInput {
                 args: vec!["a.png".into(), "b.png".into()],
                 stdin: Vec::new(),
@@ -217,5 +255,39 @@ mod tests {
             "{stderr}"
         );
         assert!(stderr.contains("Use: see <PATH>"), "{stderr}");
+    }
+
+    /// AC #3: when vision is disabled, `see` short-circuits with the
+    /// exact wording "vision not available: model does not support
+    /// images" and never touches the filesystem (so a real path
+    /// argument is irrelevant; we still pass one to mirror normal
+    /// usage).
+    #[tokio::test]
+    async fn vision_disabled_returns_exact_error() {
+        let out = SeeCommand::new(false)
+            .run(CommandInput {
+                args: vec!["/tmp/some-image.png".into()],
+                stdin: Vec::new(),
+            })
+            .await
+            .unwrap();
+        assert_eq!(out.exit_code, 1);
+        assert!(out.stdout.is_empty());
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            stderr.contains("[error] see: vision not available: model does not support images"),
+            "{stderr}"
+        );
+        assert!(
+            stderr.contains("Use: a model with mmproj loaded"),
+            "{stderr}"
+        );
+        assert!(out.attachments.is_empty());
+    }
+
+    #[test]
+    fn summary_changes_when_vision_disabled() {
+        assert!(SeeCommand::new(true).summary().contains("attach an image"));
+        assert!(SeeCommand::new(false).summary().contains("unavailable"));
     }
 }

--- a/crates/assistd-tools/src/run.rs
+++ b/crates/assistd-tools/src/run.rs
@@ -242,7 +242,7 @@ mod tests {
         r.register(GrepCommand);
         r.register(LsCommand);
         r.register(WcCommand);
-        r.register(SeeCommand);
+        r.register(SeeCommand::default());
         Arc::new(r)
     }
 
@@ -257,7 +257,7 @@ mod tests {
         r.register(WcCommand);
         r.register(EchoCommand);
         r.register(WriteCommand::permissive_for_tests());
-        r.register(SeeCommand);
+        r.register(SeeCommand::default());
         r.register(ScreenshotCommand::default());
         r.register(WebCommand::new());
         r.register(BashCommand::default());
@@ -856,7 +856,7 @@ mod tests {
     fn run_see_no_args_returns_help_on_stdout_exit_2() {
         let dir = fresh_dir();
         let mut reg = CommandRegistry::new();
-        reg.register(SeeCommand);
+        reg.register(SeeCommand::default());
         let tool = tool_with(dir.path(), Arc::new(reg));
         let result = invoke(&tool, "see");
         assert_eq!(result["exit_code"], 2);

--- a/crates/assistd/src/chat/app.rs
+++ b/crates/assistd/src/chat/app.rs
@@ -151,6 +151,11 @@ pub struct App {
     pub presence_state: Option<PresenceState>,
     pub sleep_cfg: SleepConfig,
     pub presence: Option<Arc<PresenceManager>>,
+    /// Set at chat startup from a `/props` probe of the running
+    /// llama-server. `false` means the loaded model has no mmproj —
+    /// `/attach` rejects with the AC `vision not available` error and
+    /// the status bar renders `vision: off`.
+    pub vision_enabled: bool,
     pub modal: Option<ConfirmationModal>,
     /// Push-to-talk capture state, driven by the mic-voice listener
     /// spawned alongside the event loop. Rendered as an indicator in
@@ -187,6 +192,7 @@ impl App {
         model_name: String,
         sleep_cfg: SleepConfig,
         presence: Option<Arc<PresenceManager>>,
+        vision_enabled: bool,
         picker: Option<Picker>,
     ) -> Self {
         let presence_state = presence.as_ref().map(|p| p.state());
@@ -204,6 +210,7 @@ impl App {
             presence_state,
             sleep_cfg,
             presence,
+            vision_enabled,
             modal: None,
             listening: VoiceCaptureState::Idle,
             pending_tool_call: None,
@@ -469,6 +476,18 @@ impl App {
 
     fn submit_with_origin(&mut self, text: String, origin: SubmitOrigin) {
         if origin == SubmitOrigin::Typed {
+            // Both `/attach <path>` and bare `/attach` are vision-only;
+            // when no mmproj is loaded, the AC requires the same
+            // navigation-compliant error wording as `see` / `screenshot`.
+            let is_attach = text.starts_with("/attach ") || text.trim() == "/attach";
+            if is_attach && !self.vision_enabled {
+                self.output.push_error(
+                    "[error] attach_image: vision not available: model does not support \
+                     images. Use: a model with mmproj loaded",
+                );
+                self.set_notice("vision not available");
+                return;
+            }
             if let Some(rest) = text.strip_prefix("/attach ") {
                 self.handle_attach(rest.trim());
                 return;
@@ -677,6 +696,10 @@ mod tests {
     }
 
     fn test_app() -> (App, mpsc::Receiver<ChatEvent>) {
+        test_app_with(true)
+    }
+
+    fn test_app_with(vision_enabled: bool) -> (App, mpsc::Receiver<ChatEvent>) {
         let (tx, rx) = mpsc::channel::<ChatEvent>(16);
         let client: Arc<dyn LlmBackend> = Arc::new(EchoBackend::new());
         let tools = Arc::new(ToolRegistry::default());
@@ -688,6 +711,7 @@ mod tests {
             "test-model".into(),
             test_sleep_cfg(),
             None,
+            vision_enabled,
             None,
         );
         (app, rx)
@@ -906,6 +930,7 @@ mod tests {
             "test-model".into(),
             test_sleep_cfg(),
             None,
+            true,
             None,
         );
         app.spawn_generation("hello".into(), Vec::new());
@@ -1206,6 +1231,56 @@ mod tests {
         assert!(
             rendered.iter().any(|l| l.contains("expected a path")),
             "missing usage error: {rendered:?}"
+        );
+    }
+
+    /// AC #3 (TUI side): when the loaded model has no mmproj, typing
+    /// `/attach <path>` must reject before the file is read and emit
+    /// the same "vision not available" wording as `see` / `screenshot`.
+    /// We drive keys synchronously and skip `attach_and_drain` because
+    /// the vision-disabled path returns *before* spawning the loader,
+    /// so no `AttachLoaded`/`AttachFailed` event ever lands on `rx`.
+    #[test]
+    fn attach_when_vision_disabled_pushes_error_and_stages_nothing() {
+        let (mut app, _rx) = test_app_with(false);
+        for c in "/attach /tmp/some-image.png".chars() {
+            app.on_key(typed(c));
+        }
+        app.on_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        assert!(
+            app.pending_attachments.is_empty(),
+            "vision disabled must not stage an attachment"
+        );
+        let rendered = rendered_text(&mut app);
+        assert!(
+            rendered.iter().any(|l| l.contains(
+                "[error] attach_image: vision not available: model does not support images"
+            )),
+            "missing exact AC error wording: {rendered:?}"
+        );
+        assert!(
+            rendered
+                .iter()
+                .any(|l| l.contains("Use: a model with mmproj loaded")),
+            "missing recovery hint: {rendered:?}"
+        );
+    }
+
+    /// Bare `/attach` (no path) with vision disabled also takes the
+    /// vision-disabled path — the user should see the capability
+    /// problem, not the "missing path" usage error.
+    #[test]
+    fn bare_attach_when_vision_disabled_reports_vision_error() {
+        let (mut app, _rx) = test_app_with(false);
+        for c in "/attach".chars() {
+            app.on_key(typed(c));
+        }
+        app.on_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        assert!(app.pending_attachments.is_empty());
+        let rendered = rendered_text(&mut app);
+        assert!(
+            rendered.iter().any(|l| l.contains("vision not available")),
+            "expected vision error, got {rendered:?}"
         );
     }
 }

--- a/crates/assistd/src/chat/mod.rs
+++ b/crates/assistd/src/chat/mod.rs
@@ -78,16 +78,6 @@ pub async fn run(args: ChatArgs) -> Result<()> {
     // overlay via this channel. Capacity 8 is generous — we process one
     // at a time and the agent loop is blocked waiting for the response.
     let (confirm_tx, confirm_rx) = mpsc::channel::<PendingConfirmation>(8);
-    let tools = assistd_core::build_tools(
-        &config,
-        tui_overflow_dir.clone(),
-        Arc::new(TuiGate::new(confirm_tx)),
-    )?;
-    info!(
-        "tools: registered {} (overflow dir {})",
-        tools.len(),
-        tui_overflow_dir.display()
-    );
 
     println!("loading model {} ...", config.model.name);
 
@@ -117,6 +107,36 @@ pub async fn run(args: ChatArgs) -> Result<()> {
             (None, client, Some(msg))
         }
     };
+
+    // One-shot capability probe — only meaningful when llama-server
+    // actually came up. The FailedBackend path already surfaces the
+    // startup error to the TUI, so skip the misleading mmproj warning
+    // in that case.
+    let vision_enabled = if presence.is_some() {
+        let v =
+            assistd_llm::detect_vision_support(&config.llama_server.host, config.llama_server.port)
+                .await;
+        if v {
+            info!("vision: enabled (model has mmproj)");
+        } else {
+            tracing::warn!("Vision not available: mmproj not loaded.");
+        }
+        v
+    } else {
+        false
+    };
+
+    let tools = assistd_core::build_tools(
+        &config,
+        tui_overflow_dir.clone(),
+        Arc::new(TuiGate::new(confirm_tx)),
+        vision_enabled,
+    )?;
+    info!(
+        "tools: registered {} (overflow dir {})",
+        tools.len(),
+        tui_overflow_dir.display()
+    );
 
     let mut resource_rx = vram::spawn_probe(shutdown_tx.subscribe());
 
@@ -150,6 +170,7 @@ pub async fn run(args: ChatArgs) -> Result<()> {
         model_name,
         config.sleep.clone(),
         presence.clone(),
+        vision_enabled,
         &mut resource_rx,
         shutdown_tx.clone(),
         startup_error,
@@ -179,6 +200,7 @@ async fn run_tui(
     model_name: String,
     sleep_cfg: SleepConfig,
     presence: Option<Arc<PresenceManager>>,
+    vision_enabled: bool,
     resource_rx: &mut watch::Receiver<vram::ResourceState>,
     shutdown_tx: watch::Sender<bool>,
     startup_error: Option<String>,
@@ -248,6 +270,7 @@ async fn run_tui(
         model_name,
         sleep_cfg,
         presence.clone(),
+        vision_enabled,
         picker,
     );
 

--- a/crates/assistd/src/chat/ui.rs
+++ b/crates/assistd/src/chat/ui.rs
@@ -241,6 +241,21 @@ fn render_status(frame: &mut Frame, area: Rect, app: &App) {
         ));
         left_spans.push(Span::styled(format!(" {label}"), reversed));
     }
+    // Vision capability indicator. Detected once at startup from the
+    // running llama-server's `/props` and never changes thereafter, so
+    // we render it unconditionally — the user can see at a glance
+    // whether the model can accept the next `screenshot` / `/attach`.
+    let (vision_label, vision_color) = if app.vision_enabled {
+        ("vision: on", Color::Green)
+    } else {
+        ("vision: off", Color::DarkGray)
+    };
+    left_spans.push(Span::styled(
+        format!(" │ {vision_label}"),
+        Style::default()
+            .fg(vision_color)
+            .add_modifier(Modifier::REVERSED),
+    ));
     // Persistent staged-attachment indicator. The 3-second `notice`
     // pop is too ephemeral for state that gates the next submission —
     // this stays visible until `submit` drains `pending_attachments`.

--- a/crates/assistd/src/daemon.rs
+++ b/crates/assistd/src/daemon.rs
@@ -90,6 +90,18 @@ pub async fn run(args: DaemonArgs) -> Result<()> {
         config.llama_server.host, config.llama_server.port
     );
 
+    // One-shot capability probe: ask the now-ready llama-server whether
+    // it loaded a vision encoder. Returns false on any error; gates
+    // see/screenshot/attach_image downstream.
+    let vision_enabled =
+        assistd_llm::detect_vision_support(&config.llama_server.host, config.llama_server.port)
+            .await;
+    if vision_enabled {
+        info!("vision: enabled (model has mmproj)");
+    } else {
+        tracing::warn!("Vision not available: mmproj not loaded.");
+    }
+
     let chat = LlamaChatClient::new(&config.chat, &config.llama_server, &config.model)?;
 
     // Voice input: build the mic-backed implementation when the user
@@ -243,7 +255,12 @@ pub async fn run(args: DaemonArgs) -> Result<()> {
     // channel, so destructive bash commands are denied by default. To
     // approve such commands, run them from the chat TUI where the modal
     // overlay can prompt the user.
-    let tools = assistd_core::build_tools(&config, overflow_dir.clone(), Arc::new(DenyAllGate))?;
+    let tools = assistd_core::build_tools(
+        &config,
+        overflow_dir.clone(),
+        Arc::new(DenyAllGate),
+        vision_enabled,
+    )?;
     info!(
         "tools: registered {} (overflow dir {})",
         tools.len(),


### PR DESCRIPTION
Checking for multimodality of a configured model at startup, disabling image attachment and see command if there is no image support.