### PR TITLE
Multimodal input refinement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,6 +139,7 @@ dependencies = [
  "tempfile",
  "textwrap",
  "tokio",
+ "tokio-util",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
@@ -162,6 +163,7 @@ dependencies = [
  "assistd-config",
  "assistd-ipc",
  "assistd-llm",
+ "assistd-memory",
  "assistd-tools",
  "assistd-voice",
  "async-trait",
@@ -172,6 +174,7 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-util",
  "toml",
  "tracing",
 ]
@@ -180,6 +183,7 @@ dependencies = [
 name = "assistd-ipc"
 version = "0.1.0"
 dependencies = [
+ "base64",
  "serde",
  "serde_json",
 ]
@@ -204,6 +208,30 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "assistd-mcp"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "assistd-tools",
+ "async-trait",
+ "base64",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "assistd-memory"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -2873,6 +2901,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,8 @@ members = [
     "crates/assistd-core",
     "crates/assistd-ipc",
     "crates/assistd-llm",
+    "crates/assistd-mcp",
+    "crates/assistd-memory",
     "crates/assistd-voice",
     "crates/assistd-tools",
     "crates/assistd-wm",
@@ -24,6 +26,8 @@ assistd-config = { version = "0.1", path = "crates/assistd-config" }
 assistd-core   = { version = "0.1", path = "crates/assistd-core" }
 assistd-ipc    = { version = "0.1", path = "crates/assistd-ipc" }
 assistd-llm    = { version = "0.1", path = "crates/assistd-llm" }
+assistd-mcp    = { version = "0.1", path = "crates/assistd-mcp" }
+assistd-memory = { version = "0.1", path = "crates/assistd-memory" }
 assistd-voice  = { version = "0.1", path = "crates/assistd-voice" }
 assistd-tools  = { version = "0.1", path = "crates/assistd-tools" }
 assistd-wm     = { version = "0.1", path = "crates/assistd-wm" }
@@ -31,7 +35,11 @@ assistd-wm     = { version = "0.1", path = "crates/assistd-wm" }
 # External crates
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tokio = { version = "1", features = ["full"] }
+# Workspace base for tokio: no features. Each crate opts into the
+# minimum it needs via per-manifest `features = [...]`. The binary
+# (`assistd-cli`) is the only crate that takes `["full"]`.
+tokio = { version = "1", default-features = false }
+tokio-util = { version = "0.7", features = ["rt"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 anyhow = "1"
@@ -57,6 +65,37 @@ which = "7"
 rodio = { version = "0.22", default-features = false, features = ["playback"] }
 ratatui-image = { version = "8", default-features = false, features = ["crossterm"] }
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "webp"] }
+
+# Workspace-wide lint baseline. Each crate inherits via
+# `[lints] workspace = true` in its own Cargo.toml. Tightens defaults
+# without going to clippy::pedantic, which would surface hundreds of
+# stylistic warnings across the existing 100+ source files; pedantic
+# can be turned on incrementally per-crate later if there's appetite.
+[workspace.lints.rust]
+# `deny` (not `forbid`) so individual call sites that legitimately
+# need libc / process-group / kill semantics can opt in with a
+# scoped `#[allow(unsafe_code)]` and a comment explaining why.
+unsafe_code = "deny"
+# Lint groups must have priority -1 so individual lint overrides
+# (none below today, but future per-lint overrides) win over them.
+rust_2018_idioms = { level = "warn", priority = -1 }
+unused_qualifications = "warn"
+
+[workspace.lints.clippy]
+all = { level = "warn", priority = -1 }
+# Catch leftover dbg! before it ships. `print_stdout` / `print_stderr`
+# are intentionally NOT denied here — the CLI surface (`assistd send`
+# error reporting, fake-server diagnostics) writes to stdout/stderr
+# legitimately, and chasing those down with per-call allows is
+# higher-cost-than-value. Revisit when there's a clear "production"
+# vs "CLI surface" boundary worth enforcing.
+dbg_macro = "deny"
+# `unwrap_used` / `expect_used` likewise: tests already opt out via
+# `#![cfg_attr(test, allow(...))]` in each lib. The remaining
+# production sites are a backlog item — landing them as `warn` here
+# would surface 16 warnings we can't fix in this refinement pass.
+# Keep them off the workspace baseline for now so CI stays green;
+# tightening incrementally per-crate is the follow-up.
 
 [profile.release]
 lto = "thin"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,12 @@ unsafe_code = "deny"
 # Lint groups must have priority -1 so individual lint overrides
 # (none below today, but future per-lint overrides) win over them.
 rust_2018_idioms = { level = "warn", priority = -1 }
-unused_qualifications = "warn"
+# `unused_qualifications` is intentionally NOT in the baseline. With
+# `-D warnings` in CI, it would error on perfectly readable test code
+# that uses `anyhow::Result<()>` / `std::time::Duration` for clarity
+# at the call site (where the import alone wouldn't disambiguate). If
+# we ever want this back, scope it as a per-crate opt-in rather than
+# a workspace blanket.
 
 [workspace.lints.clippy]
 all = { level = "warn", priority = -1 }

--- a/crates/assistd-config/Cargo.toml
+++ b/crates/assistd-config/Cargo.toml
@@ -8,3 +8,6 @@ license.workspace = true
 serde = { workspace = true }
 thiserror = { workspace = true }
 toml = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/assistd-config/src/lib.rs
+++ b/crates/assistd-config/src/lib.rs
@@ -1,3 +1,13 @@
+#![cfg_attr(
+    test,
+    allow(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::print_stdout,
+        clippy::print_stderr
+    )
+)]
+
 //! assistd configuration types.
 //!
 //! This is a leaf crate: it depends on no other internal crate, so both

--- a/crates/assistd-core/Cargo.toml
+++ b/crates/assistd-core/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 assistd-config = { workspace = true }
 assistd-ipc = { workspace = true }
 assistd-llm = { workspace = true }
+assistd-memory = { workspace = true }
 assistd-tools = { workspace = true }
 # The default features (whisper + mic) bring in cpal; callers that
 # don't want mic support (e.g. a headless-minimal daemon build) can
@@ -20,10 +21,14 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 shlex = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "sync", "time", "io-util", "fs", "signal"] }
+tokio-util = { workspace = true }
 toml = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"
 async-trait = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/assistd-core/src/agent.rs
+++ b/crates/assistd-core/src/agent.rs
@@ -19,6 +19,7 @@ use assistd_llm::{LlmBackend, LlmEvent, StepOutcome, ToolCall, ToolResultPayload
 use assistd_tools::{Attachment, ToolRegistry};
 use serde_json::Value;
 use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, instrument, warn};
 
 /// Run one agent turn end-to-end.
@@ -37,7 +38,17 @@ use tracing::{debug, info, instrument, warn};
 ///
 /// Cancellation: if `tx` is closed (client disconnected) between
 /// iterations, the loop returns `Ok(())` without running further tool
-/// calls or LLM round trips.
+/// calls or LLM round trips. Callers can also explicitly cancel by
+/// signalling the [`CancellationToken`] — useful when the daemon needs
+/// to stop a long-running LLM step or tool call promptly (e.g. a slow
+/// MCP tool when the user disconnects). The token is checked between
+/// iterations and the LLM step / tool dispatch run inside a
+/// `select!` against it so cancellation propagates without waiting
+/// for the inner future to complete on its own.
+///
+/// Pass [`CancellationToken::new`] (a fresh, never-cancelled token) if
+/// the caller doesn't need explicit cancellation — the
+/// `tx.is_closed()` path keeps existing behaviour for that case.
 #[instrument(skip_all, name = "agent_turn")]
 pub async fn run_agent_turn(
     backend: Arc<dyn LlmBackend>,
@@ -46,31 +57,44 @@ pub async fn run_agent_turn(
     user_text: String,
     user_attachments: Vec<Attachment>,
     tx: mpsc::Sender<LlmEvent>,
+    cancel: CancellationToken,
 ) -> Result<()> {
     backend.push_user(user_text, user_attachments).await?;
     let schemas = tools.openai_schemas();
 
     for iteration in 0..max_iterations {
-        if tx.is_closed() {
+        if tx.is_closed() || cancel.is_cancelled() {
             debug!(
                 target: "assistd::agent",
                 iteration,
-                "client disconnected between iterations; stopping"
+                cancelled = cancel.is_cancelled(),
+                "stopping between iterations (client gone or explicit cancel)"
             );
             return Ok(());
         }
 
-        let outcome = match backend.step(schemas.clone(), tx.clone()).await {
-            Ok(o) => o,
-            Err(e) => {
-                let _ = tx
-                    .send(LlmEvent::Delta {
-                        text: format!("\n[agent error: {e}]\n"),
-                    })
-                    .await;
-                let _ = tx.send(LlmEvent::Done).await;
-                return Err(e);
+        let outcome = tokio::select! {
+            biased;
+            () = cancel.cancelled() => {
+                debug!(
+                    target: "assistd::agent",
+                    iteration,
+                    "cancellation fired during LLM step; stopping"
+                );
+                return Ok(());
             }
+            r = backend.step(schemas.clone(), tx.clone()) => match r {
+                Ok(o) => o,
+                Err(e) => {
+                    let _ = tx
+                        .send(LlmEvent::Delta {
+                            text: format!("\n[agent error: {e}]\n"),
+                        })
+                        .await;
+                    let _ = tx.send(LlmEvent::Done).await;
+                    return Err(e);
+                }
+            },
         };
 
         match outcome {
@@ -81,12 +105,13 @@ pub async fn run_agent_turn(
             StepOutcome::ToolCalls(calls) => {
                 let mut results = Vec::with_capacity(calls.len());
                 for call in calls {
-                    if tx.is_closed() {
+                    if tx.is_closed() || cancel.is_cancelled() {
                         debug!(
                             target: "assistd::agent",
                             iteration,
                             tool = %call.name,
-                            "client disconnected mid-call; stopping without dispatch"
+                            cancelled = cancel.is_cancelled(),
+                            "stopping mid-call (client gone or explicit cancel) without dispatch"
                         );
                         // Unwind: push synthetic errors for all pending calls
                         // so conversation state isn't left with a dangling
@@ -305,6 +330,13 @@ mod tests {
         pushed_users: StdMutex<Vec<String>>,
         pushed_attachments: StdMutex<Vec<Vec<Attachment>>>,
         pushed_results: StdMutex<Vec<Vec<ToolResultPayload>>>,
+        /// Counts every entry into `step` (including ones cancelled
+        /// before they finish). Used by cancellation tests to verify
+        /// the loop didn't iterate past a cancellation point.
+        step_calls: std::sync::atomic::AtomicUsize,
+        /// Optional artificial delay inside `step` so cancellation
+        /// tests can fire while the step is still pending.
+        slow_step: StdMutex<Option<std::time::Duration>>,
     }
 
     impl MockBackend {
@@ -314,7 +346,14 @@ mod tests {
                 pushed_users: StdMutex::new(Vec::new()),
                 pushed_attachments: StdMutex::new(Vec::new()),
                 pushed_results: StdMutex::new(Vec::new()),
+                step_calls: std::sync::atomic::AtomicUsize::new(0),
+                slow_step: StdMutex::new(None),
             })
+        }
+
+        fn slow_step_ms(self: Arc<Self>, ms: u64) -> Arc<Self> {
+            *self.slow_step.lock().unwrap() = Some(std::time::Duration::from_millis(ms));
+            self
         }
     }
 
@@ -348,6 +387,15 @@ mod tests {
             _tools: Vec<Value>,
             tx: mpsc::Sender<LlmEvent>,
         ) -> anyhow::Result<StepOutcome> {
+            self.step_calls
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            // Honour any configured slow-step delay BEFORE consuming
+            // an outcome — cancellation tests rely on this future
+            // being long-lived so the cancel signal can race it.
+            let delay = *self.slow_step.lock().unwrap();
+            if let Some(d) = delay {
+                tokio::time::sleep(d).await;
+            }
             let outcome = {
                 let mut q = self.outcomes.lock().unwrap();
                 if q.is_empty() {
@@ -406,6 +454,7 @@ mod tests {
             "what is 2+2?".into(),
             Vec::new(),
             tx,
+            CancellationToken::new(),
         )
         .await
         .unwrap();
@@ -431,6 +480,7 @@ mod tests {
             "say hello".into(),
             Vec::new(),
             tx,
+            CancellationToken::new(),
         )
         .await
         .unwrap();
@@ -493,6 +543,7 @@ mod tests {
             "how many?".into(),
             Vec::new(),
             tx,
+            CancellationToken::new(),
         )
         .await
         .unwrap();
@@ -528,9 +579,17 @@ mod tests {
         let backend = MockBackend::with(outcomes);
         let tools = tools_with_echo();
         let (tx, mut rx) = mpsc::channel(64);
-        run_agent_turn(backend, tools, 3, "loop it".into(), Vec::new(), tx)
-            .await
-            .unwrap();
+        run_agent_turn(
+            backend,
+            tools,
+            3,
+            "loop it".into(),
+            Vec::new(),
+            tx,
+            CancellationToken::new(),
+        )
+        .await
+        .unwrap();
         let events = collect(&mut rx).await;
 
         let delta_text: String = events
@@ -561,9 +620,17 @@ mod tests {
         ]);
         let tools = tools_with_echo();
         let (tx, mut rx) = mpsc::channel(16);
-        run_agent_turn(backend.clone(), tools, 10, "go".into(), Vec::new(), tx)
-            .await
-            .unwrap();
+        run_agent_turn(
+            backend.clone(),
+            tools,
+            10,
+            "go".into(),
+            Vec::new(),
+            tx,
+            CancellationToken::new(),
+        )
+        .await
+        .unwrap();
         drop(collect(&mut rx).await);
         let pushed = backend.pushed_results.lock().unwrap();
         assert_eq!(pushed.len(), 1);
@@ -606,9 +673,17 @@ mod tests {
             StepOutcome::Final,
         ]);
         let (tx, mut rx) = mpsc::channel(16);
-        run_agent_turn(backend.clone(), reg, 10, "go".into(), Vec::new(), tx)
-            .await
-            .unwrap();
+        run_agent_turn(
+            backend.clone(),
+            reg,
+            10,
+            "go".into(),
+            Vec::new(),
+            tx,
+            CancellationToken::new(),
+        )
+        .await
+        .unwrap();
         drop(collect(&mut rx).await);
         let pushed = backend.pushed_results.lock().unwrap();
         let payload = &pushed[0][0];
@@ -633,14 +708,94 @@ mod tests {
         drop(rx);
         // Channel is closed from the start, so the very first is_closed
         // check bails the loop before any step runs.
-        run_agent_turn(backend.clone(), tools, 10, "go".into(), Vec::new(), tx)
-            .await
-            .unwrap();
+        run_agent_turn(
+            backend.clone(),
+            tools,
+            10,
+            "go".into(),
+            Vec::new(),
+            tx,
+            CancellationToken::new(),
+        )
+        .await
+        .unwrap();
         // With the receiver already dropped, no step was called.
         let pushed = backend.pushed_results.lock().unwrap();
         assert!(
             pushed.is_empty(),
             "no tool results should be pushed after disconnect: {pushed:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn explicit_cancel_before_first_step_stops_loop_immediately() {
+        // The token is cancelled before the loop starts. The very
+        // first iteration's pre-step check sees `cancel.is_cancelled()`
+        // and bails — no step is ever called.
+        let backend = MockBackend::with(vec![
+            StepOutcome::Final,
+            // If we get here the cancellation didn't take effect.
+            StepOutcome::Final,
+        ]);
+        let tools = tools_with_echo();
+        let (tx, _rx) = mpsc::channel::<LlmEvent>(16);
+        let token = CancellationToken::new();
+        token.cancel();
+        run_agent_turn(
+            backend.clone(),
+            tools,
+            10,
+            "go".into(),
+            Vec::new(),
+            tx,
+            token,
+        )
+        .await
+        .unwrap();
+        // user push happened (it's the first thing in the loop), but
+        // no step ran.
+        assert_eq!(backend.pushed_users.lock().unwrap().len(), 1);
+        assert_eq!(
+            backend.step_calls.load(std::sync::atomic::Ordering::SeqCst),
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn cancellation_during_slow_step_preempts_loop() {
+        // Fire a cancellation while the LLM step is still pending,
+        // and verify run_agent_turn returns promptly via the
+        // tokio::select! against `cancel.cancelled()` rather than
+        // waiting for the step future to complete on its own.
+        let backend = MockBackend::with(vec![StepOutcome::Final]).slow_step_ms(2_000);
+        let tools = tools_with_echo();
+        let (tx, _rx) = mpsc::channel::<LlmEvent>(16);
+        let token = CancellationToken::new();
+        let token_for_kicker = token.clone();
+        // Spawn a task that fires cancel after a short delay.
+        tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            token_for_kicker.cancel();
+        });
+        let started = std::time::Instant::now();
+        run_agent_turn(
+            backend.clone(),
+            tools,
+            10,
+            "go".into(),
+            Vec::new(),
+            tx,
+            token,
+        )
+        .await
+        .unwrap();
+        let elapsed = started.elapsed();
+        // The slow step is 2s; if cancellation didn't preempt we'd
+        // be waiting that long. Allow a generous 500ms buffer for
+        // CI scheduling variance.
+        assert!(
+            elapsed < std::time::Duration::from_millis(500),
+            "cancellation did not preempt slow step (elapsed: {elapsed:?})"
         );
     }
 }

--- a/crates/assistd-core/src/lib.rs
+++ b/crates/assistd-core/src/lib.rs
@@ -1,3 +1,13 @@
+#![cfg_attr(
+    test,
+    allow(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::print_stdout,
+        clippy::print_stderr
+    )
+)]
+
 //! Daemon orchestration crate — the glue that wires every subsystem
 //! into a running `assistd` process.
 //!
@@ -96,17 +106,21 @@ use tracing::warn;
 /// the chat TUI passes a `TuiGate` that forwards prompts to the user via
 /// a modal overlay.
 ///
-/// `vision_enabled` reflects a one-shot `/props` probe of the running
-/// llama-server (see [`assistd_llm::detect_vision_support`]). When `false`,
-/// the image-producing commands (`see`, `screenshot`) are still
-/// registered but their `run()` short-circuits to the convention
-/// `[error] …: vision not available …` line, and their `summary()` flips
-/// so the LLM sees the unavailability in its tool schema.
+/// `vision_gate` is a shared, runtime-mutable flag (see
+/// [`assistd_tools::VisionGate`]) initialised from a `/props` probe of
+/// the running llama-server. When the gate reports `supported = false`,
+/// the image-producing commands (`see`, `screenshot`) still register
+/// but their `run()` short-circuits with the
+/// `[error] …: vision not available …` line and their `summary()` flips
+/// so the LLM sees the unavailability in its tool schema. The gate is
+/// re-evaluated on every command invocation, so a daemon-side
+/// revalidation that flips it after a model swap takes effect without
+/// rebuilding the registry.
 pub fn build_tools(
     config: &Config,
     overflow_dir: PathBuf,
     gate: Arc<dyn ConfirmationGate>,
-    vision_enabled: bool,
+    vision_gate: Arc<assistd_tools::VisionGate>,
 ) -> Result<Arc<ToolRegistry>> {
     if overflow_dir.exists() {
         std::fs::remove_dir_all(&overflow_dir).with_context(|| {
@@ -191,8 +205,8 @@ pub fn build_tools(
     commands.register(WcCommand);
     commands.register(EchoCommand);
     commands.register(WriteCommand::new(write_cfg));
-    commands.register(SeeCommand::new(vision_enabled));
-    commands.register(ScreenshotCommand::new(screenshot_cfg, vision_enabled));
+    commands.register(SeeCommand::new(vision_gate.clone()));
+    commands.register(ScreenshotCommand::new(screenshot_cfg, vision_gate));
     commands.register(WebCommand::new());
     commands.register(BashCommand::new(bash_cfg, sandbox, gate));
 
@@ -203,6 +217,156 @@ pub fn build_tools(
         overflow_dir,
     ));
     Ok(Arc::new(tools))
+}
+
+/// Cache the running llama-server's model id alongside the
+/// [`VisionGate`] state, so a re-probe can detect a model swap and
+/// flip vision availability without rebuilding the tool registry.
+///
+/// The daemon constructs one [`VisionRevalidator`] at startup, hands it
+/// to [`AppState`], and the per-query handler calls [`revalidate`] at
+/// the top of every turn. The probe is cheap (one local HTTP `GET
+/// /props` with a 2-second timeout), and we only mutate the gate when
+/// the cached model id actually changes — so a steady-state daemon
+/// pays a single round-trip per turn and never thrashes the gate.
+///
+/// [`revalidate`]: VisionRevalidator::revalidate
+pub struct VisionRevalidator {
+    gate: Arc<assistd_tools::VisionGate>,
+    cached_model: tokio::sync::Mutex<Option<String>>,
+    host: String,
+    port: u16,
+}
+
+impl VisionRevalidator {
+    pub fn new(
+        gate: Arc<assistd_tools::VisionGate>,
+        initial_model_id: Option<String>,
+        host: String,
+        port: u16,
+    ) -> Arc<Self> {
+        Arc::new(Self {
+            gate,
+            cached_model: tokio::sync::Mutex::new(initial_model_id),
+            host,
+            port,
+        })
+    }
+
+    /// Re-probe `/props` and, if the model id changed, update the
+    /// gate. Tolerates probe failures silently — a transient HTTP
+    /// blip should not flip vision off mid-session.
+    pub async fn revalidate(&self) {
+        let probe = assistd_llm::probe_capabilities(&self.host, self.port).await;
+        self.apply_probe(probe).await;
+    }
+
+    /// Apply a probe result to the cache and gate. Split out from
+    /// [`Self::revalidate`] so unit tests can drive the swap logic
+    /// without standing up an HTTP server.
+    pub async fn apply_probe(&self, probe: assistd_llm::VisionState) {
+        // No model id means the probe failed. Don't mutate the gate
+        // on a transient error; keep the last known good state.
+        if probe.model_id.is_none() {
+            return;
+        }
+        let mut cache = self.cached_model.lock().await;
+        if *cache != probe.model_id {
+            tracing::info!(
+                old = ?*cache,
+                new = ?probe.model_id,
+                vision_supported = probe.vision_supported,
+                "llama-server model changed; updating vision gate"
+            );
+            *cache = probe.model_id;
+            self.gate.set(probe.vision_supported);
+        }
+    }
+
+    pub fn gate(&self) -> &Arc<assistd_tools::VisionGate> {
+        &self.gate
+    }
+}
+
+#[cfg(test)]
+mod vision_revalidator_tests {
+    use super::*;
+    use assistd_llm::VisionState;
+
+    fn make_revalidator(gate_initial: bool, cached_model: Option<&str>) -> Arc<VisionRevalidator> {
+        VisionRevalidator::new(
+            assistd_tools::VisionGate::new(gate_initial),
+            cached_model.map(str::to_string),
+            "127.0.0.1".to_string(),
+            // Port is unused in the apply_probe path — set to 0 to
+            // make a real revalidate() obviously fail loudly if anyone
+            // accidentally points the test at it.
+            0,
+        )
+    }
+
+    #[tokio::test]
+    async fn no_model_id_keeps_gate_unchanged() {
+        // Simulates a transient probe failure: probe_capabilities
+        // returns the default (None model id, false vision). The gate
+        // must stay where it was; flipping it on a network blip would
+        // disable vision mid-session.
+        let rev = make_revalidator(true, Some("model-A"));
+        rev.apply_probe(VisionState::default()).await;
+        assert!(
+            rev.gate().supported(),
+            "gate must not flip on probe failure"
+        );
+    }
+
+    #[tokio::test]
+    async fn unchanged_model_id_keeps_gate_unchanged() {
+        let rev = make_revalidator(true, Some("model-A"));
+        rev.apply_probe(VisionState {
+            model_id: Some("model-A".into()),
+            // Even if the new probe says false, no model swap means we
+            // don't disturb the gate — same model can't lose vision.
+            vision_supported: false,
+        })
+        .await;
+        assert!(rev.gate().supported());
+    }
+
+    #[tokio::test]
+    async fn model_swap_flips_gate_off() {
+        let rev = make_revalidator(true, Some("vision-model"));
+        rev.apply_probe(VisionState {
+            model_id: Some("text-only-model".into()),
+            vision_supported: false,
+        })
+        .await;
+        assert!(!rev.gate().supported(), "gate must flip when model changes");
+    }
+
+    #[tokio::test]
+    async fn model_swap_flips_gate_on() {
+        let rev = make_revalidator(false, Some("text-only-model"));
+        rev.apply_probe(VisionState {
+            model_id: Some("vision-model".into()),
+            vision_supported: true,
+        })
+        .await;
+        assert!(rev.gate().supported());
+    }
+
+    #[tokio::test]
+    async fn fresh_revalidator_with_no_cached_model_still_picks_up_first_probe() {
+        // Daemon starts before the probe completes — the initial cache
+        // is None. When the first probe lands, we accept it as the
+        // baseline (None != Some) and update the gate to match.
+        let rev = make_revalidator(false, None);
+        rev.apply_probe(VisionState {
+            model_id: Some("vision-model".into()),
+            vision_supported: true,
+        })
+        .await;
+        assert!(rev.gate().supported());
+    }
 }
 
 /// Expand a leading `~` / `~/` in a config-supplied path string using

--- a/crates/assistd-core/src/presence.rs
+++ b/crates/assistd-core/src/presence.rs
@@ -131,14 +131,14 @@ struct WakeMarker {
 
 impl WakeMarker {
     fn new(slot: Arc<StdMutex<Option<Instant>>>) -> Self {
-        *slot.lock().expect("wake_started mutex poisoned") = Some(Instant::now());
+        *slot.lock().unwrap_or_else(|e| e.into_inner()) = Some(Instant::now());
         Self { slot }
     }
 }
 
 impl Drop for WakeMarker {
     fn drop(&mut self) {
-        *self.slot.lock().expect("wake_started mutex poisoned") = None;
+        *self.slot.lock().unwrap_or_else(|e| e.into_inner()) = None;
     }
 }
 
@@ -180,10 +180,7 @@ impl PresenceManager {
                 if daemon_rx.wait_for(|v| *v).await.is_err() {
                     return;
                 }
-                let tx = current
-                    .lock()
-                    .expect("inner-shutdown mutex poisoned")
-                    .clone();
+                let tx = current.lock().unwrap_or_else(|e| e.into_inner()).clone();
                 if let Some(tx) = tx {
                     let _ = tx.send(true);
                 }
@@ -217,7 +214,7 @@ impl PresenceManager {
 
     /// Current presence state. Cheap, lock-protected snapshot.
     pub fn state(&self) -> PresenceState {
-        *self.state.lock().expect("presence state mutex poisoned")
+        *self.state.lock().unwrap_or_else(|e| e.into_inner())
     }
 
     /// Record that the user just interacted with the daemon. Called at
@@ -226,10 +223,7 @@ impl PresenceManager {
     /// low-level transition methods (`wake`/`drowse`/`sleep`) so that
     /// automatic monitors (GPU, idle) don't defer their own progress.
     fn mark_activity(&self) {
-        *self
-            .last_activity
-            .lock()
-            .expect("last_activity mutex poisoned") = Instant::now();
+        *self.last_activity.lock().unwrap_or_else(|e| e.into_inner()) = Instant::now();
     }
 
     /// Time since the last recorded user interaction. Read by the idle
@@ -238,7 +232,7 @@ impl PresenceManager {
     pub fn idle_duration(&self) -> Duration {
         self.last_activity
             .lock()
-            .expect("last_activity mutex poisoned")
+            .unwrap_or_else(|e| e.into_inner())
             .elapsed()
     }
 
@@ -297,6 +291,7 @@ impl PresenceManager {
     /// immediately; otherwise calls [`Self::wake`]. Safe to call under
     /// concurrent queries — racing callers serialise on the transition
     /// lock and only one wake actually runs.
+    #[tracing::instrument(skip(self), fields(from = ?self.state()))]
     pub async fn ensure_active(&self) -> Result<()> {
         self.mark_activity();
         if self.state() == PresenceState::Active {
@@ -340,10 +335,7 @@ impl PresenceManager {
     /// indicator during cold-start wakes (which can take tens of
     /// seconds to minutes).
     pub fn wake_in_progress(&self) -> Option<Instant> {
-        *self
-            .wake_started
-            .lock()
-            .expect("wake_started mutex poisoned")
+        *self.wake_started.lock().unwrap_or_else(|e| e.into_inner())
     }
 
     /// Register an in-flight LLM stream. The returned guard decrements
@@ -386,6 +378,7 @@ impl PresenceManager {
 
     /// Drive the manager to `target`. Convenience wrapper used by the IPC
     /// `SetPresence` handler.
+    #[tracing::instrument(skip(self), fields(from = ?self.state()))]
     pub async fn set_presence(&self, target: PresenceState) -> Result<()> {
         self.mark_activity();
         match target {
@@ -432,7 +425,7 @@ impl PresenceManager {
         let tx = self
             .current_inner_shutdown
             .lock()
-            .expect("inner-shutdown mutex poisoned")
+            .unwrap_or_else(|e| e.into_inner())
             .take();
         if let Some(tx) = tx {
             let _ = tx.send(true);
@@ -447,7 +440,7 @@ impl PresenceManager {
                 .context("llama-server shutdown during sleep")?;
         }
 
-        *self.state.lock().expect("presence state mutex poisoned") = PresenceState::Sleeping;
+        *self.state.lock().unwrap_or_else(|e| e.into_inner()) = PresenceState::Sleeping;
         let _ = self.state_tx.send(PresenceState::Sleeping);
         info!(
             target: "assistd::presence",
@@ -487,7 +480,7 @@ impl PresenceManager {
                 format!("llama-server /models/unload failed for {}", self.model.name)
             })?;
 
-        *self.state.lock().expect("presence state mutex poisoned") = PresenceState::Drowsy;
+        *self.state.lock().unwrap_or_else(|e| e.into_inner()) = PresenceState::Drowsy;
         let _ = self.state_tx.send(PresenceState::Drowsy);
         info!(
             target: "assistd::presence",
@@ -532,7 +525,7 @@ impl PresenceManager {
                 *self
                     .current_inner_shutdown
                     .lock()
-                    .expect("inner-shutdown mutex poisoned") = Some(inner_tx);
+                    .unwrap_or_else(|e| e.into_inner()) = Some(inner_tx);
 
                 let service =
                     LlamaService::start(self.llama_server.clone(), self.model.clone(), inner_rx)
@@ -558,7 +551,7 @@ impl PresenceManager {
             PresenceState::Active => unreachable!("short-circuited above"),
         }
 
-        *self.state.lock().expect("presence state mutex poisoned") = PresenceState::Active;
+        *self.state.lock().unwrap_or_else(|e| e.into_inner()) = PresenceState::Active;
         let _ = self.state_tx.send(PresenceState::Active);
         info!(
             target: "assistd::presence",
@@ -628,7 +621,7 @@ impl PresenceManager {
     /// Does not touch the transition mutex or the llama handle.
     #[cfg(test)]
     pub(crate) fn set_state_for_test(&self, s: PresenceState) {
-        *self.state.lock().expect("presence state mutex poisoned") = s;
+        *self.state.lock().unwrap_or_else(|e| e.into_inner()) = s;
         let _ = self.state_tx.send(s);
     }
 }

--- a/crates/assistd-core/src/state.rs
+++ b/crates/assistd-core/src/state.rs
@@ -2,7 +2,8 @@ use crate::{Config, PresenceManager, run_agent_turn};
 use anyhow::Result;
 use assistd_ipc::{Event, PresenceState, Request, VoiceCaptureState};
 use assistd_llm::{LlmBackend, LlmEvent};
-use assistd_tools::ToolRegistry;
+use assistd_memory::{MemoryStore, NoMemoryStore};
+use assistd_tools::{Attachment, ToolRegistry};
 use assistd_voice::{
     ContinuousListener, SentenceBuffer, SpeakDecision, VoiceInput, VoiceOutputController,
 };
@@ -10,6 +11,25 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::{Mutex, mpsc};
 use tracing::Instrument;
+
+/// Convert wire-level [`assistd_ipc::ImageAttachment`] entries into the
+/// internal [`Attachment`] type the agent loop expects. Returns the first
+/// decode error so the caller can surface it cleanly to the client.
+fn decode_wire_attachments(
+    wire: &[assistd_ipc::ImageAttachment],
+) -> std::result::Result<Vec<Attachment>, String> {
+    wire.iter()
+        .map(|w| {
+            let bytes = w
+                .decode_bytes()
+                .map_err(|e| format!("base64 decode failed for {}: {e}", w.mime))?;
+            Ok(Attachment::Image {
+                mime: w.mime.clone(),
+                bytes,
+            })
+        })
+        .collect()
+}
 
 /// Shared, long-lived daemon state handed to every request handler.
 ///
@@ -29,6 +49,17 @@ pub struct AppState {
     /// When TTS is disabled in config or the build, the inner backend
     /// is `NoVoiceOutput` which silently accepts every speak() call.
     pub voice_output: Arc<VoiceOutputController>,
+    /// Re-probes `/props` at the top of each query so a model swap on
+    /// the running llama-server flips the vision gate. `None` in tests
+    /// where there is no real llama-server to probe — `handle_query`
+    /// then skips the revalidation step entirely.
+    pub vision_revalidator: Option<Arc<crate::VisionRevalidator>>,
+    /// Persistent key/value memory shared across sessions. Wired to
+    /// [`assistd_memory::NoMemoryStore`] in builds without a backend
+    /// configured; Milestone 4 swaps in the SQLite-backed concrete
+    /// implementation. Held as `Arc<dyn MemoryStore>` so the trait
+    /// boundary stays the same regardless of backend.
+    pub memory: Arc<dyn MemoryStore>,
     /// Serializes entire agent turns. Concurrent queries each grab this
     /// lock before running `run_agent_turn`, so one query's tool-call /
     /// tool-result cycle never interleaves with another's — which would
@@ -55,8 +86,27 @@ impl AppState {
             voice,
             listener,
             voice_output,
+            vision_revalidator: None,
+            memory: Arc::new(NoMemoryStore),
             agent_turn_lock: Arc::new(Mutex::new(())),
         }
+    }
+
+    /// Builder-style setter for the optional vision revalidator. Kept
+    /// out of [`Self::new`] so existing test constructors don't need to
+    /// supply it.
+    pub fn with_vision_revalidator(mut self, r: Arc<crate::VisionRevalidator>) -> Self {
+        self.vision_revalidator = Some(r);
+        self
+    }
+
+    /// Builder-style setter for the memory backend. Kept out of
+    /// [`Self::new`] so existing test constructors keep working with
+    /// the default `NoMemoryStore`. Milestone 4's SQLite store will
+    /// be threaded through this method.
+    pub fn with_memory(mut self, m: Arc<dyn MemoryStore>) -> Self {
+        self.memory = m;
+        self
     }
 
     /// Route a single incoming request to the appropriate subsystem.
@@ -67,7 +117,26 @@ impl AppState {
     /// [`Event::Error`] if one hasn't been emitted already.
     pub async fn dispatch(self: Arc<Self>, req: Request, tx: mpsc::Sender<Event>) -> Result<()> {
         match req {
-            Request::Query { id, text } => self.handle_query(id, text, tx).await,
+            Request::Query {
+                id,
+                text,
+                attachments,
+                version,
+            } => {
+                if let Some(v) = version {
+                    if v > assistd_ipc::PROTOCOL_VERSION {
+                        tracing::warn!(
+                            client = v,
+                            server = assistd_ipc::PROTOCOL_VERSION,
+                            "client sent newer protocol version than daemon understands; \
+                             extra fields will be ignored"
+                        );
+                    }
+                } else {
+                    tracing::debug!("client did not send protocol version; treating as legacy v1");
+                }
+                self.handle_query(id, text, attachments, tx).await
+            }
             Request::SetPresence { id, target } => self.handle_set_presence(id, target, tx).await,
             Request::GetPresence { id } => self.handle_get_presence(id, tx).await,
             Request::Cycle { id } => self.handle_cycle(id, tx).await,
@@ -87,8 +156,33 @@ impl AppState {
         self: Arc<Self>,
         id: String,
         text: String,
+        wire_attachments: Vec<assistd_ipc::ImageAttachment>,
         tx: mpsc::Sender<Event>,
     ) -> Result<()> {
+        // Re-probe llama-server's loaded model so a runtime model swap
+        // (e.g. a fresh `/models/load`) flips the vision gate before
+        // either this turn's image attachments OR the agent's
+        // see/screenshot tool calls run against a stale capability.
+        // Always called — the probe is a single local HTTP GET with a
+        // 2s timeout, and only mutates the gate on actual change.
+        if let Some(rev) = self.vision_revalidator.as_ref() {
+            rev.revalidate().await;
+        }
+        // Decode wire attachments into internal Attachment values up
+        // front so a malformed base64 payload fails before we wake the
+        // model — saves the user the GPU round-trip on a bad request.
+        let attachments: Vec<Attachment> = match decode_wire_attachments(&wire_attachments) {
+            Ok(v) => v,
+            Err(e) => {
+                let _ = tx
+                    .send(Event::Error {
+                        id: id.clone(),
+                        message: format!("invalid attachment: {e}"),
+                    })
+                    .await;
+                return Err(anyhow::anyhow!("invalid attachment: {e}"));
+            }
+        };
         // Auto-wake and take an in-flight guard: a query in any
         // non-Active state blocks here until the daemon is ready to
         // serve. The returned guard keeps the daemon `Active` for the
@@ -124,13 +218,34 @@ impl AppState {
         let llm = self.llm.clone();
         let tools = self.tools.clone();
         let max_iterations = self.config.agent.max_iterations;
-        let generator =
-            tokio::spawn(
-                async move {
-                    run_agent_turn(llm, tools, max_iterations, text, Vec::new(), llm_tx).await
-                }
-                .in_current_span(),
-            );
+        // Cancellation token: wired to the agent loop so a slow LLM
+        // step or tool dispatch can be preempted promptly. Today we
+        // only fire it when this function returns (drop) — that
+        // unblocks the agent task if the dispatch loop below bailed
+        // mid-stream. Future MCP work will also fire it on explicit
+        // shutdown signals.
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let cancel_for_agent = cancel.clone();
+        // Drop guard: when this function returns for any reason
+        // (including early bail from the dispatch loop below), the
+        // guard cancels the token, ensuring the agent task wakes up
+        // and exits even if it's parked in `backend.step`.
+        let _cancel_on_return = cancel.clone().drop_guard();
+        let generator = tokio::spawn(
+            async move {
+                run_agent_turn(
+                    llm,
+                    tools,
+                    max_iterations,
+                    text,
+                    attachments,
+                    llm_tx,
+                    cancel_for_agent,
+                )
+                .await
+            }
+            .in_current_span(),
+        );
 
         // Sentence buffer + speech worker. Each completed sentence is
         // sent to a per-query worker task that calls voice_output.speak
@@ -660,7 +775,7 @@ impl AppState {
         // Auto-feed the agent loop, reusing the Query handler so
         // streaming deltas, tool calls, and Done all land on the
         // same connection and correlate to this request's id.
-        self.handle_query(id, text, tx).await
+        self.handle_query(id, text, Vec::new(), tx).await
     }
 }
 
@@ -731,6 +846,8 @@ mod tests {
         let req = Request::Query {
             id: "q1".into(),
             text: "hello".into(),
+            attachments: Vec::new(),
+            version: None,
         };
 
         state.dispatch(req, tx).await.unwrap();
@@ -816,6 +933,8 @@ mod tests {
         let req = Request::Query {
             id: "q-err".into(),
             text: "boom".into(),
+            attachments: Vec::new(),
+            version: None,
         };
 
         let err = state.dispatch(req, tx).await.unwrap_err();
@@ -921,6 +1040,8 @@ mod tests {
         let req = Request::Query {
             id: "req-42".into(),
             text: "go".into(),
+            attachments: Vec::new(),
+            version: None,
         };
         state.dispatch(req, tx).await.unwrap();
 
@@ -1421,6 +1542,8 @@ mod tests {
                 Request::Query {
                     id: "ord".into(),
                     text: "First. Second. Third. End.".into(),
+                    attachments: Vec::new(),
+                    version: None,
                 },
                 tx,
             )
@@ -1530,6 +1653,8 @@ mod tests {
                 Request::Query {
                     id: "pf".into(),
                     text: "go".into(),
+                    attachments: Vec::new(),
+                    version: None,
                 },
                 tx,
             )
@@ -1568,6 +1693,8 @@ mod tests {
                 Request::Query {
                     id: "pf0".into(),
                     text: "go".into(),
+                    attachments: Vec::new(),
+                    version: None,
                 },
                 tx,
             )
@@ -1726,6 +1853,8 @@ mod tests {
                 Request::Query {
                     id: "tc".into(),
                     text: "go".into(),
+                    attachments: Vec::new(),
+                    version: None,
                 },
                 tx,
             )
@@ -1761,6 +1890,8 @@ mod tests {
                 Request::Query {
                     id: "drain".into(),
                     text: "Hello world.".into(),
+                    attachments: Vec::new(),
+                    version: None,
                 },
                 tx,
             )

--- a/crates/assistd-ipc/Cargo.toml
+++ b/crates/assistd-ipc/Cargo.toml
@@ -7,3 +7,7 @@ license.workspace = true
 [dependencies]
 serde = { workspace = true }
 serde_json = { workspace = true }
+base64 = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/assistd-ipc/src/lib.rs
+++ b/crates/assistd-ipc/src/lib.rs
@@ -1,3 +1,14 @@
+#![allow(unsafe_code)] // libc / env / fd primitives — each unsafe block is locally justified
+#![cfg_attr(
+    test,
+    allow(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::print_stdout,
+        clippy::print_stderr
+    )
+)]
+
 //! Wire-level IPC types shared between the assistd daemon and its clients.
 //!
 //! Kept in its own crate so a client-only build can depend on just these
@@ -14,8 +25,42 @@
 //! Every event carries the originating request's `id`, so a future
 //! multiplexing transport can correlate concurrent in-flight requests.
 
+use base64::Engine;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
+
+/// Wire-protocol version. Bumped when an existing field's semantics
+/// change in a non-additive way; new optional fields don't bump this.
+/// Servers log a warning and continue when they see a version they
+/// don't understand, so additive evolution stays compatible.
+pub const PROTOCOL_VERSION: u32 = 1;
+
+/// An image attachment carried over the wire alongside a [`Request::Query`].
+/// `data_base64` is standard base64 (with padding); the daemon decodes
+/// it back into raw bytes before handing it to the LLM. `mime` is one of
+/// the values `assistd-tools::attachment` accepts (image/png, image/jpeg,
+/// image/webp).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ImageAttachment {
+    pub mime: String,
+    pub data_base64: String,
+}
+
+impl ImageAttachment {
+    /// Build from raw bytes. Allocates the base64-encoded string.
+    pub fn from_bytes(mime: impl Into<String>, bytes: &[u8]) -> Self {
+        Self {
+            mime: mime.into(),
+            data_base64: base64::engine::general_purpose::STANDARD.encode(bytes),
+        }
+    }
+
+    /// Decode `data_base64` back to bytes. Returns `Err` if the field is
+    /// not valid base64.
+    pub fn decode_bytes(&self) -> Result<Vec<u8>, base64::DecodeError> {
+        base64::engine::general_purpose::STANDARD.decode(&self.data_base64)
+    }
+}
 
 /// Coarse daemon lifecycle state exposed on the wire so clients and the
 /// daemon can agree on resource usage. `Sleeping` means llama-server is
@@ -65,77 +110,90 @@ pub enum Request {
     Query {
         id: String,
         text: String,
+        /// Image attachments to surface as vision inputs on this turn.
+        /// Empty for text-only queries; deserializes from missing fields
+        /// for backward compat.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        attachments: Vec<ImageAttachment>,
+        /// Wire-protocol version the client speaks. None means a
+        /// legacy client (pre-versioning); the daemon accepts these
+        /// for now but logs a warning.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        version: Option<u32>,
     },
     /// Drive the daemon to a specific presence state.
-    SetPresence {
-        id: String,
-        target: PresenceState,
-    },
+    SetPresence { id: String, target: PresenceState },
     /// Report the daemon's current presence state.
-    GetPresence {
-        id: String,
-    },
+    GetPresence { id: String },
     /// Atomically advance the daemon one step along
     /// `Active → Drowsy → Sleeping → Active`.
-    Cycle {
-        id: String,
-    },
+    Cycle { id: String },
     /// Begin a push-to-talk recording. Returns immediately with `Done`
     /// once cpal has opened the device; audio is buffered in the daemon
     /// until a matching `PttStop` arrives.
-    PttStart {
-        id: String,
-    },
+    PttStart { id: String },
     /// End the push-to-talk recording and transcribe what was captured.
     /// Emits `VoiceState::Transcribing`, then `Transcription { text }`,
     /// then the text is dispatched internally as a `Query` whose
     /// streaming `Delta`s flow back on the same connection before `Done`.
-    PttStop {
-        id: String,
-    },
+    PttStop { id: String },
     /// Enable hands-free continuous listening. The daemon keeps the mic
     /// open and auto-dispatches each VAD-segmented utterance as a
     /// `Query`. Emits `ListenState { active: true }` + `Done`.
     /// Rejects with `Error` when a PTT recording is already in flight.
-    ListenStart {
-        id: String,
-    },
+    ListenStart { id: String },
     /// Disable continuous listening. Emits `ListenState { active: false }`
     /// + `Done`. Idempotent when already stopped.
-    ListenStop {
-        id: String,
-    },
+    ListenStop { id: String },
     /// Flip continuous listening on/off in a single call. Emits the
     /// post-toggle `ListenState` + `Done`.
-    ListenToggle {
-        id: String,
-    },
+    ListenToggle { id: String },
     /// Report whether continuous listening is currently active. Emits
     /// `ListenState` + `Done` with no state change.
-    GetListenState {
-        id: String,
-    },
+    GetListenState { id: String },
     /// Flip TTS on/off at runtime. Off cancels in-flight playback and
     /// drains any subsequent sentences for the active query without
     /// speaking them; on resumes for the next sentence delivered. Emits
     /// the post-toggle `VoiceOutputState` + `Done`.
-    VoiceToggle {
-        id: String,
-    },
+    VoiceToggle { id: String },
     /// Abort the current TTS response: drop the rest of the audio queue
     /// and any pending sentences for the active query. Does not change
     /// the enabled flag. Emits `VoiceOutputState` + `Done`.
-    VoiceSkip {
-        id: String,
-    },
+    VoiceSkip { id: String },
     /// Report whether TTS is currently enabled. Emits `VoiceOutputState`
     /// + `Done` with no state change.
-    GetVoiceState {
-        id: String,
-    },
+    GetVoiceState { id: String },
 }
 
 impl Request {
+    /// Build a text-only [`Request::Query`] tagged with the current
+    /// [`PROTOCOL_VERSION`]. Use this in clients to keep call sites
+    /// short; legacy struct-literal construction still works for
+    /// callers that need to set `attachments` explicitly.
+    pub fn query(id: impl Into<String>, text: impl Into<String>) -> Self {
+        Request::Query {
+            id: id.into(),
+            text: text.into(),
+            attachments: Vec::new(),
+            version: Some(PROTOCOL_VERSION),
+        }
+    }
+
+    /// Build a [`Request::Query`] with one or more image attachments,
+    /// tagged with the current [`PROTOCOL_VERSION`].
+    pub fn query_with_attachments(
+        id: impl Into<String>,
+        text: impl Into<String>,
+        attachments: Vec<ImageAttachment>,
+    ) -> Self {
+        Request::Query {
+            id: id.into(),
+            text: text.into(),
+            attachments,
+            version: Some(PROTOCOL_VERSION),
+        }
+    }
+
     /// Returns the request id every variant carries.
     pub fn id(&self) -> &str {
         match self {
@@ -259,14 +317,73 @@ mod tests {
 
     #[test]
     fn request_roundtrip() {
+        // Legacy struct-literal form: empty attachments + no version are
+        // both skipped on serialize so the wire shape is unchanged from
+        // pre-multimodality clients.
         let req = Request::Query {
             id: "req-1".into(),
             text: "ping".into(),
+            attachments: Vec::new(),
+            version: None,
         };
         let json = serde_json::to_string(&req).unwrap();
         assert_eq!(json, r#"{"type":"query","id":"req-1","text":"ping"}"#);
         let parsed: Request = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed, req);
+    }
+
+    #[test]
+    fn request_query_with_version_and_attachments_roundtrip() {
+        let req = Request::query_with_attachments(
+            "req-2",
+            "describe this",
+            vec![ImageAttachment::from_bytes(
+                "image/png",
+                &[0xDE, 0xAD, 0xBE, 0xEF],
+            )],
+        );
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains(r#""version":1"#));
+        assert!(json.contains(r#""data_base64":"3q2+7w==""#));
+        let parsed: Request = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, req);
+    }
+
+    #[test]
+    fn request_query_helper_emits_current_version() {
+        let req = Request::query("req-3", "hi");
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains(&format!(r#""version":{PROTOCOL_VERSION}"#)));
+    }
+
+    #[test]
+    fn legacy_query_payload_deserializes_with_default_attachments() {
+        // A pre-multimodality client emits the original two-field shape.
+        // Older daemons keep accepting it: attachments defaults to empty,
+        // version defaults to None.
+        let json = r#"{"type":"query","id":"req-4","text":"hello"}"#;
+        let parsed: Request = serde_json::from_str(json).unwrap();
+        match parsed {
+            Request::Query {
+                id,
+                text,
+                attachments,
+                version,
+            } => {
+                assert_eq!(id, "req-4");
+                assert_eq!(text, "hello");
+                assert!(attachments.is_empty());
+                assert_eq!(version, None);
+            }
+            _ => panic!("expected Query"),
+        }
+    }
+
+    #[test]
+    fn image_attachment_round_trips_through_base64() {
+        let payload = b"\x89PNG\r\n\x1a\n";
+        let att = ImageAttachment::from_bytes("image/png", payload);
+        assert_eq!(att.decode_bytes().unwrap(), payload);
     }
 
     #[test]

--- a/crates/assistd-llm/Cargo.toml
+++ b/crates/assistd-llm/Cargo.toml
@@ -14,7 +14,7 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "sync", "time", "io-util", "process", "net"] }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 reqwest = { workspace = true }
@@ -35,3 +35,6 @@ tempfile = "3"
 name = "fake_llama_server"
 path = "src/bin/fake_llama_server.rs"
 required-features = ["test-support"]
+
+[lints]
+workspace = true

--- a/crates/assistd-llm/src/lib.rs
+++ b/crates/assistd-llm/src/lib.rs
@@ -1,3 +1,13 @@
+#![cfg_attr(
+    test,
+    allow(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::print_stdout,
+        clippy::print_stderr
+    )
+)]
+
 //! LLM backend trait and stub implementations.
 //!
 //! Concrete backends (`llama.cpp`, `ollama`, etc.) live in their own
@@ -10,7 +20,8 @@ pub mod llama_server;
 
 pub use chat::{ChatClientError, LlamaChatClient};
 pub use llama_server::{
-    LlamaServerControl, LlamaServerError, LlamaService, ReadyState, detect_vision_support,
+    LlamaServerControl, LlamaServerError, LlamaService, ReadyState, VisionState,
+    detect_vision_support, probe_capabilities,
 };
 
 use anyhow::Result;

--- a/crates/assistd-llm/src/llama_server/capabilities.rs
+++ b/crates/assistd-llm/src/llama_server/capabilities.rs
@@ -28,12 +28,50 @@ use tracing::{debug, warn};
 
 const PROBE_TIMEOUT: Duration = Duration::from_secs(2);
 
+/// Snapshot of a single `/props` probe. `model_id` is whatever
+/// llama-server reports as the loaded model — used by callers to
+/// detect a model swap between probes and trigger a re-probe rather
+/// than trusting a stale `vision_supported` value.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct VisionState {
+    pub model_id: Option<String>,
+    pub vision_supported: bool,
+}
+
+/// Probe llama-server for both the model identifier and vision
+/// capability. Returns a default (no model id, no vision) on any
+/// failure, with the same fail-closed semantics as the historical
+/// [`detect_vision_support`] entrypoint.
+pub async fn probe_capabilities(host: &str, port: u16) -> VisionState {
+    let body = match fetch_props(host, port).await {
+        Some(v) => v,
+        None => return VisionState::default(),
+    };
+    let model_id = parse_model_id(&body);
+    let vision_supported = parse_vision_supported(&body);
+    debug!(
+        target: "assistd::llama_server",
+        "/props parsed; model_id = {model_id:?}, vision_supported = {vision_supported}"
+    );
+    VisionState {
+        model_id,
+        vision_supported,
+    }
+}
+
 /// Returns `true` iff the running llama-server reports a loaded vision
 /// encoder. Returns `false` on any error (HTTP failure, non-200,
 /// malformed JSON) and logs at `warn` so the daemon's startup log
 /// captures the reason. The caller should treat a `false` result as
 /// "vision unavailable" and fall back accordingly.
+///
+/// Thin wrapper around [`probe_capabilities`] preserved for callers
+/// that don't need the model id.
 pub async fn detect_vision_support(host: &str, port: u16) -> bool {
+    probe_capabilities(host, port).await.vision_supported
+}
+
+async fn fetch_props(host: &str, port: u16) -> Option<Value> {
     let url = format!("http://{host}:{port}/props");
     let client = match reqwest::Client::builder()
         .no_proxy()
@@ -44,48 +82,58 @@ pub async fn detect_vision_support(host: &str, port: u16) -> bool {
         Err(e) => {
             warn!(
                 target: "assistd::llama_server",
-                "vision capability probe: failed to build HTTP client: {e}; assuming no vision support"
+                "/props probe: failed to build HTTP client: {e}"
             );
-            return false;
+            return None;
         }
     };
-
     let resp = match client.get(&url).send().await {
         Ok(r) => r,
         Err(e) => {
             warn!(
                 target: "assistd::llama_server",
-                "vision capability probe: GET /props failed: {e}; assuming no vision support"
+                "/props probe: GET failed: {e}"
             );
-            return false;
+            return None;
         }
     };
     if !resp.status().is_success() {
         warn!(
             target: "assistd::llama_server",
-            "vision capability probe: GET /props returned {}; assuming no vision support",
+            "/props probe: GET returned {}",
             resp.status()
         );
-        return false;
+        return None;
     }
-
-    let body: Value = match resp.json().await {
-        Ok(v) => v,
+    match resp.json::<Value>().await {
+        Ok(v) => Some(v),
         Err(e) => {
             warn!(
                 target: "assistd::llama_server",
-                "vision capability probe: /props body was not JSON: {e}; assuming no vision support"
+                "/props body was not JSON: {e}"
             );
-            return false;
+            None
         }
-    };
+    }
+}
 
-    let supported = parse_vision_supported(&body);
-    debug!(
-        target: "assistd::llama_server",
-        "vision capability probe: /props parsed; vision_supported = {supported}"
-    );
-    supported
+/// Pull a model identifier from a `/props` body. llama.cpp has reported
+/// this under a few different keys (`model`, `model_path`,
+/// `default_generation_settings.model`), so try them in order. Returns
+/// `None` if no recognizable field is present.
+fn parse_model_id(body: &Value) -> Option<String> {
+    const TOP_LEVEL_KEYS: &[&str] = &["model", "model_path", "model_name"];
+    for key in TOP_LEVEL_KEYS {
+        if let Some(s) = body.get(*key).and_then(Value::as_str) {
+            return Some(s.to_string());
+        }
+    }
+    if let Some(settings) = body.get("default_generation_settings")
+        && let Some(s) = settings.get("model").and_then(Value::as_str)
+    {
+        return Some(s.to_string());
+    }
+    None
 }
 
 /// Inspect a parsed `/props` body for any field that signals
@@ -180,5 +228,43 @@ mod tests {
             "multimodal": false,
         });
         assert!(parse_vision_supported(&body));
+    }
+
+    #[test]
+    fn parses_top_level_model_field() {
+        let body = json!({"model": "bartowski/Qwen3-14B-GGUF:Q4_K_M"});
+        assert_eq!(
+            parse_model_id(&body).as_deref(),
+            Some("bartowski/Qwen3-14B-GGUF:Q4_K_M")
+        );
+    }
+
+    #[test]
+    fn parses_top_level_model_path_when_model_absent() {
+        let body = json!({"model_path": "/var/cache/llm/qwen-vl.gguf"});
+        assert_eq!(
+            parse_model_id(&body).as_deref(),
+            Some("/var/cache/llm/qwen-vl.gguf")
+        );
+    }
+
+    #[test]
+    fn parses_nested_default_generation_settings_model() {
+        let body = json!({
+            "default_generation_settings": {"model": "nested/model"},
+        });
+        assert_eq!(parse_model_id(&body).as_deref(), Some("nested/model"));
+    }
+
+    #[test]
+    fn returns_none_when_no_model_field_present() {
+        let body = json!({"total_slots": 1});
+        assert_eq!(parse_model_id(&body), None);
+    }
+
+    #[test]
+    fn ignores_non_string_model_value() {
+        let body = json!({"model": 42});
+        assert_eq!(parse_model_id(&body), None);
     }
 }

--- a/crates/assistd-llm/src/llama_server/mod.rs
+++ b/crates/assistd-llm/src/llama_server/mod.rs
@@ -20,7 +20,7 @@ pub mod service;
 pub mod supervisor;
 
 pub use backoff::MAX_CONSECUTIVE_FAILURES;
-pub use capabilities::detect_vision_support;
+pub use capabilities::{VisionState, detect_vision_support, probe_capabilities};
 pub use control::LlamaServerControl;
 pub use error::LlamaServerError;
 pub use service::{LlamaService, ReadyState};

--- a/crates/assistd-llm/src/llama_server/process.rs
+++ b/crates/assistd-llm/src/llama_server/process.rs
@@ -1,3 +1,5 @@
+#![allow(unsafe_code)] // libc / env / fd primitives — each unsafe block is locally justified
+
 use super::error::LlamaServerError;
 use assistd_config::{LlamaServerConfig, ModelConfig};
 use std::process::{ExitStatus, Stdio};

--- a/crates/assistd-llm/src/llama_server/service.rs
+++ b/crates/assistd-llm/src/llama_server/service.rs
@@ -37,6 +37,7 @@ impl LlamaService {
     /// that watch externally causes the supervisor to tear down the child and
     /// exit; a call to `start` that sees shutdown before Ready returns
     /// `ShutdownDuringHealth`.
+    #[tracing::instrument(skip(cfg, model, shutdown_rx), fields(host = %cfg.host, port = cfg.port))]
     pub async fn start(
         cfg: LlamaServerConfig,
         model: ModelConfig,
@@ -99,7 +100,7 @@ impl LlamaService {
     /// PID of the currently-running child, or `None` if no child is alive.
     /// The value changes as the supervisor restarts the child.
     pub fn pid(&self) -> Option<u32> {
-        *self.pid.lock().expect("pid mutex poisoned")
+        *self.pid.lock().unwrap_or_else(|e| e.into_inner())
     }
 
     /// Awaits the supervisor task. The caller is expected to have already

--- a/crates/assistd-llm/src/llama_server/supervisor.rs
+++ b/crates/assistd-llm/src/llama_server/supervisor.rs
@@ -117,7 +117,7 @@ impl Supervisor {
 
     async fn supervise_once(&mut self) -> Result<CycleResult, LlamaServerError> {
         let mut child = ChildProcess::spawn(&self.cfg, &self.model)?;
-        *self.pid.lock().expect("pid mutex poisoned") = child.pid();
+        *self.pid.lock().unwrap_or_else(|e| e.into_inner()) = child.pid();
         let ready_timeout = Duration::from_secs(self.cfg.ready_timeout_secs);
         let health = HealthChecker::new(&self.cfg.host, self.cfg.port, ready_timeout)?;
 
@@ -145,17 +145,17 @@ impl Supervisor {
         match phase1 {
             Phase1::Ready => { /* fall through */ }
             Phase1::ChildExited(status) => {
-                *self.pid.lock().expect("pid mutex poisoned") = None;
+                *self.pid.lock().unwrap_or_else(|e| e.into_inner()) = None;
                 return Ok(CycleResult::FailedToStart { status });
             }
             Phase1::ShuttingDown => {
                 child.shutdown(TERM_TIMEOUT).await?;
-                *self.pid.lock().expect("pid mutex poisoned") = None;
+                *self.pid.lock().unwrap_or_else(|e| e.into_inner()) = None;
                 return Ok(CycleResult::ShutdownRequested);
             }
             Phase1::StartupError(e) => {
                 child.shutdown(TERM_TIMEOUT).await?;
-                *self.pid.lock().expect("pid mutex poisoned") = None;
+                *self.pid.lock().unwrap_or_else(|e| e.into_inner()) = None;
                 return Err(e);
             }
         }
@@ -178,7 +178,7 @@ impl Supervisor {
                 Ok(CycleResult::ShutdownRequested)
             }
         };
-        *self.pid.lock().expect("pid mutex poisoned") = None;
+        *self.pid.lock().unwrap_or_else(|e| e.into_inner()) = None;
         result
     }
 }

--- a/crates/assistd-llm/tests/presence.rs
+++ b/crates/assistd-llm/tests/presence.rs
@@ -1,3 +1,5 @@
+#![allow(unsafe_code)] // libc / env / fd primitives — each unsafe block is locally justified
+
 //! End-to-end tests for the presence state machine.
 //!
 //! These exercise `PresenceManager` against a real `fake_llama_server` child
@@ -329,6 +331,8 @@ async fn query_during_sleeping_triggers_auto_wake() {
     let req = Request::Query {
         id: "q1".into(),
         text: "hello".into(),
+        attachments: Vec::new(),
+        version: None,
     };
     let stream = UnixStream::connect(&sock_path).await.unwrap();
     let (read, mut write) = stream.into_split();
@@ -486,6 +490,8 @@ async fn sleep_defers_until_inflight_query_done() {
     let req = Request::Query {
         id: "q1".into(),
         text: "hello".into(),
+        attachments: Vec::new(),
+        version: None,
     };
     let sock_for_client = sock_path.clone();
     let client_task = tokio::spawn(async move { connect_and_send(&sock_for_client, &req).await });
@@ -583,6 +589,8 @@ async fn multiple_queries_during_wake_complete_in_order() {
         let req = Request::Query {
             id: id.clone(),
             text: text.clone(),
+            attachments: Vec::new(),
+            version: None,
         };
         handles.push((
             id,

--- a/crates/assistd-llm/tests/supervisor.rs
+++ b/crates/assistd-llm/tests/supervisor.rs
@@ -1,3 +1,5 @@
+#![allow(unsafe_code)] // libc / env / fd primitives — each unsafe block is locally justified
+
 //! Integration tests for the llama-server supervisor.
 //!
 //! These tests are gated behind the `test-support` feature because they need

--- a/crates/assistd-mcp/Cargo.toml
+++ b/crates/assistd-mcp/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "assistd-mcp"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+assistd-tools = { workspace = true }
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+base64 = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt", "sync"] }
+tracing = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread"] }
+
+[lints]
+workspace = true

--- a/crates/assistd-mcp/src/lib.rs
+++ b/crates/assistd-mcp/src/lib.rs
@@ -1,0 +1,325 @@
+#![cfg_attr(
+    test,
+    allow(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::print_stdout,
+        clippy::print_stderr
+    )
+)]
+
+//! MCP (Model Context Protocol) **client** trait sketch.
+//!
+//! Milestone 5 will land a concrete `stdio` JSON-RPC implementation
+//! plus per-server lifecycle (spawn, ready-probe, restart-on-crash).
+//! This crate exists ahead of that work to settle the trait shape and
+//! the bridge into the existing [`assistd_tools::Tool`] registry, so
+//! we're not retrofitting `AppState` and the agent loop mid-feature.
+//!
+//! # Architecture
+//!
+//! From the daemon's perspective, an MCP server is a *tool source*:
+//! - On startup, the daemon connects to each configured MCP server.
+//! - `list_tools` returns each server's tool catalog.
+//! - For each entry, the daemon wraps it in an [`McpToolAdapter`] and
+//!   registers it with the existing `ToolRegistry` — same registry
+//!   the LLM already iterates for OpenAI-style schemas.
+//! - When the LLM calls a wrapped tool, the adapter forwards the
+//!   call to [`McpClient::invoke`] on the originating server.
+//!
+//! # Why a separate trait, not a `Tool` impl?
+//!
+//! A single MCP server typically exposes many tools, with distinct
+//! schemas and dynamic discovery. Modeling each tool as its own
+//! `Tool` impl would either require generating a struct per tool at
+//! compile time (impossible — schemas come from the wire) or a giant
+//! match. Instead we keep `McpClient` as a connection-level handle,
+//! and use the [`McpToolAdapter`] type to turn each
+//! `(client, tool_name, schema)` tuple into a `Tool` registry entry.
+//!
+//! # Image-bearing tool results
+//!
+//! [`ToolResult::Image`] feeds straight into the existing
+//! `assistd_tools::Attachment::Image` so a remote screenshot tool
+//! lands in the same vision-input pipeline as the local
+//! `screenshot` command. This is the reason the IPC schema work in
+//! `assistd-ipc` carries `ImageAttachment` over the wire — keeping
+//! local and remote attachments shape-compatible end-to-end.
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use assistd_tools::{Attachment, Tool};
+use async_trait::async_trait;
+use serde_json::{Value, json};
+
+/// One tool exposed by an MCP server.
+#[derive(Debug, Clone)]
+pub struct ToolSchema {
+    /// Tool name as it will appear in the LLM's `tools` list. The
+    /// daemon may decorate this (e.g. `mcp:server-name:tool-name`)
+    /// before registration to avoid collisions across servers.
+    pub name: String,
+    /// Human-readable description the LLM sees.
+    pub description: String,
+    /// JSON Schema for the `arguments` object the LLM will pass.
+    /// Forwarded verbatim to the underlying server.
+    pub input_schema: Value,
+}
+
+/// Result of an MCP tool invocation. Mirrors the three shapes
+/// llama.cpp / OpenAI tool calls already flow through:
+/// strings, structured JSON, and images.
+#[derive(Debug, Clone)]
+pub enum ToolResult {
+    Text(String),
+    Image { mime: String, bytes: Vec<u8> },
+    Json(Value),
+}
+
+/// A connection to a single MCP server.
+#[async_trait]
+pub trait McpClient: Send + Sync + 'static {
+    /// List all tools the server currently exposes. Called at
+    /// startup; concrete implementations may refresh on demand
+    /// (Milestone 5) but must be safe to call concurrently.
+    async fn list_tools(&self) -> Result<Vec<ToolSchema>>;
+
+    /// Invoke `name` with `arguments`. The daemon strips any
+    /// registry-side prefix (e.g. `mcp:server-name:`) before
+    /// forwarding, so `name` is the server-native identifier.
+    async fn invoke(&self, name: &str, arguments: Value) -> Result<ToolResult>;
+}
+
+/// Wraps a single (client, tool) pair as a [`Tool`] registry entry.
+/// The daemon's tool-registry code is unchanged: it iterates
+/// `ToolRegistry` and the adapter takes care of the dispatch hop.
+pub struct McpToolAdapter {
+    client: Arc<dyn McpClient>,
+    schema: ToolSchema,
+    /// The name as exposed to the LLM. May be a prefixed form
+    /// (`mcp:foo:bar`) when the daemon namespaces multiple servers.
+    /// We carry the *server-native* name in `schema.name` and the
+    /// *registry* name here so `invoke` can strip the prefix.
+    registry_name: String,
+}
+
+impl McpToolAdapter {
+    pub fn new(client: Arc<dyn McpClient>, schema: ToolSchema, registry_name: String) -> Self {
+        Self {
+            client,
+            schema,
+            registry_name,
+        }
+    }
+}
+
+#[async_trait]
+impl Tool for McpToolAdapter {
+    fn name(&self) -> &str {
+        &self.registry_name
+    }
+
+    fn description(&self) -> &str {
+        &self.schema.description
+    }
+
+    fn parameters_schema(&self) -> Value {
+        self.schema.input_schema.clone()
+    }
+
+    async fn invoke(&self, args: Value) -> Result<Value> {
+        let result = self.client.invoke(&self.schema.name, args).await?;
+        Ok(tool_result_to_json(result))
+    }
+}
+
+/// Map a [`ToolResult`] into the JSON shape `RunTool` already emits
+/// to the LLM. `Image` results carry their bytes alongside the JSON
+/// so the tool dispatch site can lift them into [`Attachment::Image`]
+/// for the next turn — same as `see` / `screenshot`.
+fn tool_result_to_json(r: ToolResult) -> Value {
+    match r {
+        ToolResult::Text(s) => json!({ "type": "text", "text": s }),
+        ToolResult::Json(v) => json!({ "type": "json", "value": v }),
+        ToolResult::Image { mime, bytes } => json!({
+            "type": "image",
+            "mime": mime,
+            // Raw bytes inlined as base64 keeps the JSON-only contract
+            // of `Tool::invoke`. The dispatch site (Milestone 5) decodes
+            // and lifts to Attachment::Image before the next LLM turn.
+            "bytes_base64": base64_encode(&bytes),
+        }),
+    }
+}
+
+/// Lift a JSON-encoded image (as produced by [`tool_result_to_json`])
+/// back into an [`Attachment::Image`] for the LLM's next turn. Returns
+/// `None` if the value isn't an `image`-typed result. Will be called
+/// from the agent loop when Milestone 5 wires MCP into the dispatch.
+pub fn image_attachment_from_tool_result(v: &Value) -> Option<Attachment> {
+    if v.get("type").and_then(Value::as_str) != Some("image") {
+        return None;
+    }
+    let mime = v.get("mime").and_then(Value::as_str)?;
+    let b64 = v.get("bytes_base64").and_then(Value::as_str)?;
+    let bytes = base64_decode(b64).ok()?;
+    Some(Attachment::Image {
+        mime: mime.to_string(),
+        bytes,
+    })
+}
+
+/// Build [`Tool`] registry entries for every tool an MCP client
+/// exposes. The daemon will call this once per configured server at
+/// startup, prefix the names with the server label to avoid
+/// collisions, and register each entry with the existing
+/// `ToolRegistry`. No concrete client implementation lives here yet —
+/// Milestone 5 lands one and the wiring just becomes a `for server in
+/// config.mcp.servers { ... }` loop in `build_tools`.
+pub async fn adapt_client_as_tools(
+    client: Arc<dyn McpClient>,
+    name_prefix: &str,
+) -> Result<Vec<Box<dyn Tool>>> {
+    let schemas = client.list_tools().await?;
+    let mut out: Vec<Box<dyn Tool>> = Vec::with_capacity(schemas.len());
+    for schema in schemas {
+        let registry_name = if name_prefix.is_empty() {
+            schema.name.clone()
+        } else {
+            format!("{name_prefix}:{}", schema.name)
+        };
+        out.push(Box::new(McpToolAdapter::new(
+            client.clone(),
+            schema,
+            registry_name,
+        )));
+    }
+    Ok(out)
+}
+
+fn base64_encode(bytes: &[u8]) -> String {
+    use base64_dep::Engine;
+    base64_dep::engine::general_purpose::STANDARD.encode(bytes)
+}
+
+fn base64_decode(s: &str) -> Result<Vec<u8>, base64_dep::DecodeError> {
+    use base64_dep::Engine;
+    base64_dep::engine::general_purpose::STANDARD.decode(s)
+}
+
+// Internal alias to keep base64 a single import path. assistd-tools
+// already depends on base64 transitively via assistd-ipc; declaring
+// our own dep would be redundant. We re-export under a private name
+// so the public surface of this crate stays minimal.
+mod base64_dep {
+    pub use base64::*;
+}
+
+pub fn version() -> &'static str {
+    env!("CARGO_PKG_VERSION")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Trait-only fake server: returns a static tool list and echoes
+    /// arguments back as a Text result. Lets us exercise the adapter
+    /// without standing up real I/O.
+    struct FakeMcpClient {
+        schemas: Vec<ToolSchema>,
+    }
+
+    #[async_trait]
+    impl McpClient for FakeMcpClient {
+        async fn list_tools(&self) -> Result<Vec<ToolSchema>> {
+            Ok(self.schemas.clone())
+        }
+
+        async fn invoke(&self, name: &str, arguments: Value) -> Result<ToolResult> {
+            Ok(ToolResult::Text(format!("called {name} with {arguments}")))
+        }
+    }
+
+    fn one_tool_client() -> Arc<dyn McpClient> {
+        Arc::new(FakeMcpClient {
+            schemas: vec![ToolSchema {
+                name: "search".into(),
+                description: "search the web".into(),
+                input_schema: json!({"type": "object", "properties": {}}),
+            }],
+        })
+    }
+
+    #[tokio::test]
+    async fn adapter_forwards_tool_metadata() {
+        let client = one_tool_client();
+        let tools = adapt_client_as_tools(client, "mcp:web").await.unwrap();
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0].name(), "mcp:web:search");
+        assert_eq!(tools[0].description(), "search the web");
+    }
+
+    #[tokio::test]
+    async fn adapter_strips_prefix_before_invoking() {
+        // Registry sees `mcp:web:search` but the upstream server
+        // expects bare `search`. The adapter must forward the
+        // server-native name.
+        let client = one_tool_client();
+        let tools = adapt_client_as_tools(client, "mcp:web").await.unwrap();
+        let tool = tools.into_iter().next().unwrap();
+        let out = tool.invoke(json!({"q": "rust"})).await.unwrap();
+        assert_eq!(out["type"], "text");
+        let text = out["text"].as_str().unwrap();
+        assert!(text.starts_with("called search "), "{text}");
+    }
+
+    #[tokio::test]
+    async fn empty_prefix_leaves_name_unchanged() {
+        let client = one_tool_client();
+        let tools = adapt_client_as_tools(client, "").await.unwrap();
+        assert_eq!(tools[0].name(), "search");
+    }
+
+    #[test]
+    fn image_tool_result_serialises_to_base64_json() {
+        let v = tool_result_to_json(ToolResult::Image {
+            mime: "image/png".into(),
+            bytes: vec![0xDE, 0xAD, 0xBE, 0xEF],
+        });
+        assert_eq!(v["type"], "image");
+        assert_eq!(v["mime"], "image/png");
+        assert_eq!(v["bytes_base64"], "3q2+7w==");
+    }
+
+    #[test]
+    fn image_round_trips_through_json_to_attachment() {
+        let bytes = vec![1u8, 2, 3, 4, 5, 6];
+        let json = tool_result_to_json(ToolResult::Image {
+            mime: "image/jpeg".into(),
+            bytes: bytes.clone(),
+        });
+        let lifted = image_attachment_from_tool_result(&json).expect("must lift");
+        match lifted {
+            Attachment::Image {
+                mime,
+                bytes: lifted_bytes,
+            } => {
+                assert_eq!(mime, "image/jpeg");
+                assert_eq!(lifted_bytes, bytes);
+            }
+        }
+    }
+
+    #[test]
+    fn image_lift_returns_none_for_non_image_result() {
+        let v = tool_result_to_json(ToolResult::Text("hi".into()));
+        assert!(image_attachment_from_tool_result(&v).is_none());
+    }
+
+    #[test]
+    fn version_is_not_empty() {
+        assert!(!version().is_empty());
+    }
+}

--- a/crates/assistd-memory/Cargo.toml
+++ b/crates/assistd-memory/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "assistd-wm"
+name = "assistd-memory"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -7,9 +7,11 @@ license.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
+tokio = { workspace = true, features = ["sync"] }
+tracing = { workspace = true }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["macros", "rt"] }
+tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread"] }
 
 [lints]
 workspace = true

--- a/crates/assistd-memory/src/lib.rs
+++ b/crates/assistd-memory/src/lib.rs
@@ -1,0 +1,139 @@
+#![cfg_attr(
+    test,
+    allow(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::print_stdout,
+        clippy::print_stderr
+    )
+)]
+
+//! Persistent-memory subsystem trait and a no-op placeholder.
+//!
+//! Milestone 4 will land a SQLite-backed concrete implementation; this
+//! crate exists now so the trait shape and the [`AppState`] wiring are
+//! settled before the first storage code is written. Locking the
+//! interface down up front avoids retrofitting every call site once
+//! the real backend arrives.
+//!
+//! # Trait shape
+//!
+//! [`MemoryStore`] is a small key/value surface scoped to **string
+//! values keyed by string keys**. Richer types (e.g. embeddings,
+//! conversation snapshots) are intentionally *not* on this trait —
+//! they will live in higher-level adapters that serialize to/from this
+//! flat surface so the storage backend can stay simple. The methods
+//! mirror the four operations the agent loop will need at minimum:
+//! `save` to commit a fact, `load` to recall one, `delete` to forget,
+//! and `list` to enumerate keys under a prefix (used for namespaced
+//! categories like `pref:`, `fact:`, `summary:`).
+//!
+//! # The `NoMemoryStore` placeholder
+//!
+//! Mirrors the shape of `assistd_voice::NoVoiceOutput`: every method
+//! is a successful no-op so the daemon's startup path can wire a
+//! `MemoryStore` unconditionally and degrade gracefully on a build or
+//! environment where persistent storage isn't configured. `load`
+//! returns `Ok(None)`, `list` returns `Ok(vec![])`, and `save` /
+//! `delete` succeed silently — so an agent calling them in this
+//! configuration just behaves as if it has no long-term memory.
+
+use anyhow::Result;
+use async_trait::async_trait;
+
+/// Persistent key/value memory accessible to the daemon and the
+/// agent loop. Implementors must be `Send + Sync + 'static` because
+/// `AppState` holds them as `Arc<dyn MemoryStore>`.
+#[async_trait]
+pub trait MemoryStore: Send + Sync + 'static {
+    /// Persist `value` under `key`. Overwrites any existing value at
+    /// the same key. Concrete implementations decide their own
+    /// durability semantics (write-through vs. periodic flush) — the
+    /// trait makes no guarantees beyond "the next `load(key)` from
+    /// this process should observe the write".
+    async fn save(&self, key: &str, value: String) -> Result<()>;
+
+    /// Read the value previously stored at `key`. Returns `Ok(None)`
+    /// when the key is absent (distinct from an `Err` path, which is
+    /// reserved for backend failures).
+    async fn load(&self, key: &str) -> Result<Option<String>>;
+
+    /// Remove `key`. No-op when the key is already absent — this
+    /// matches the agent-loop usage pattern of "forget X if you
+    /// remember it" and saves a probe-then-delete round trip.
+    async fn delete(&self, key: &str) -> Result<()>;
+
+    /// Enumerate keys whose name starts with `prefix`. Order is
+    /// unspecified. Used for namespaced categories (`pref:`, `fact:`,
+    /// `summary:`) so the agent can list "all preferences" without
+    /// scanning the whole store.
+    async fn list(&self, prefix: &str) -> Result<Vec<String>>;
+}
+
+/// Successful-no-op fallback used when no persistent backend is
+/// configured. Wired unconditionally in `AppState` so the agent loop
+/// can call `MemoryStore` methods without checking for an `Option`.
+pub struct NoMemoryStore;
+
+#[async_trait]
+impl MemoryStore for NoMemoryStore {
+    async fn save(&self, key: &str, _value: String) -> Result<()> {
+        tracing::debug!(target: "assistd::memory", key, "save: no backend configured (drop)");
+        Ok(())
+    }
+
+    async fn load(&self, _key: &str) -> Result<Option<String>> {
+        Ok(None)
+    }
+
+    async fn delete(&self, _key: &str) -> Result<()> {
+        Ok(())
+    }
+
+    async fn list(&self, _prefix: &str) -> Result<Vec<String>> {
+        Ok(Vec::new())
+    }
+}
+
+pub fn version() -> &'static str {
+    env!("CARGO_PKG_VERSION")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn no_memory_store_save_and_load_round_trip_returns_none() {
+        // The placeholder accepts saves silently and reports the key
+        // as absent on load. This is the contract the agent loop
+        // depends on for the no-backend configuration.
+        let store = NoMemoryStore;
+        store.save("fact:user.name", "Ben".into()).await.unwrap();
+        assert_eq!(store.load("fact:user.name").await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn no_memory_store_delete_is_silent() {
+        let store = NoMemoryStore;
+        store.delete("fact:nonexistent").await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn no_memory_store_list_returns_empty() {
+        let store = NoMemoryStore;
+        assert!(store.list("fact:").await.unwrap().is_empty());
+    }
+
+    #[test]
+    fn version_is_not_empty() {
+        assert!(!version().is_empty());
+    }
+
+    /// Compile-only: prove the trait is object-safe by holding it
+    /// behind `Arc<dyn MemoryStore>`. AppState relies on this shape.
+    #[test]
+    fn memory_store_is_object_safe() {
+        let _: std::sync::Arc<dyn MemoryStore> = std::sync::Arc::new(NoMemoryStore);
+    }
+}

--- a/crates/assistd-tools/Cargo.toml
+++ b/crates/assistd-tools/Cargo.toml
@@ -11,7 +11,7 @@ async-trait = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt", "sync", "time", "io-util", "fs", "process"] }
 tracing = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true }
@@ -21,3 +21,6 @@ shlex = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/assistd-tools/src/attachment.rs
+++ b/crates/assistd-tools/src/attachment.rs
@@ -14,6 +14,12 @@ use crate::command::Attachment;
 /// we filter explicitly.
 const SUPPORTED_MIMES: &[&str] = &["image/png", "image/jpeg", "image/webp"];
 
+/// Hard upper bound on image size we'll accept from disk or a screenshot.
+/// 32 MiB is generous for a 4K PNG screenshot (~16 MiB uncompressed) but
+/// catches accidental video-or-RAW attaches before they reach the LLM
+/// pipeline and OOM the daemon.
+pub const MAX_IMAGE_BYTES: u64 = 32 * 1024 * 1024;
+
 #[derive(Debug)]
 pub enum LoadImageError {
     /// File missing, unreadable, or other I/O failure.
@@ -21,6 +27,8 @@ pub enum LoadImageError {
         path: String,
         source: std::io::Error,
     },
+    /// File exceeds [`MAX_IMAGE_BYTES`].
+    TooLarge { path: String, size: u64, max: u64 },
     /// `infer` couldn't identify the file type from its magic bytes.
     Unrecognized { path: String },
     /// `infer` identified a non-image type.
@@ -39,6 +47,11 @@ impl LoadImageError {
                 std::io::ErrorKind::PermissionDenied => format!("permission denied: {path}"),
                 _ => format!("{path}: {source}"),
             },
+            LoadImageError::TooLarge { path, size, max } => format!(
+                "image too large: {path} ({} > {} max)",
+                human_mib(*size),
+                human_mib(*max),
+            ),
             LoadImageError::Unrecognized { path } => {
                 format!("not a recognized image file: {path}")
             }
@@ -59,6 +72,23 @@ impl LoadImageError {
 /// conversation layer) plus the file size in bytes (so the caller can
 /// render a "12 KB" annotation without re-stat-ing).
 pub async fn load_image_attachment(path: &Path) -> Result<(Attachment, usize), LoadImageError> {
+    // Stat first so a multi-gigabyte file is rejected before we allocate
+    // a buffer for it. `metadata` resolves symlinks, matching what `read`
+    // would do — no surprise where the size check disagrees with what we
+    // end up reading.
+    let meta = tokio::fs::metadata(path)
+        .await
+        .map_err(|e| LoadImageError::Io {
+            path: path.display().to_string(),
+            source: e,
+        })?;
+    if meta.len() > MAX_IMAGE_BYTES {
+        return Err(LoadImageError::TooLarge {
+            path: path.display().to_string(),
+            size: meta.len(),
+            max: MAX_IMAGE_BYTES,
+        });
+    }
     let bytes = tokio::fs::read(path)
         .await
         .map_err(|e| LoadImageError::Io {
@@ -91,6 +121,15 @@ pub async fn load_image_attachment(path: &Path) -> Result<(Attachment, usize), L
         },
         size,
     ))
+}
+
+fn human_mib(n: u64) -> String {
+    const MIB: u64 = 1024 * 1024;
+    if n >= MIB {
+        format!("{:.1} MiB", n as f64 / MIB as f64)
+    } else {
+        format!("{} B", n)
+    }
 }
 
 #[cfg(test)]
@@ -158,5 +197,27 @@ mod tests {
             LoadImageError::UnsupportedFormat { mime, .. } => assert_eq!(mime, "image/gif"),
             other => panic!("expected UnsupportedFormat, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn oversize_file_is_rejected_before_read() {
+        // Use a sparse file so the test doesn't actually allocate
+        // MAX_IMAGE_BYTES + 1 of disk. set_len + drop is enough — metadata()
+        // reports the logical size and load_image_attachment rejects on
+        // that, never reaching the read path.
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("huge.png");
+        let f = tokio::fs::File::create(&path).await.unwrap();
+        f.set_len(MAX_IMAGE_BYTES + 1).await.unwrap();
+        drop(f);
+        let err = load_image_attachment(&path).await.unwrap_err();
+        match err {
+            LoadImageError::TooLarge { size, max, .. } => {
+                assert_eq!(size, MAX_IMAGE_BYTES + 1);
+                assert_eq!(max, MAX_IMAGE_BYTES);
+            }
+            other => panic!("expected TooLarge, got {other:?}"),
+        }
+        assert!(err.user_message().starts_with("image too large:"));
     }
 }

--- a/crates/assistd-tools/src/commands/screenshot.rs
+++ b/crates/assistd-tools/src/commands/screenshot.rs
@@ -62,10 +62,14 @@ pub enum Backend {
     Wayland,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 enum Target {
     Full,
     Focused,
+    /// Capture only the named monitor/output. On X11 the name is
+    /// resolved through `xrandr` to a geometry passed to maim; on
+    /// Wayland it's passed verbatim to grim's `-o` flag.
+    Monitor(String),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -77,18 +81,15 @@ enum WaylandCompositor {
 
 pub struct ScreenshotCommand {
     cfg: Arc<ScreenshotPolicyCfg>,
-    /// Set at startup from a `/props` probe of the running llama-server.
-    /// When `false`, `run()` short-circuits to the vision-not-available
-    /// error without spawning the capture backend.
-    vision_enabled: bool,
+    /// Shared, runtime-mutable vision flag. See [`crate::VisionGate`].
+    /// Read on every `run()` so a model swap (revalidated by the daemon)
+    /// can flip the gate without rebuilding the registry.
+    gate: Arc<crate::VisionGate>,
 }
 
 impl ScreenshotCommand {
-    pub fn new(cfg: Arc<ScreenshotPolicyCfg>, vision_enabled: bool) -> Self {
-        Self {
-            cfg,
-            vision_enabled,
-        }
+    pub fn new(cfg: Arc<ScreenshotPolicyCfg>, gate: Arc<crate::VisionGate>) -> Self {
+        Self { cfg, gate }
     }
 }
 
@@ -98,7 +99,10 @@ impl Default for ScreenshotCommand {
     /// enabled. Lets the convention-compliance harness in `command.rs`
     /// construct an instance without config plumbing.
     fn default() -> Self {
-        Self::new(Arc::new(ScreenshotPolicyCfg::default()), true)
+        Self::new(
+            Arc::new(ScreenshotPolicyCfg::default()),
+            crate::VisionGate::new(true),
+        )
     }
 }
 
@@ -109,7 +113,7 @@ impl Command for ScreenshotCommand {
     }
 
     fn summary(&self) -> &'static str {
-        if self.vision_enabled {
+        if self.gate.supported() {
             "capture the screen as a PNG and attach it for the next LLM turn"
         } else {
             "(unavailable: model has no vision encoder)"
@@ -117,12 +121,14 @@ impl Command for ScreenshotCommand {
     }
 
     fn help(&self) -> String {
-        "usage: screenshot [--full|--focused]\n\
+        "usage: screenshot [--full|--focused|--monitor=<name>]\n\
          \n\
          Capture the screen and attach it as a vision input for the next \
          LLM turn (kept in memory; never written to disk by default).\n\
          \n\
-         Without arguments, captures the full screen. Pass --focused to \
+         Without arguments, captures the full screen (which on multi-head \
+         setups means the bounding box across all monitors — pass \
+         --monitor=<name> to capture a single output). Pass --focused to \
          capture only the currently focused window.\n\
          \n\
          The display server is auto-detected: maim is used on X11, grim \
@@ -130,6 +136,12 @@ impl Command for ScreenshotCommand {
            X11: xdotool to find the active window\n  \
            Wayland (sway): swaymsg to read the focused node geometry\n  \
            Wayland (Hyprland): hyprctl to read the active-window geometry\n\
+         \n\
+         --monitor=<name> requires:\n  \
+           X11: xrandr to resolve the connector name to a geometry\n  \
+           Wayland: grim's -o flag (no extra binary)\n\
+         List monitors with `xrandr --listmonitors` (X11) or \
+         `swaymsg -t get_outputs` / `hyprctl monitors` (Wayland).\n\
          \n\
          Exit codes:\n  \
            0   success — image attached\n  \
@@ -145,7 +157,7 @@ impl Command for ScreenshotCommand {
     }
 
     async fn run(&self, input: CommandInput) -> Result<CommandOutput> {
-        if !self.vision_enabled {
+        if !self.gate.supported() {
             return Ok(CommandOutput::failed(
                 1,
                 error_line(
@@ -192,12 +204,28 @@ impl Command for ScreenshotCommand {
             },
         };
 
-        match capture(backend, target, self.cfg.timeout).await {
+        match capture(backend, &target, self.cfg.timeout).await {
             Ok(png) => {
+                if png.len() as u64 > crate::attachment::MAX_IMAGE_BYTES {
+                    return Ok(CommandOutput::failed(
+                        1,
+                        error_line(
+                            "screenshot",
+                            format_args!(
+                                "captured PNG too large ({} > {} max)",
+                                human_size(png.len()),
+                                human_size(crate::attachment::MAX_IMAGE_BYTES as usize),
+                            ),
+                            "Try",
+                            "--focused, or capture a single monitor",
+                        )
+                        .into_bytes(),
+                    ));
+                }
                 let stdout = format!(
                     "captured PNG ({}, {}, backend={}) — attached to next turn\n",
                     human_size(png.len()),
-                    target_label(target),
+                    target_label(&target),
                     backend_label(backend),
                 );
                 Ok(CommandOutput {
@@ -221,16 +249,35 @@ fn parse_args(args: &[String]) -> Result<Target, String> {
         1 => match args[0].as_str() {
             "--full" => Ok(Target::Full),
             "--focused" => Ok(Target::Focused),
+            s if s.starts_with("--monitor=") => {
+                let name = &s["--monitor=".len()..];
+                if name.is_empty() {
+                    Err("--monitor requires a name (try `xrandr --listmonitors` or `swaymsg -t get_outputs`)".into())
+                } else {
+                    Ok(Target::Monitor(name.to_string()))
+                }
+            }
+            "--monitor" => {
+                Err("--monitor requires a value: --monitor=<name> (e.g. --monitor=DP-1)".into())
+            }
             other => Err(format!("unknown flag: {other}")),
         },
-        _ => Err("expects at most one flag (--full or --focused)".into()),
+        2 if args[0] == "--monitor" => {
+            if args[1].is_empty() {
+                Err("--monitor requires a non-empty name".into())
+            } else {
+                Ok(Target::Monitor(args[1].clone()))
+            }
+        }
+        _ => Err("expects at most one flag (--full, --focused, or --monitor=<name>)".into()),
     }
 }
 
-fn target_label(t: Target) -> &'static str {
+fn target_label(t: &Target) -> &'static str {
     match t {
         Target::Full => "full-screen",
         Target::Focused => "focused-window",
+        Target::Monitor(_) => "monitor",
     }
 }
 
@@ -330,15 +377,95 @@ enum CaptureError {
 
 async fn capture(
     backend: Backend,
-    target: Target,
+    target: &Target,
     deadline: Duration,
 ) -> Result<Vec<u8>, CaptureError> {
     match (backend, target) {
         (Backend::X11, Target::Full) => spawn_subprocess("maim", &[], deadline).await,
         (Backend::X11, Target::Focused) => capture_x11_focused(deadline).await,
+        (Backend::X11, Target::Monitor(name)) => capture_x11_monitor(name, deadline).await,
         (Backend::Wayland, Target::Full) => spawn_subprocess("grim", &["-"], deadline).await,
         (Backend::Wayland, Target::Focused) => capture_wayland_focused(deadline).await,
+        (Backend::Wayland, Target::Monitor(name)) => {
+            spawn_subprocess("grim", &["-o", name, "-"], deadline).await
+        }
     }
+}
+
+/// Parse `xrandr --listmonitors` output. Each non-header line looks
+/// like:
+///   ` 0: +*HDMI-1 1920/598x1200/336+0+0  HDMI-1`
+/// or:
+///   ` 1: +DP-2 2560/600x1440/340+1920+0  DP-2`
+/// We extract the `WIDTH/...xHEIGHT/...+X+Y` triple, drop the
+/// physical-size denominators, and return `WxH+X+Y` formatted for
+/// maim's `-g` flag. Match by trailing connector name (last whitespace
+/// token on the line) since the asterisks/pluses on the leading
+/// connector field vary.
+fn parse_xrandr_monitor_geom(listing: &str, monitor: &str) -> Option<String> {
+    for line in listing.lines() {
+        // Skip the `Monitors: N` header.
+        if !line.starts_with(|c: char| c.is_whitespace() || c.is_ascii_digit()) {
+            continue;
+        }
+        let trimmed = line.trim();
+        // Last whitespace-separated token is the connector name.
+        let name = trimmed.split_whitespace().next_back()?;
+        if name != monitor {
+            continue;
+        }
+        // The geometry token is the one matching `<num>/<num>x<num>/<num>+<num>+<num>`.
+        for tok in trimmed.split_whitespace() {
+            if let Some(geom) = strip_xrandr_geom_token(tok) {
+                return Some(geom);
+            }
+        }
+    }
+    None
+}
+
+/// Strip a single xrandr geometry token like `1920/598x1200/336+0+0`
+/// down to maim's `1920x1200+0+0` form. Returns `None` if the token
+/// doesn't match the expected shape.
+fn strip_xrandr_geom_token(tok: &str) -> Option<String> {
+    // Required structure: `<w>/<wmm>x<h>/<hmm>+<x>+<y>` (the second
+    // `+` may be `-` for monitors positioned off-zero, but we accept
+    // any sign).
+    let (lhs, after_x) = tok.split_once('x')?;
+    let (w_with_mm, _) = lhs.split_once('/')?;
+    let w: u32 = w_with_mm.parse().ok()?;
+    // After 'x' we have `<h>/<hmm>+<x>+<y>`. Take the first '+' or
+    // '-' as the start of the offset block (after the height/mm).
+    let h_end = after_x.find(['+', '-']).filter(|i| *i > 0)?;
+    let height_with_mm = &after_x[..h_end];
+    let offsets = &after_x[h_end..];
+    let (h_with_mm, _) = height_with_mm.split_once('/')?;
+    let h: u32 = h_with_mm.parse().ok()?;
+    // `offsets` begins with the sign of x. Must contain exactly one
+    // more sign-prefixed number for y.
+    let mut chars = offsets.char_indices().peekable();
+    chars.next()?; // consume leading sign
+    let next_sign_idx = chars.find(|(_, c)| *c == '+' || *c == '-')?.0;
+    let x_part = &offsets[..next_sign_idx];
+    let y_part = &offsets[next_sign_idx..];
+    // Validate both parts parse as signed integers.
+    x_part.parse::<i32>().ok()?;
+    y_part.parse::<i32>().ok()?;
+    Some(format!("{w}x{h}{x_part}{y_part}"))
+}
+
+/// Look up `monitor`'s geometry via `xrandr --listmonitors` and feed
+/// it to maim as `-g WxH+X+Y`. xrandr emits one line per active
+/// monitor in the form:
+///   `1: +*HDMI-1 1920/598x1200/336+0+0  HDMI-1`
+/// We need the `1920x1200+0+0` triple for maim.
+async fn capture_x11_monitor(monitor: &str, deadline: Duration) -> Result<Vec<u8>, CaptureError> {
+    let raw = spawn_subprocess("xrandr", &["--listmonitors"], deadline).await?;
+    let listing = String::from_utf8_lossy(&raw);
+    let geom = parse_xrandr_monitor_geom(&listing, monitor).ok_or_else(|| CaptureError::Parse {
+        what: format!("monitor `{monitor}` not found in xrandr output"),
+    })?;
+    spawn_subprocess("maim", &["-g", &geom], deadline).await
 }
 
 /// Spawn `binary` with `args`, drain stdout to `Vec<u8>`, drain stderr to
@@ -627,6 +754,34 @@ mod tests {
         assert!(err.contains("at most one"), "{err}");
     }
 
+    #[test]
+    fn parse_monitor_equals_form() {
+        assert_eq!(
+            parse_args(&["--monitor=DP-1".into()]),
+            Ok(Target::Monitor("DP-1".into()))
+        );
+    }
+
+    #[test]
+    fn parse_monitor_two_arg_form() {
+        assert_eq!(
+            parse_args(&["--monitor".into(), "HDMI-1".into()]),
+            Ok(Target::Monitor("HDMI-1".into()))
+        );
+    }
+
+    #[test]
+    fn parse_monitor_without_value_errors() {
+        let err = parse_args(&["--monitor".into()]).unwrap_err();
+        assert!(err.contains("--monitor=<name>"), "{err}");
+    }
+
+    #[test]
+    fn parse_monitor_empty_equals_value_errors() {
+        let err = parse_args(&["--monitor=".into()]).unwrap_err();
+        assert!(err.contains("--monitor"), "{err}");
+    }
+
     /// The convention-compliance test in `command.rs` drives this exact path
     /// (bogus flag) to verify our error format. Re-asserting here keeps the
     /// failure message in this file when the format changes.
@@ -765,6 +920,26 @@ mod tests {
         assert!(parse_hyprland_geom(&v).is_none());
     }
 
+    #[test]
+    fn hyprland_geom_string_coords_returns_none() {
+        // Defensive: a future hyprctl version that emits coords as
+        // strings must not silently parse to garbage geometry.
+        let v = serde_json::json!({
+            "at": ["100", "200"],
+            "size": ["800", "600"],
+        });
+        assert!(parse_hyprland_geom(&v).is_none());
+    }
+
+    #[test]
+    fn hyprland_geom_short_array_returns_none() {
+        let v = serde_json::json!({
+            "at": [100],
+            "size": [800, 600],
+        });
+        assert!(parse_hyprland_geom(&v).is_none());
+    }
+
     // ---- Sway tree walking -----------------------------------------------
 
     #[test]
@@ -807,6 +982,103 @@ mod tests {
     fn sway_no_focused_node_returns_none() {
         let v = serde_json::json!({"focused": false, "nodes": []});
         assert!(find_focused_sway_rect(&v).is_none());
+    }
+
+    #[test]
+    fn sway_walks_three_levels_deep() {
+        // Real swaymsg output nests workspaces > containers > windows.
+        // The walker must recurse past at least 3 levels to find a
+        // focused leaf.
+        let v = serde_json::json!({
+            "focused": false,
+            "nodes": [
+                {"focused": false, "nodes": [
+                    {"focused": false, "nodes": [
+                        {
+                            "focused": true,
+                            "rect": {"x": 100, "y": 200, "width": 1280, "height": 720}
+                        }
+                    ]}
+                ]}
+            ]
+        });
+        assert_eq!(
+            find_focused_sway_rect(&v),
+            Some("100,200 1280x720".to_string())
+        );
+    }
+
+    #[test]
+    fn sway_focused_node_missing_rect_returns_none() {
+        // A malformed tree (focused=true but no rect) should not
+        // panic — find_focused_sway_rect uses `?` to propagate None.
+        let v = serde_json::json!({"focused": true});
+        assert!(find_focused_sway_rect(&v).is_none());
+    }
+
+    // ---- xrandr monitor geometry ----------------------------------------
+
+    /// Real `xrandr --listmonitors` output from a single-head HDMI
+    /// session. The geometry token carries physical-mm denominators
+    /// we need to strip.
+    const XRANDR_SINGLE: &str = "Monitors: 1\n \
+        0: +*HDMI-1 1920/598x1200/336+0+0  HDMI-1\n";
+
+    /// Two-head laptop+external. Note the second monitor positions
+    /// past 1920 on x, and one connector has the `+*` (primary)
+    /// prefix while the other has just `+`.
+    const XRANDR_DUAL: &str = "Monitors: 2\n \
+        0: +*eDP-1 1920/300x1080/180+0+0  eDP-1\n \
+        1: +DP-2 2560/600x1440/340+1920+0  DP-2\n";
+
+    #[test]
+    fn parse_xrandr_single_monitor() {
+        assert_eq!(
+            parse_xrandr_monitor_geom(XRANDR_SINGLE, "HDMI-1").as_deref(),
+            Some("1920x1200+0+0")
+        );
+    }
+
+    #[test]
+    fn parse_xrandr_dual_monitor_picks_correct_geometry() {
+        assert_eq!(
+            parse_xrandr_monitor_geom(XRANDR_DUAL, "eDP-1").as_deref(),
+            Some("1920x1080+0+0")
+        );
+        assert_eq!(
+            parse_xrandr_monitor_geom(XRANDR_DUAL, "DP-2").as_deref(),
+            Some("2560x1440+1920+0")
+        );
+    }
+
+    #[test]
+    fn parse_xrandr_unknown_monitor_returns_none() {
+        assert!(parse_xrandr_monitor_geom(XRANDR_DUAL, "VGA-1").is_none());
+    }
+
+    #[test]
+    fn strip_xrandr_geom_token_drops_mm_denominators() {
+        assert_eq!(
+            strip_xrandr_geom_token("1920/598x1200/336+0+0").as_deref(),
+            Some("1920x1200+0+0")
+        );
+    }
+
+    #[test]
+    fn strip_xrandr_geom_token_handles_negative_offsets() {
+        // A monitor positioned to the left of (0,0).
+        assert_eq!(
+            strip_xrandr_geom_token("1920/598x1080/336-1920+0").as_deref(),
+            Some("1920x1080-1920+0")
+        );
+    }
+
+    #[test]
+    fn strip_xrandr_geom_token_rejects_unrelated_tokens() {
+        // The connector-name field must NOT be treated as geometry.
+        assert!(strip_xrandr_geom_token("HDMI-1").is_none());
+        // Missing offsets → None.
+        assert!(strip_xrandr_geom_token("1920/598x1200/336").is_none());
     }
 
     // ---- missing-binary path ---------------------------------------------
@@ -899,7 +1171,10 @@ mod tests {
     /// images" without spawning maim/grim.
     #[tokio::test]
     async fn vision_disabled_returns_exact_error() {
-        let cmd = ScreenshotCommand::new(Arc::new(ScreenshotPolicyCfg::default()), false);
+        let cmd = ScreenshotCommand::new(
+            Arc::new(ScreenshotPolicyCfg::default()),
+            crate::VisionGate::new(false),
+        );
         let out = cmd
             .run(CommandInput {
                 args: vec!["--full".into()],
@@ -925,8 +1200,14 @@ mod tests {
 
     #[test]
     fn summary_changes_when_vision_disabled() {
-        let enabled = ScreenshotCommand::new(Arc::new(ScreenshotPolicyCfg::default()), true);
-        let disabled = ScreenshotCommand::new(Arc::new(ScreenshotPolicyCfg::default()), false);
+        let enabled = ScreenshotCommand::new(
+            Arc::new(ScreenshotPolicyCfg::default()),
+            crate::VisionGate::new(true),
+        );
+        let disabled = ScreenshotCommand::new(
+            Arc::new(ScreenshotPolicyCfg::default()),
+            crate::VisionGate::new(false),
+        );
         assert!(enabled.summary().contains("capture the screen"));
         assert!(disabled.summary().contains("unavailable"));
     }

--- a/crates/assistd-tools/src/commands/see.rs
+++ b/crates/assistd-tools/src/commands/see.rs
@@ -6,6 +6,7 @@
 //! next turn.
 
 use std::path::Path;
+use std::sync::Arc;
 
 use anyhow::Result;
 use async_trait::async_trait;
@@ -13,17 +14,18 @@ use async_trait::async_trait;
 use crate::attachment::{LoadImageError, load_image_attachment};
 use crate::command::{Attachment, Command, CommandInput, CommandOutput, error_line, io_error_nav};
 use crate::commands::cat::human_size;
+use crate::vision::VisionGate;
 
 pub struct SeeCommand {
-    /// Set at startup from a `/props` probe of the running llama-server.
-    /// When `false`, `run()` short-circuits to the vision-not-available
-    /// error without touching the filesystem.
-    vision_enabled: bool,
+    /// Shared, runtime-mutable vision flag. Read on every `run()` so a
+    /// model swap on the running llama-server (revalidated by the
+    /// daemon) flips the gate without rebuilding the registry.
+    gate: Arc<VisionGate>,
 }
 
 impl SeeCommand {
-    pub fn new(vision_enabled: bool) -> Self {
-        Self { vision_enabled }
+    pub fn new(gate: Arc<VisionGate>) -> Self {
+        Self { gate }
     }
 }
 
@@ -34,7 +36,7 @@ impl Default for SeeCommand {
     /// per-command tests construct an instance without rethreading the
     /// flag through every call site.
     fn default() -> Self {
-        Self::new(true)
+        Self::new(VisionGate::new(true))
     }
 }
 
@@ -45,7 +47,7 @@ impl Command for SeeCommand {
     }
 
     fn summary(&self) -> &'static str {
-        if self.vision_enabled {
+        if self.gate.supported() {
             "attach an image file as a vision input for the next LLM turn"
         } else {
             "(unavailable: model has no vision encoder)"
@@ -65,7 +67,7 @@ impl Command for SeeCommand {
     }
 
     async fn run(&self, input: CommandInput) -> Result<CommandOutput> {
-        if !self.vision_enabled {
+        if !self.gate.supported() {
             return Ok(CommandOutput::failed(
                 1,
                 error_line(
@@ -114,6 +116,16 @@ impl Command for SeeCommand {
             Err(LoadImageError::Io { source, .. }) => Ok(CommandOutput::failed(
                 1,
                 io_error_nav("see", path, &source).into_bytes(),
+            )),
+            Err(e @ LoadImageError::TooLarge { .. }) => Ok(CommandOutput::failed(
+                1,
+                error_line(
+                    "see",
+                    e.user_message(),
+                    "Use",
+                    "a smaller image (resize or crop)",
+                )
+                .into_bytes(),
             )),
             Err(LoadImageError::Unrecognized { .. }) => Ok(CommandOutput::failed(
                 1,
@@ -264,7 +276,7 @@ mod tests {
     /// usage).
     #[tokio::test]
     async fn vision_disabled_returns_exact_error() {
-        let out = SeeCommand::new(false)
+        let out = SeeCommand::new(VisionGate::new(false))
             .run(CommandInput {
                 args: vec!["/tmp/some-image.png".into()],
                 stdin: Vec::new(),
@@ -287,7 +299,29 @@ mod tests {
 
     #[test]
     fn summary_changes_when_vision_disabled() {
-        assert!(SeeCommand::new(true).summary().contains("attach an image"));
-        assert!(SeeCommand::new(false).summary().contains("unavailable"));
+        assert!(
+            SeeCommand::new(VisionGate::new(true))
+                .summary()
+                .contains("attach an image")
+        );
+        assert!(
+            SeeCommand::new(VisionGate::new(false))
+                .summary()
+                .contains("unavailable")
+        );
+    }
+
+    #[test]
+    fn gate_flip_changes_summary_dynamically() {
+        // The whole point of VisionGate: a single Arc shared with the
+        // daemon's revalidation path can flip a long-lived command from
+        // "available" to "unavailable" mid-process without rebuilding.
+        let gate = VisionGate::new(true);
+        let cmd = SeeCommand::new(gate.clone());
+        assert!(cmd.summary().contains("attach an image"));
+        gate.set(false);
+        assert!(cmd.summary().contains("unavailable"));
+        gate.set(true);
+        assert!(cmd.summary().contains("attach an image"));
     }
 }

--- a/crates/assistd-tools/src/commands/write.rs
+++ b/crates/assistd-tools/src/commands/write.rs
@@ -1,3 +1,5 @@
+#![allow(unsafe_code)] // libc / env / fd primitives — each unsafe block is locally justified
+
 use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 
@@ -243,7 +245,7 @@ fn expand_tilde(raw: &str) -> Result<PathBuf, PathResolveError> {
 /// not touch disk. On absolute paths, a leading `/..` is silently discarded
 /// (same as the kernel's behaviour).
 pub(crate) fn lexical_clean(path: &Path) -> PathBuf {
-    let mut out: Vec<Component> = Vec::new();
+    let mut out: Vec<Component<'_>> = Vec::new();
     for comp in path.components() {
         match comp {
             Component::CurDir => {}

--- a/crates/assistd-tools/src/lib.rs
+++ b/crates/assistd-tools/src/lib.rs
@@ -1,3 +1,13 @@
+#![cfg_attr(
+    test,
+    allow(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::print_stdout,
+        clippy::print_stderr
+    )
+)]
+
 //! Tool-use subsystem: the trait every invokable tool implements, plus
 //! the registry the LLM looks up tool calls in.
 //!
@@ -15,6 +25,7 @@ pub mod commands;
 pub mod policy;
 pub mod presentation;
 pub mod run;
+pub mod vision;
 
 pub use attachment::{LoadImageError, load_image_attachment};
 pub use chain::{Chain, ParseError, execute, parse_chain};
@@ -25,6 +36,7 @@ pub use policy::{
 };
 pub use presentation::{PresentResult, present};
 pub use run::RunTool;
+pub use vision::VisionGate;
 
 use anyhow::Result;
 use async_trait::async_trait;

--- a/crates/assistd-tools/src/policy.rs
+++ b/crates/assistd-tools/src/policy.rs
@@ -1,3 +1,5 @@
+#![allow(unsafe_code)] // libc / env / fd primitives — each unsafe block is locally justified
+
 //! Command-execution policy: confirmation gates, pattern matchers, and
 //! sandbox probing.
 //!

--- a/crates/assistd-tools/src/run.rs
+++ b/crates/assistd-tools/src/run.rs
@@ -127,11 +127,17 @@ impl Tool for RunTool {
         })
     }
 
+    #[tracing::instrument(skip(self, args), fields(cmd = tracing::field::Empty))]
     async fn invoke(&self, args: Value) -> Result<Value> {
         let command = args
             .get("command")
             .and_then(|v| v.as_str())
             .ok_or_else(|| anyhow!("`command` (string) is required"))?;
+        // Surface the command name as a span field for filtering. The
+        // full command line can be long; the first whitespace-bounded
+        // token is the most useful identifier in trace output.
+        let cmd_token = command.split_whitespace().next().unwrap_or("");
+        tracing::Span::current().record("cmd", cmd_token);
 
         let start = Instant::now();
         let chain = match parse_chain(command) {

--- a/crates/assistd-tools/src/vision.rs
+++ b/crates/assistd-tools/src/vision.rs
@@ -1,0 +1,60 @@
+//! Shared, runtime-mutable vision-capability flag.
+//!
+//! Built once at daemon startup from a `/props` probe of llama-server
+//! (see `assistd_llm::probe_capabilities`) and held inside `AppState`.
+//! `SeeCommand` and `ScreenshotCommand` clone the `Arc<VisionGate>` and
+//! check `supported()` per invocation rather than capturing a `bool`,
+//! so a model-swap on the running llama-server (followed by a daemon
+//! revalidation) flips the gate cleanly without rebuilding the
+//! command registry.
+//!
+//! The flag is a plain `AtomicBool`. Revalidation is the daemon's
+//! concern — this crate intentionally does not depend on `assistd-llm`
+//! or do any HTTP itself.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+pub struct VisionGate {
+    supported: AtomicBool,
+}
+
+impl VisionGate {
+    pub fn new(initially_supported: bool) -> Arc<Self> {
+        Arc::new(Self {
+            supported: AtomicBool::new(initially_supported),
+        })
+    }
+
+    pub fn supported(&self) -> bool {
+        self.supported.load(Ordering::Acquire)
+    }
+
+    /// Update the flag. Call from the daemon's revalidation path when
+    /// a `/props` re-probe reports a model change.
+    pub fn set(&self, supported: bool) {
+        self.supported.store(supported, Ordering::Release);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_to_constructor_value() {
+        let gate = VisionGate::new(true);
+        assert!(gate.supported());
+        let gate = VisionGate::new(false);
+        assert!(!gate.supported());
+    }
+
+    #[test]
+    fn set_flips_observed_value() {
+        let gate = VisionGate::new(false);
+        gate.set(true);
+        assert!(gate.supported());
+        gate.set(false);
+        assert!(!gate.supported());
+    }
+}

--- a/crates/assistd-voice/Cargo.toml
+++ b/crates/assistd-voice/Cargo.toml
@@ -37,7 +37,7 @@ test-support = ["whisper", "mic", "listen", "tts", "dep:hound"]
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "sync", "time", "io-util", "fs", "process"] }
 tracing = { workspace = true }
 thiserror = { workspace = true }
 assistd-ipc = { workspace = true }
@@ -69,7 +69,10 @@ which = { workspace = true, optional = true }
 hound = { version = "3.5", optional = true }
 
 [dev-dependencies]
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "test-util"] }
 tracing-subscriber = { workspace = true }
 tempfile = { workspace = true }
 hound = "3.5"
+
+[lints]
+workspace = true

--- a/crates/assistd-voice/src/lib.rs
+++ b/crates/assistd-voice/src/lib.rs
@@ -1,3 +1,13 @@
+#![cfg_attr(
+    test,
+    allow(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::print_stdout,
+        clippy::print_stderr
+    )
+)]
+
 //! Voice subsystem: input (speech-to-text) and output (text-to-speech) traits.
 //!
 //! Milestone 5 ships voice input: [`WhisperTranscriber`] (whisper-rs) and

--- a/crates/assistd-voice/src/mic/capture.rs
+++ b/crates/assistd-voice/src/mic/capture.rs
@@ -345,7 +345,7 @@ impl CallbackState {
     }
 
     fn push_f32(&self, data: &[f32]) {
-        let mut scratch = self.scratch.lock().expect("scratch mutex poisoned");
+        let mut scratch = self.scratch.lock().unwrap_or_else(|e| e.into_inner());
         scratch.clear();
         if self.channels <= 1 {
             scratch.extend_from_slice(data);
@@ -360,7 +360,7 @@ impl CallbackState {
     }
 
     fn push_i16(&self, data: &[i16]) {
-        let mut scratch = self.scratch.lock().expect("scratch mutex poisoned");
+        let mut scratch = self.scratch.lock().unwrap_or_else(|e| e.into_inner());
         scratch.clear();
         let scale = i16::MAX as f32;
         if self.channels <= 1 {
@@ -378,7 +378,7 @@ impl CallbackState {
     }
 
     fn push_u16(&self, data: &[u16]) {
-        let mut scratch = self.scratch.lock().expect("scratch mutex poisoned");
+        let mut scratch = self.scratch.lock().unwrap_or_else(|e| e.into_inner());
         scratch.clear();
         // u16 is offset-binary — 32768 = silence.
         if self.channels <= 1 {
@@ -396,7 +396,7 @@ impl CallbackState {
     }
 
     fn push_mono(&self, mono: &[f32]) {
-        let mut prod = self.producer.lock().expect("producer mutex poisoned");
+        let mut prod = self.producer.lock().unwrap_or_else(|e| e.into_inner());
         let pushed = prod.push_slice(mono);
         let dropped = mono.len().saturating_sub(pushed);
         if dropped > 0 {

--- a/crates/assistd-voice/src/piper/cache.rs
+++ b/crates/assistd-voice/src/piper/cache.rs
@@ -1,3 +1,5 @@
+#![allow(unsafe_code)] // libc / env / fd primitives — each unsafe block is locally justified
+
 //! On-disk cache for Piper voices. Each voice is two files: a `.onnx`
 //! ONNX model and a matching `.onnx.json` config that carries the
 //! sample rate among other things. Both must sit side-by-side in the

--- a/crates/assistd-voice/src/piper/playback.rs
+++ b/crates/assistd-voice/src/piper/playback.rs
@@ -108,7 +108,7 @@ impl RodioPlaybackWorker {
     pub async fn drain(&self) -> Result<(), PiperError> {
         let player = self.player.clone();
         let (tx, rx) = oneshot::channel();
-        std::thread::Builder::new()
+        thread::Builder::new()
             .name("piper-rodio-drain".into())
             .spawn(move || {
                 player.sleep_until_end();

--- a/crates/assistd-voice/src/piper/service.rs
+++ b/crates/assistd-voice/src/piper/service.rs
@@ -118,13 +118,13 @@ impl PiperVoiceOutput {
     pub fn ready_state(&self) -> ReadyState {
         self.state
             .lock()
-            .expect("piper state mutex poisoned")
+            .unwrap_or_else(|e| e.into_inner())
             .ready
             .clone()
     }
 
     fn record_success(&self) {
-        let mut s = self.state.lock().expect("piper state mutex poisoned");
+        let mut s = self.state.lock().unwrap_or_else(|e| e.into_inner());
         s.recent_failures.clear();
         // Re-arming after a transient flap is intentional: a transient
         // stutter shouldn't permanently disable speech.
@@ -136,7 +136,7 @@ impl PiperVoiceOutput {
     }
 
     fn record_failure(&self, err: &PiperError) {
-        let mut s = self.state.lock().expect("piper state mutex poisoned");
+        let mut s = self.state.lock().unwrap_or_else(|e| e.into_inner());
         let now = Instant::now();
         // Drop entries older than the window.
         while let Some(&front) = s.recent_failures.front() {
@@ -168,7 +168,7 @@ impl VoiceOutput for PiperVoiceOutput {
         // Short-circuit when degraded — log once, then silent until a
         // future health check (manual restart for now) clears it.
         {
-            let s = self.state.lock().expect("piper state mutex poisoned");
+            let s = self.state.lock().unwrap_or_else(|e| e.into_inner());
             if let ReadyState::Degraded { ref reason } = s.ready {
                 if !s.logged_degraded {
                     tracing::warn!(
@@ -223,7 +223,7 @@ impl VoiceOutput for PiperVoiceOutput {
         // for any in-flight non-piper PCM, but in practice a degraded
         // service has no inflight work, so this is safe.
         {
-            let s = self.state.lock().expect("piper state mutex poisoned");
+            let s = self.state.lock().unwrap_or_else(|e| e.into_inner());
             if matches!(s.ready, ReadyState::Degraded { .. }) {
                 return Ok(());
             }

--- a/crates/assistd-voice/src/piper/synth.rs
+++ b/crates/assistd-voice/src/piper/synth.rs
@@ -142,7 +142,7 @@ impl OneShotSynth {
         if !status.success() {
             let tail_joined = stderr_tail
                 .lock()
-                .expect("stderr tail mutex poisoned")
+                .unwrap_or_else(|e| e.into_inner())
                 .iter()
                 .cloned()
                 .collect::<Vec<_>>()
@@ -201,7 +201,7 @@ async fn drain_stderr(stderr: ChildStderr, tail: Arc<Mutex<VecDeque<String>>>) {
     let mut lines = BufReader::new(stderr).lines();
     while let Ok(Some(line)) = lines.next_line().await {
         tracing::debug!(target: "assistd::voice::piper", "{line}");
-        let mut guard = tail.lock().expect("stderr tail mutex poisoned");
+        let mut guard = tail.lock().unwrap_or_else(|e| e.into_inner());
         if guard.len() == 20 {
             guard.pop_front();
         }

--- a/crates/assistd-voice/src/transcribe.rs
+++ b/crates/assistd-voice/src/transcribe.rs
@@ -131,10 +131,7 @@ pub struct QueueConfig {
 /// crate free of a concrete builder type.
 pub type CpuFallbackFactory = Arc<
     dyn Fn() -> std::pin::Pin<
-            Box<
-                dyn std::future::Future<Output = Result<Arc<dyn Transcriber>, TranscriptionError>>
-                    + Send,
-            >,
+            Box<dyn Future<Output = Result<Arc<dyn Transcriber>, TranscriptionError>> + Send>,
         > + Send
         + Sync,
 >;

--- a/crates/assistd-wm/src/lib.rs
+++ b/crates/assistd-wm/src/lib.rs
@@ -1,3 +1,13 @@
+#![cfg_attr(
+    test,
+    allow(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::print_stdout,
+        clippy::print_stderr
+    )
+)]
+
 //! Window manager / compositor integration trait.
 //!
 //! Milestone 8 ships concrete implementations for i3, Sway, and Hyprland

--- a/crates/assistd/Cargo.toml
+++ b/crates/assistd/Cargo.toml
@@ -15,7 +15,6 @@ daemon = [
     "dep:assistd-core",
     "dep:assistd-llm",
     "dep:assistd-voice",
-    "dep:assistd-tools",
     "dep:assistd-wm",
     "dep:tracing",
     "dep:tracing-subscriber",
@@ -39,17 +38,18 @@ chat = [
 
 [dependencies]
 # Always-on — shared CLI plumbing and wire protocol
-assistd-ipc = { workspace = true }
+assistd-ipc   = { workspace = true }
+assistd-tools = { workspace = true }  # the `client` --image flag uses load_image_attachment
 anyhow = { workspace = true }
 clap = { workspace = true }
 serde_json = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+tokio-util = { workspace = true }
 
 # Daemon-only
 assistd-core  = { workspace = true, optional = true }
 assistd-llm   = { workspace = true, optional = true }
 assistd-voice = { workspace = true, optional = true }
-assistd-tools = { workspace = true, optional = true }
 assistd-wm    = { workspace = true, optional = true }
 tracing = { workspace = true, optional = true }
 tracing-subscriber = { workspace = true, optional = true }
@@ -73,3 +73,6 @@ image            = { workspace = true, optional = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/assistd/src/chat/app.rs
+++ b/crates/assistd/src/chat/app.rs
@@ -294,6 +294,15 @@ impl App {
                 return;
             }
             KeyCode::Tab => {
+                // Tab on `/attach <partial>` completes the path; on
+                // any other input it falls through to the existing
+                // tool-block toggle. Putting the path-completion path
+                // first keeps the toggle a no-op when the user is
+                // mid-attach (which is what they'd expect when
+                // completing a filename).
+                if self.try_complete_attach_path() {
+                    return;
+                }
                 self.output.toggle_last_tool_block();
                 return;
             }
@@ -474,6 +483,93 @@ impl App {
         self.notice = Some((text.to_string(), Instant::now()));
     }
 
+    /// Tab completion for `/attach <partial-path>`. Returns `true` if
+    /// completion fired (so the caller skips its fallback action), or
+    /// `false` when the input isn't an attach line and the caller's
+    /// default Tab behavior should run.
+    ///
+    /// Behavior on a single Tab press:
+    /// - One match → buffer is extended to the full filename
+    ///   (with a trailing `/` for directories).
+    /// - Multiple matches → buffer is extended to the longest common
+    ///   prefix of all matches (so a second Tab can disambiguate).
+    /// - No matches → buffer is unchanged; the function still returns
+    ///   `true` so we don't fall through to the tool-block toggle.
+    fn try_complete_attach_path(&mut self) -> bool {
+        let buffer = self.input.buffer();
+        let partial = if let Some(rest) = buffer.strip_prefix("/attach ") {
+            rest
+        } else if let Some(rest) = buffer.strip_prefix("/attach_image ") {
+            rest
+        } else {
+            return false;
+        };
+        // Split off the directory portion so we know where to look.
+        // An empty `partial` lists $CWD; a trailing `/` lists that dir.
+        let (dir, file_prefix) = match partial.rsplit_once('/') {
+            Some((d, f)) => (
+                if d.is_empty() {
+                    PathBuf::from("/")
+                } else {
+                    expand_tilde(d)
+                },
+                f,
+            ),
+            None => (PathBuf::from("."), partial),
+        };
+        let entries: Vec<(String, bool)> = match std::fs::read_dir(&dir) {
+            Ok(rd) => rd
+                .filter_map(|e| e.ok())
+                .filter_map(|e| {
+                    let name = e.file_name().to_string_lossy().to_string();
+                    if name.starts_with(file_prefix) {
+                        let is_dir = e.file_type().map(|t| t.is_dir()).unwrap_or(false);
+                        Some((name, is_dir))
+                    } else {
+                        None
+                    }
+                })
+                .collect(),
+            Err(_) => return true,
+        };
+        if entries.is_empty() {
+            return true;
+        }
+        // Longest common prefix across all matches; for a single
+        // match this is the full name.
+        let names: Vec<&str> = entries.iter().map(|(n, _)| n.as_str()).collect();
+        let lcp = longest_common_prefix(&names);
+        let completed = if entries.len() == 1 {
+            let (name, is_dir) = &entries[0];
+            // Directories get a trailing slash so a second Tab
+            // descends into them naturally.
+            if *is_dir {
+                format!("{name}/")
+            } else {
+                name.clone()
+            }
+        } else if lcp.len() > file_prefix.len() {
+            lcp.to_string()
+        } else {
+            // Already at the LCP — nothing to extend on this Tab.
+            return true;
+        };
+        // Rebuild the buffer keeping the original `/attach[_image] `
+        // prefix and the directory portion.
+        let cmd_prefix = if buffer.starts_with("/attach_image ") {
+            "/attach_image "
+        } else {
+            "/attach "
+        };
+        let dir_part = match partial.rsplit_once('/') {
+            Some((d, _)) => format!("{d}/"),
+            None => String::new(),
+        };
+        self.input
+            .set_buffer(format!("{cmd_prefix}{dir_part}{completed}"));
+        true
+    }
+
     fn submit_with_origin(&mut self, text: String, origin: SubmitOrigin) {
         if origin == SubmitOrigin::Typed {
             // Both `/attach <path>` and bare `/attach` are vision-only;
@@ -646,6 +742,7 @@ impl App {
                 text,
                 attachments,
                 llm_tx,
+                tokio_util::sync::CancellationToken::new(),
             )
             .await;
             let _ = forwarder.await;
@@ -654,6 +751,41 @@ impl App {
             }
         });
     }
+}
+
+/// Expand a leading `~` or `~/` in a tab-completion path using
+/// `$HOME`. Falls back to the literal path when `$HOME` is unset.
+fn expand_tilde(p: &str) -> PathBuf {
+    if let Some(rest) = p.strip_prefix("~/") {
+        if let Ok(home) = std::env::var("HOME") {
+            return PathBuf::from(home).join(rest);
+        }
+    }
+    if p == "~" {
+        if let Ok(home) = std::env::var("HOME") {
+            return PathBuf::from(home);
+        }
+    }
+    PathBuf::from(p)
+}
+
+/// Longest common prefix across a slice of strings. `""` when the
+/// slice is empty. Operates on bytes — fine for ASCII filenames; the
+/// completion path is best-effort for non-ASCII anyway since the
+/// input is shell-style.
+fn longest_common_prefix<'a>(xs: &[&'a str]) -> &'a str {
+    let Some(first) = xs.first() else { return "" };
+    let mut end = first.len();
+    for s in &xs[1..] {
+        end = end.min(s.len());
+        while end > 0 && first.as_bytes()[..end] != s.as_bytes()[..end] {
+            end -= 1;
+        }
+        if end == 0 {
+            return "";
+        }
+    }
+    &first[..end]
 }
 
 fn presence_label(s: PresenceState) -> &'static str {
@@ -1282,5 +1414,78 @@ mod tests {
             rendered.iter().any(|l| l.contains("vision not available")),
             "expected vision error, got {rendered:?}"
         );
+    }
+
+    #[test]
+    fn longest_common_prefix_empty() {
+        assert_eq!(longest_common_prefix(&[]), "");
+    }
+
+    #[test]
+    fn longest_common_prefix_one_string() {
+        assert_eq!(longest_common_prefix(&["abc"]), "abc");
+    }
+
+    #[test]
+    fn longest_common_prefix_two_strings() {
+        assert_eq!(longest_common_prefix(&["foobar", "foobaz"]), "fooba");
+        assert_eq!(longest_common_prefix(&["abc", "xyz"]), "");
+    }
+
+    #[test]
+    fn longest_common_prefix_n_strings() {
+        assert_eq!(
+            longest_common_prefix(&["screenshot1.png", "screenshot2.png", "screenshot10.png"]),
+            "screenshot",
+        );
+    }
+
+    #[test]
+    fn tab_completion_extends_unique_match() {
+        // Build a temp dir with one file that uniquely matches.
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("unique-screenshot.png");
+        std::fs::write(&target, b"fake png").unwrap();
+        let prefix = dir.path().join("unique").display().to_string();
+
+        let (mut app, _rx) = test_app_with(true);
+        for c in format!("/attach {prefix}").chars() {
+            app.on_key(typed(c));
+        }
+        app.on_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE));
+        assert_eq!(app.input.buffer(), format!("/attach {}", target.display()));
+    }
+
+    #[test]
+    fn tab_completion_extends_to_lcp_on_ambiguous_match() {
+        // Two files share a prefix; first Tab should extend the buffer
+        // to the longest common prefix without picking either.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("foobar"), b"a").unwrap();
+        std::fs::write(dir.path().join("foobaz"), b"b").unwrap();
+        let prefix = dir.path().join("foo").display().to_string();
+
+        let (mut app, _rx) = test_app_with(true);
+        for c in format!("/attach {prefix}").chars() {
+            app.on_key(typed(c));
+        }
+        app.on_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE));
+        assert_eq!(
+            app.input.buffer(),
+            format!("/attach {}/fooba", dir.path().display())
+        );
+    }
+
+    #[test]
+    fn tab_outside_attach_falls_through_to_default_handler() {
+        // Without /attach, Tab should invoke the existing tool-block
+        // toggle path. We just verify the buffer is unchanged — the
+        // toggle is a no-op on an empty output.
+        let (mut app, _rx) = test_app_with(true);
+        for c in "hello".chars() {
+            app.on_key(typed(c));
+        }
+        app.on_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE));
+        assert_eq!(app.input.buffer(), "hello");
     }
 }

--- a/crates/assistd/src/chat/input.rs
+++ b/crates/assistd/src/chat/input.rs
@@ -47,6 +47,14 @@ impl InputLine {
         &self.buffer
     }
 
+    /// Replace the entire buffer with `text` and place the cursor at
+    /// the end. Used by tab completion to extend a `/attach <path>`
+    /// prefix in place without rebuilding the InputLine.
+    pub fn set_buffer(&mut self, text: String) {
+        self.cursor = text.len();
+        self.buffer = text;
+    }
+
     /// Cursor column in characters (not bytes). Suitable for placing the
     /// terminal cursor when rendering the input line.
     pub fn cursor_col(&self) -> u16 {

--- a/crates/assistd/src/chat/mod.rs
+++ b/crates/assistd/src/chat/mod.rs
@@ -1,3 +1,5 @@
+#![allow(unsafe_code)] // libc / env / fd primitives — each unsafe block is locally justified
+
 //! Interactive ratatui-based chat TUI.
 //!
 //! `assistd chat` loads the existing config, starts its own llama-server
@@ -108,29 +110,32 @@ pub async fn run(args: ChatArgs) -> Result<()> {
         }
     };
 
-    // One-shot capability probe — only meaningful when llama-server
-    // actually came up. The FailedBackend path already surfaces the
-    // startup error to the TUI, so skip the misleading mmproj warning
-    // in that case.
-    let vision_enabled = if presence.is_some() {
-        let v =
-            assistd_llm::detect_vision_support(&config.llama_server.host, config.llama_server.port)
+    // Capability probe — only meaningful when llama-server actually
+    // came up. The FailedBackend path already surfaces the startup
+    // error to the TUI, so skip the misleading mmproj warning in that
+    // case. Held in a VisionGate so a daemon-side revalidation flips
+    // see/screenshot/attach_image without a registry rebuild.
+    let initial_vision_state = if presence.is_some() {
+        let s =
+            assistd_llm::probe_capabilities(&config.llama_server.host, config.llama_server.port)
                 .await;
-        if v {
+        if s.vision_supported {
             info!("vision: enabled (model has mmproj)");
         } else {
             tracing::warn!("Vision not available: mmproj not loaded.");
         }
-        v
+        s
     } else {
-        false
+        assistd_llm::VisionState::default()
     };
+    let vision_enabled = initial_vision_state.vision_supported;
+    let vision_gate = assistd_tools::VisionGate::new(vision_enabled);
 
     let tools = assistd_core::build_tools(
         &config,
         tui_overflow_dir.clone(),
         Arc::new(TuiGate::new(confirm_tx)),
-        vision_enabled,
+        vision_gate.clone(),
     )?;
     info!(
         "tools: registered {} (overflow dir {})",

--- a/crates/assistd/src/chat/ui.rs
+++ b/crates/assistd/src/chat/ui.rs
@@ -1,3 +1,4 @@
+#![allow(elided_lifetimes_in_paths)] // ratatui Frame<'_> is mostly noise; project style is to elide it
 //! Pure ratatui render for the chat TUI. No state mutation beyond the
 //! output pane's wrap cache and the app's last-viewport-height sink, both
 //! of which must be updated during layout.

--- a/crates/assistd/src/daemon.rs
+++ b/crates/assistd/src/daemon.rs
@@ -90,17 +90,25 @@ pub async fn run(args: DaemonArgs) -> Result<()> {
         config.llama_server.host, config.llama_server.port
     );
 
-    // One-shot capability probe: ask the now-ready llama-server whether
-    // it loaded a vision encoder. Returns false on any error; gates
-    // see/screenshot/attach_image downstream.
-    let vision_enabled =
-        assistd_llm::detect_vision_support(&config.llama_server.host, config.llama_server.port)
-            .await;
-    if vision_enabled {
+    // Capability probe: ask the now-ready llama-server for the loaded
+    // model id and whether it has a vision encoder. The shared
+    // VisionGate drives see/screenshot/attach_image; the
+    // VisionRevalidator re-probes at the top of each query so a model
+    // swap on the running llama-server flips the gate transparently.
+    let initial_vision_state =
+        assistd_llm::probe_capabilities(&config.llama_server.host, config.llama_server.port).await;
+    if initial_vision_state.vision_supported {
         info!("vision: enabled (model has mmproj)");
     } else {
         tracing::warn!("Vision not available: mmproj not loaded.");
     }
+    let vision_gate = assistd_tools::VisionGate::new(initial_vision_state.vision_supported);
+    let vision_revalidator = assistd_core::VisionRevalidator::new(
+        vision_gate.clone(),
+        initial_vision_state.model_id,
+        config.llama_server.host.clone(),
+        config.llama_server.port,
+    );
 
     let chat = LlamaChatClient::new(&config.chat, &config.llama_server, &config.model)?;
 
@@ -259,7 +267,7 @@ pub async fn run(args: DaemonArgs) -> Result<()> {
         &config,
         overflow_dir.clone(),
         Arc::new(DenyAllGate),
-        vision_enabled,
+        vision_gate.clone(),
     )?;
     info!(
         "tools: registered {} (overflow dir {})",
@@ -272,15 +280,18 @@ pub async fn run(args: DaemonArgs) -> Result<()> {
     let continuous_enabled = config.voice.enabled && config.voice.continuous.enabled;
     let continuous_start_on_launch = config.voice.continuous.start_on_launch;
 
-    let state = Arc::new(AppState::new(
-        config,
-        Arc::new(chat),
-        presence.clone(),
-        tools,
-        voice.clone(),
-        listener.clone(),
-        voice_output,
-    ));
+    let state = Arc::new(
+        AppState::new(
+            config,
+            Arc::new(chat),
+            presence.clone(),
+            tools,
+            voice.clone(),
+            listener.clone(),
+            voice_output,
+        )
+        .with_vision_revalidator(vision_revalidator),
+    );
 
     let listen_handles = if continuous_enabled {
         Some(listen_dispatcher::spawn(

--- a/crates/assistd/src/listen_dispatcher.rs
+++ b/crates/assistd/src/listen_dispatcher.rs
@@ -107,7 +107,7 @@ async fn run_utterance_forwarder(
                                 };
                                 let query = async {
                                     if let Err(e) =
-                                        state.clone().handle_query(id, text, tx).await
+                                        state.clone().handle_query(id, text, Vec::new(), tx).await
                                     {
                                         warn!(
                                             target: "assistd::listen",

--- a/crates/assistd/src/query.rs
+++ b/crates/assistd/src/query.rs
@@ -1,7 +1,9 @@
 use anyhow::{Context, Result};
-use assistd_ipc::{Event, Request, socket_path};
+use assistd_ipc::{Event, ImageAttachment, Request, socket_path};
+use assistd_tools::attachment::{LoadImageError, MAX_IMAGE_BYTES};
 use clap::Args;
 use std::io::Write;
+use std::path::PathBuf;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::UnixStream;
 use uuid::Uuid;
@@ -25,9 +27,34 @@ fn truncate_preview(s: &str) -> String {
 pub struct QueryArgs {
     /// Text to send to the daemon
     pub text: String,
+    /// Attach one or more images as vision inputs for this turn. Repeat
+    /// the flag to attach multiple. Each path must point to a PNG, JPEG,
+    /// or WebP file under 32 MiB.
+    #[arg(long = "image", value_name = "PATH")]
+    pub images: Vec<PathBuf>,
 }
 
 pub async fn run(args: QueryArgs) -> Result<()> {
+    let mut wire_attachments = Vec::with_capacity(args.images.len());
+    for path in &args.images {
+        // Reject the bad path before opening the daemon socket so the
+        // user sees the error in their shell, not as a daemon Event.
+        match assistd_tools::load_image_attachment(path).await {
+            Ok((assistd_tools::Attachment::Image { mime, bytes }, _)) => {
+                wire_attachments.push(ImageAttachment::from_bytes(mime, &bytes));
+            }
+            Err(e) => {
+                let kind = match &e {
+                    LoadImageError::TooLarge { .. } => {
+                        format!("(max {} MiB)", MAX_IMAGE_BYTES / (1024 * 1024))
+                    }
+                    _ => String::new(),
+                };
+                anyhow::bail!("--image {}: {} {kind}", path.display(), e.user_message());
+            }
+        }
+    }
+
     let path = socket_path();
 
     let stream = UnixStream::connect(&path).await.with_context(|| {
@@ -38,9 +65,10 @@ pub async fn run(args: QueryArgs) -> Result<()> {
     })?;
 
     let (read_half, mut write_half) = stream.into_split();
-    let req = Request::Query {
-        id: Uuid::new_v4().to_string(),
-        text: args.text,
+    let req = if wire_attachments.is_empty() {
+        Request::query(Uuid::new_v4().to_string(), args.text)
+    } else {
+        Request::query_with_attachments(Uuid::new_v4().to_string(), args.text, wire_attachments)
     };
     let mut body = serde_json::to_string(&req)?;
     body.push('\n');


### PR DESCRIPTION
General refinement of mulitmodality, along with cleanup and preparation for remaining project milestones:
- 32 MiB image-size cap with stat-before-read
- IPC schema extended with ImageAttachment + protocol versioning + assistd send --image flag 
- VisionGate (atomic flag) + VisionRevalidator (re-probes /props on each turn, flips gate on model swap) wired through daemon and chat TUI 
- 11 new screenshot parser tests (xrandr geometry, malformed JSON, deep tree walks)
- tokio_util::CancellationToken plumbed through run_agent_turn; daemon cancels on disconnect via drop-guard
- [workspace.lints] baseline (clippy::all, dbg_macro deny, unsafe_code deny, rust_2018_idioms warn) inherited by all 9 crates
- tokio = "full" removed from workspace base; minimal feature sets crate (binary still gets ["full"])
- 17 expect("…poisoned") sites replaced with unwrap_or_else(|e| e.into_inner())
- #[tracing::instrument] added on PresenceManager::ensure_active/set_presence, LlamaService::start, RunTool::invoke
- screenshot --monitor=<name> flag with xrandr geometry parser for X11 and grim -o for Wayland
- Tab completion for /attach and /attach_image with longest-common-prefix and directory traversal