### PR TITLE
Add memory management CLI

### DIFF
--- a/crates/assistd-core/src/state.rs
+++ b/crates/assistd-core/src/state.rs
@@ -298,7 +298,13 @@ impl AppState {
             }
             Request::MemoryLoad { id, key } => self.handle_memory_load(id, key, tx).await,
             Request::MemoryList { id, prefix } => self.handle_memory_list(id, prefix, tx).await,
+            Request::MemoryListAll { id, prefix, limit } => {
+                self.handle_memory_list_all(id, prefix, limit, tx).await
+            }
             Request::MemoryDelete { id, key } => self.handle_memory_delete(id, key, tx).await,
+            Request::MemoryForget { id, memory_id } => {
+                self.handle_memory_forget(id, memory_id, tx).await
+            }
             Request::MemorySemanticSearch { id, query, limit } => {
                 self.handle_memory_semantic_search(id, query, limit, tx)
                     .await
@@ -644,6 +650,78 @@ impl AppState {
                     .send(Event::Error {
                         id,
                         message: format!("memory delete failed: {e:#}"),
+                    })
+                    .await;
+                Err(e)
+            }
+        }
+    }
+
+    async fn handle_memory_list_all(
+        self: Arc<Self>,
+        id: String,
+        prefix: String,
+        limit: u32,
+        tx: mpsc::Sender<Event>,
+    ) -> Result<()> {
+        match self.memory_ops.list_full(&prefix).await {
+            Ok(rows) => {
+                // `limit = 0` means no cap (matches the wire convention used
+                // by `MemorySearch`). Otherwise truncate after the SQL has
+                // already ordered lexicographically by key.
+                let cap = if limit == 0 {
+                    rows.len()
+                } else {
+                    rows.len().min(limit as usize)
+                };
+                for row in rows.into_iter().take(cap) {
+                    let _ = tx
+                        .send(Event::MemoryRow {
+                            id: id.clone(),
+                            memory_id: row.id,
+                            key: row.key,
+                            value: row.value,
+                        })
+                        .await;
+                }
+                let _ = tx.send(Event::Done { id }).await;
+                Ok(())
+            }
+            Err(e) => {
+                let _ = tx
+                    .send(Event::Error {
+                        id,
+                        message: format!("memory list_all failed: {e:#}"),
+                    })
+                    .await;
+                Err(e)
+            }
+        }
+    }
+
+    async fn handle_memory_forget(
+        self: Arc<Self>,
+        id: String,
+        memory_id: i64,
+        tx: mpsc::Sender<Event>,
+    ) -> Result<()> {
+        match self.memory_ops.forget(memory_id).await {
+            Ok(removed) => {
+                let _ = tx
+                    .send(Event::MemoryForgetResult {
+                        id: id.clone(),
+                        deleted: removed.is_some(),
+                        key: removed,
+                    })
+                    .await;
+                let _ = tx.send(Event::Done { id }).await;
+                Ok(())
+            }
+            Err(e) => {
+                let _ = tx
+                    .send(Event::Error {
+                        id,
+                        message: format!("memory forget failed: {e:#}"),
                     })
                     .await;
                 Err(e)

--- a/crates/assistd-ipc/src/lib.rs
+++ b/crates/assistd-ipc/src/lib.rs
@@ -191,9 +191,26 @@ pub enum Request {
         #[serde(default)]
         prefix: String,
     },
+    /// Enumerate full `(id, key, value)` rows whose key starts with
+    /// `prefix`. Streams one [`Event::MemoryRow`] per match in
+    /// lexicographic key order, then a terminal `Done`. `limit = 0`
+    /// means "no cap" (matches the `MemorySearch` convention).
+    MemoryListAll {
+        id: String,
+        #[serde(default)]
+        prefix: String,
+        #[serde(default)]
+        limit: u32,
+    },
     /// Remove `key` from the memory store. No-op when absent. Emits
     /// `Done` on success.
     MemoryDelete { id: String, key: String },
+    /// Remove the memory whose row id is `memory_id`. Emits a single
+    /// [`Event::MemoryForgetResult`] (with `deleted: false` when the
+    /// id didn't match any row), then a terminal `Done`. Distinct from
+    /// `MemoryDelete` so the CLI can take an integer id and the daemon
+    /// can echo back the deleted key.
+    MemoryForget { id: String, memory_id: i64 },
     /// Semantic search over persisted conversation chunks. Embeds the
     /// query and ranks past messages by cosine similarity. Emits zero
     /// or more `SemanticHit` events ordered best-first, then `Done`.
@@ -256,7 +273,9 @@ impl Request {
             | Request::MemorySave { id, .. }
             | Request::MemoryLoad { id, .. }
             | Request::MemoryList { id, .. }
+            | Request::MemoryListAll { id, .. }
             | Request::MemoryDelete { id, .. }
+            | Request::MemoryForget { id, .. }
             | Request::MemorySemanticSearch { id, .. } => id,
         }
     }
@@ -282,7 +301,9 @@ impl Request {
             Request::MemorySave { .. } => "memory_save",
             Request::MemoryLoad { .. } => "memory_load",
             Request::MemoryList { .. } => "memory_list",
+            Request::MemoryListAll { .. } => "memory_list_all",
             Request::MemoryDelete { .. } => "memory_delete",
+            Request::MemoryForget { .. } => "memory_forget",
             Request::MemorySemanticSearch { .. } => "memory_semantic_search",
         }
     }
@@ -371,6 +392,27 @@ pub enum Event {
     /// order. Always emitted exactly once before the terminal `Done`,
     /// even when empty.
     MemoryKeys { id: String, keys: Vec<String> },
+    /// One `(id, key, value)` row emitted by `MemoryListAll`. The
+    /// daemon streams these in lexicographic key order, then a
+    /// terminal `Done`. `memory_id` is the SQLite row id — the CLI
+    /// uses it as the argument to `assistd memory forget <id>`.
+    MemoryRow {
+        id: String,
+        memory_id: i64,
+        key: String,
+        value: String,
+    },
+    /// Result of a `MemoryForget`. Always emitted exactly once before
+    /// the terminal `Done`. `deleted = false` (with `key = None`)
+    /// signals that no row with the given id existed — the CLI maps
+    /// this to a "no memory with id=N" stderr message and exit 2.
+    /// `key = Some(k)` carries the deleted row's key so the CLI can
+    /// echo `forgot id=N key=k`.
+    MemoryForgetResult {
+        id: String,
+        deleted: bool,
+        key: Option<String>,
+    },
     /// Terminal error event — the stream is over.
     Error { id: String, message: String },
     /// Terminal success event — the stream is over.
@@ -398,6 +440,8 @@ impl Event {
             | Event::SemanticHit { id, .. }
             | Event::MemoryValue { id, .. }
             | Event::MemoryKeys { id, .. }
+            | Event::MemoryRow { id, .. }
+            | Event::MemoryForgetResult { id, .. }
             | Event::Error { id, .. }
             | Event::Done { id } => id,
         }
@@ -569,12 +613,48 @@ mod tests {
                 id: "r4".into(),
                 key: "k".into(),
             },
+            Request::MemoryListAll {
+                id: "r5".into(),
+                prefix: "fact:".into(),
+                limit: 0,
+            },
+            Request::MemoryForget {
+                id: "r6".into(),
+                memory_id: 42,
+            },
         ];
         for r in cases {
             let parsed: Request =
                 serde_json::from_str(&serde_json::to_string(&r).unwrap()).unwrap();
             assert_eq!(parsed, r);
         }
+    }
+
+    #[test]
+    fn memory_list_all_request_omits_optional_fields() {
+        // Both `prefix` and `limit` use `#[serde(default)]`, so a
+        // pre-feature client that only sends `id` should still parse
+        // (additive evolution).
+        let json = r#"{"type":"memory_list_all","id":"r"}"#;
+        let parsed: Request = serde_json::from_str(json).unwrap();
+        match parsed {
+            Request::MemoryListAll { id, prefix, limit } => {
+                assert_eq!(id, "r");
+                assert_eq!(prefix, "");
+                assert_eq!(limit, 0);
+            }
+            _ => panic!("expected MemoryListAll"),
+        }
+    }
+
+    #[test]
+    fn memory_forget_request_carries_id() {
+        let req = Request::MemoryForget {
+            id: "r".into(),
+            memory_id: 7,
+        };
+        assert_eq!(req.id(), "r");
+        assert_eq!(req.kind(), "memory_forget");
     }
 
     #[test]
@@ -612,11 +692,47 @@ mod tests {
                 id: "r".into(),
                 keys: vec!["a".into(), "b".into()],
             },
+            Event::MemoryRow {
+                id: "r".into(),
+                memory_id: 17,
+                key: "fact:user.name".into(),
+                value: "Ben".into(),
+            },
+            Event::MemoryForgetResult {
+                id: "r".into(),
+                deleted: true,
+                key: Some("fact:user.name".into()),
+            },
+            Event::MemoryForgetResult {
+                id: "r".into(),
+                deleted: false,
+                key: None,
+            },
         ];
         for e in cases {
             let parsed: Event = serde_json::from_str(&serde_json::to_string(&e).unwrap()).unwrap();
             assert_eq!(parsed, e);
         }
+    }
+
+    #[test]
+    fn memory_row_and_forget_result_are_not_terminal() {
+        let row = Event::MemoryRow {
+            id: "r".into(),
+            memory_id: 1,
+            key: "k".into(),
+            value: "v".into(),
+        };
+        assert!(!row.is_terminal());
+        assert_eq!(row.id(), "r");
+
+        let forget = Event::MemoryForgetResult {
+            id: "f".into(),
+            deleted: true,
+            key: Some("k".into()),
+        };
+        assert!(!forget.is_terminal());
+        assert_eq!(forget.id(), "f");
     }
 
     #[test]

--- a/crates/assistd-memory/src/lib.rs
+++ b/crates/assistd-memory/src/lib.rs
@@ -53,6 +53,17 @@ pub use sqlite::{
 use anyhow::Result;
 use async_trait::async_trait;
 
+/// One row from the `memories` table, exposed as a single struct for
+/// callers that need the row id alongside the key/value pair (the
+/// `assistd memory list` CLI prints `id\tkey\tvalue`; the `forget <id>`
+/// CLI takes the id from this struct's earlier output).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MemoryRecord {
+    pub id: i64,
+    pub key: String,
+    pub value: String,
+}
+
 /// Persistent key/value memory accessible to the daemon and the
 /// agent loop. Implementors must be `Send + Sync + 'static` because
 /// `AppState` holds them as `Arc<dyn MemoryStore>`.
@@ -81,11 +92,25 @@ pub trait MemoryStore: Send + Sync + 'static {
     /// remember it" and saves a probe-then-delete round trip.
     async fn delete(&self, key: &str) -> Result<()>;
 
+    /// Remove the row with `id`. Returns `Ok(Some(key))` with the key
+    /// of the deleted row on hit, `Ok(None)` when no row matched —
+    /// callers that need to distinguish hit/miss (the `assistd memory
+    /// forget <id>` CLI) use the option, callers that don't can ignore
+    /// it. Errs only on backend failure.
+    async fn delete_by_id(&self, id: i64) -> Result<Option<String>>;
+
     /// Enumerate keys whose name starts with `prefix`. Order is
     /// unspecified. Used for namespaced categories (`pref:`, `fact:`,
     /// `summary:`) so the agent can list "all preferences" without
     /// scanning the whole store.
     async fn list(&self, prefix: &str) -> Result<Vec<String>>;
+
+    /// Enumerate full rows whose key starts with `prefix`. Like
+    /// [`MemoryStore::list`] but returns `(id, key, value)` triples in
+    /// one round trip — used by the `assistd memory list` CLI which
+    /// prints all three fields. Order is unspecified at the trait
+    /// level (the SQLite impl yields lexicographic by key).
+    async fn list_full(&self, prefix: &str) -> Result<Vec<MemoryRecord>>;
 }
 
 /// Successful-no-op fallback used when no persistent backend is
@@ -108,7 +133,15 @@ impl MemoryStore for NoMemoryStore {
         Ok(())
     }
 
+    async fn delete_by_id(&self, _id: i64) -> Result<Option<String>> {
+        Ok(None)
+    }
+
     async fn list(&self, _prefix: &str) -> Result<Vec<String>> {
+        Ok(Vec::new())
+    }
+
+    async fn list_full(&self, _prefix: &str) -> Result<Vec<MemoryRecord>> {
         Ok(Vec::new())
     }
 }
@@ -139,9 +172,21 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn no_memory_store_delete_by_id_returns_none() {
+        let store = NoMemoryStore;
+        assert!(store.delete_by_id(42).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
     async fn no_memory_store_list_returns_empty() {
         let store = NoMemoryStore;
         assert!(store.list("fact:").await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn no_memory_store_list_full_returns_empty() {
+        let store = NoMemoryStore;
+        assert!(store.list_full("fact:").await.unwrap().is_empty());
     }
 
     #[test]

--- a/crates/assistd-memory/src/sqlite/store.rs
+++ b/crates/assistd-memory/src/sqlite/store.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 
-use crate::MemoryStore;
+use crate::{MemoryRecord, MemoryStore};
 
 use super::connection::SqliteHandle;
 use super::writer::{WriteCall, WriteOp};
@@ -83,6 +83,14 @@ impl MemoryStore for SqliteMemoryStore {
         .await
     }
 
+    async fn delete_by_id(&self, id: i64) -> Result<Option<String>> {
+        WriteCall::run(self.handle.writer(), |ack| WriteOp::DeleteMemoryById {
+            id,
+            ack,
+        })
+        .await
+    }
+
     async fn list(&self, prefix: &str) -> Result<Vec<String>> {
         // SQLite `LIKE` with a literal terminator is the simple path —
         // we escape `%` and `_` in the prefix so a key like `pref:%`
@@ -105,6 +113,34 @@ impl MemoryStore for SqliteMemoryStore {
             })
             .await
             .context("memory list")
+    }
+
+    async fn list_full(&self, prefix: &str) -> Result<Vec<MemoryRecord>> {
+        let escaped = prefix
+            .replace('\\', "\\\\")
+            .replace('%', "\\%")
+            .replace('_', "\\_");
+        let pattern = format!("{escaped}%");
+        self.handle
+            .conn()
+            .call(move |c| {
+                let mut stmt = c.prepare(
+                    "SELECT id, key, value FROM memories \
+                     WHERE key LIKE ?1 ESCAPE '\\' ORDER BY key",
+                )?;
+                let rows = stmt
+                    .query_map(rusqlite::params![pattern], |r| {
+                        Ok(MemoryRecord {
+                            id: r.get(0)?,
+                            key: r.get(1)?,
+                            value: r.get(2)?,
+                        })
+                    })?
+                    .collect::<std::result::Result<Vec<_>, _>>()?;
+                Ok(rows)
+            })
+            .await
+            .context("memory list_full")
     }
 }
 
@@ -160,6 +196,49 @@ mod tests {
         store.save("other:c", "3".into()).await.unwrap();
         let keys = store.list("pref:").await.unwrap();
         assert_eq!(keys, vec!["pref:a", "pref:b"]);
+    }
+
+    #[tokio::test]
+    async fn list_full_returns_id_key_value_in_lex_order() {
+        let (store, _w) = fresh().await;
+        store.save("pref:b", "two".into()).await.unwrap();
+        store.save("pref:a", "one".into()).await.unwrap();
+        store.save("other:c", "three".into()).await.unwrap();
+        let rows = store.list_full("pref:").await.unwrap();
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].key, "pref:a");
+        assert_eq!(rows[0].value, "one");
+        assert_eq!(rows[1].key, "pref:b");
+        assert_eq!(rows[1].value, "two");
+        assert!(rows[0].id > 0 && rows[1].id > 0);
+        assert_ne!(rows[0].id, rows[1].id);
+    }
+
+    #[tokio::test]
+    async fn list_full_empty_prefix_returns_all_rows() {
+        let (store, _w) = fresh().await;
+        store.save("a", "1".into()).await.unwrap();
+        store.save("b", "2".into()).await.unwrap();
+        let rows = store.list_full("").await.unwrap();
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].key, "a");
+        assert_eq!(rows[1].key, "b");
+    }
+
+    #[tokio::test]
+    async fn delete_by_id_returns_some_key_on_hit() {
+        let (store, _w) = fresh().await;
+        let id = store.save("fact:user.name", "Ben".into()).await.unwrap();
+        let removed = store.delete_by_id(id).await.unwrap();
+        assert_eq!(removed.as_deref(), Some("fact:user.name"));
+        assert_eq!(store.load("fact:user.name").await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn delete_by_id_returns_none_on_miss() {
+        let (store, _w) = fresh().await;
+        let removed = store.delete_by_id(99_999).await.unwrap();
+        assert!(removed.is_none());
     }
 
     #[tokio::test]

--- a/crates/assistd-memory/src/sqlite/writer.rs
+++ b/crates/assistd-memory/src/sqlite/writer.rs
@@ -65,6 +65,15 @@ pub enum WriteOp {
         key: String,
         ack: oneshot::Sender<Result<()>>,
     },
+    /// Delete a memory by row id. Returns the key of the deleted row
+    /// on hit so the IPC `MemoryForget` handler can echo it back to
+    /// the CLI; returns `None` when no row with that id exists. The
+    /// `memory_embeddings.memory_id ... ON DELETE CASCADE` FK cleans
+    /// the embedding row in the same statement.
+    DeleteMemoryById {
+        id: i64,
+        ack: oneshot::Sender<Result<Option<String>>>,
+    },
     /// Persist one chunk of a conversation message. Returns the chunk
     /// rowid via the ack so the caller can dispatch an embed job.
     StoreChunk {
@@ -196,6 +205,10 @@ async fn handle_op(conn: &Connection, op: WriteOp) {
         }
         WriteOp::DeleteMemory { key, ack } => {
             let res = delete_memory(conn, key).await;
+            let _ = ack.send(res);
+        }
+        WriteOp::DeleteMemoryById { id, ack } => {
+            let res = delete_memory_by_id(conn, id).await;
             let _ = ack.send(res);
         }
         WriteOp::StoreChunk {
@@ -381,6 +394,33 @@ async fn delete_memory(conn: &Connection, key: String) -> Result<()> {
     })
     .await
     .context("delete_memory")
+}
+
+async fn delete_memory_by_id(conn: &Connection, id: i64) -> Result<Option<String>> {
+    // `RETURNING key` (SQLite >= 3.35) gives us the deleted row's key
+    // in the same round trip; `QueryReturnedNoRows` means the id
+    // didn't exist. The `memory_embeddings.memory_id` FK has
+    // `ON DELETE CASCADE`, so the embedding row drops with the memory
+    // — no second statement needed.
+    conn.call(move |c| {
+        let result = c
+            .query_row(
+                "DELETE FROM memories WHERE id = ?1 RETURNING key",
+                rusqlite::params![id],
+                |r| r.get::<_, String>(0),
+            )
+            .map(Some)
+            .or_else(|e| {
+                if matches!(e, rusqlite::Error::QueryReturnedNoRows) {
+                    Ok(None)
+                } else {
+                    Err(e)
+                }
+            })?;
+        Ok(result)
+    })
+    .await
+    .context("delete_memory_by_id")
 }
 
 async fn store_chunk(

--- a/crates/assistd-tools/src/memory.rs
+++ b/crates/assistd-tools/src/memory.rs
@@ -14,6 +14,8 @@ use std::sync::Arc;
 use anyhow::Result;
 use assistd_memory::{ConversationStore, MemoryStore, SearchHit, TurnSummary};
 
+pub use assistd_memory::MemoryRecord;
+
 /// Default cap on `search` / `list` result sizes when the IPC client
 /// asks for `limit = 0` (the wire default for the `MemorySearch`
 /// variant). Big enough to be useful for casual `assistd memory search`
@@ -55,6 +57,23 @@ impl MemoryOps {
 
     pub async fn delete(&self, key: &str) -> Result<()> {
         self.store.delete(key).await
+    }
+
+    /// Delete a memory by row id. Returns `Some(key)` of the deleted
+    /// row on hit, `None` when no row matched. Used by the IPC
+    /// `MemoryForget` handler so the CLI can echo the key back to the
+    /// user (`forgot id=N key=...`) and distinguish hit/miss without
+    /// a second probe.
+    pub async fn forget(&self, id: i64) -> Result<Option<String>> {
+        self.store.delete_by_id(id).await
+    }
+
+    /// Like [`MemoryOps::list`] but returns full `(id, key, value)`
+    /// rows in one round trip — used by the `assistd memory list` CLI.
+    /// Order is whatever the backend yields (lexicographic by key for
+    /// the SQLite impl).
+    pub async fn list_full(&self, prefix: &str) -> Result<Vec<MemoryRecord>> {
+        self.store.list_full(prefix).await
     }
 
     pub async fn search(&self, query: &str, limit: usize) -> Result<Vec<SearchHit>> {

--- a/crates/assistd/src/main.rs
+++ b/crates/assistd/src/main.rs
@@ -115,7 +115,8 @@ enum Commands {
     Chat(chat::ChatArgs),
 
     /// Inspect or mutate persistent memory: search conversation
-    /// history, save / load / list / delete key-value memories.
+    /// history, save / load / list / forget / delete key-value
+    /// memories.
     #[cfg(feature = "client")]
     Memory(memory_cli::MemoryArgs),
 }

--- a/crates/assistd/src/memory_cli.rs
+++ b/crates/assistd/src/memory_cli.rs
@@ -23,31 +23,37 @@ pub struct MemoryArgs {
 #[derive(Subcommand)]
 pub enum MemoryAction {
     /// Search persisted conversation content. Two modes:
-    /// - `fts` (default): SQLite FTS5 full-text search. Supports phrase
-    ///   queries (`"foo bar"`), boolean ops (`foo AND bar`), and prefix
-    ///   matches (`foo*`).
-    /// - `semantic`: cosine-similarity search over embedded chunks.
-    ///   Robust to paraphrase. Requires the embedding subsystem.
+    /// - `semantic` (default): cosine-similarity search over embedded
+    ///   chunks. Robust to paraphrase. Requires the embedding
+    ///   subsystem.
+    /// - `fts`: SQLite FTS5 full-text search. Supports phrase queries
+    ///   (`"foo bar"`), boolean ops (`foo AND bar`), and prefix matches
+    ///   (`foo*`).
     Search {
         /// Query string. Interpretation depends on `--mode`.
         query: String,
         /// Cap on number of hits returned.
-        #[arg(long, default_value = "20")]
+        #[arg(long, default_value = "5")]
         limit: u32,
-        /// Search mode. Defaults to `fts` (legacy behavior).
-        #[arg(long, value_enum, default_value_t = SearchMode::Fts)]
+        /// Search mode. Defaults to `semantic` (the most-relevant
+        /// ranking; pass `--mode fts` for keyword/exact-phrase work).
+        #[arg(long, value_enum, default_value_t = SearchMode::Semantic)]
         mode: SearchMode,
     },
     /// Persist a value under `key`. Overwrites any prior value.
     Save { key: String, value: String },
     /// Read the value previously stored at `key`.
     Load { key: String },
-    /// List keys whose name starts with `prefix`. Empty prefix lists
-    /// every key.
+    /// List all stored memories (id, key, value) whose key starts with
+    /// `prefix`. Empty prefix lists every memory. Output is one
+    /// tab-separated row per memory in lexicographic key order.
     List {
         #[arg(default_value = "")]
         prefix: String,
     },
+    /// Forget the memory with row id `id`. Prints `forgot id=N key=...`
+    /// on success; exits 2 with `no memory with id=N` on miss.
+    Forget { id: i64 },
     /// Remove `key` from the store. No-op if absent.
     Delete { key: String },
 }
@@ -75,7 +81,12 @@ impl MemoryAction {
             } => Request::MemorySemanticSearch { id, query, limit },
             MemoryAction::Save { key, value } => Request::MemorySave { id, key, value },
             MemoryAction::Load { key } => Request::MemoryLoad { id, key },
-            MemoryAction::List { prefix } => Request::MemoryList { id, prefix },
+            MemoryAction::List { prefix } => Request::MemoryListAll {
+                id,
+                prefix,
+                limit: 0,
+            },
+            MemoryAction::Forget { id: memory_id } => Request::MemoryForget { id, memory_id },
             MemoryAction::Delete { key } => Request::MemoryDelete { id, key },
         }
     }
@@ -89,6 +100,15 @@ pub async fn run(args: MemoryArgs) -> Result<()> {
             path.display()
         )
     })?;
+
+    // Capture the forget target id before `into_request` consumes the
+    // action — needed so the `MemoryForgetResult` printer can echo it
+    // back on the miss path (`no memory with id=N`), where the daemon
+    // doesn't carry a key.
+    let forget_target = match &args.action {
+        MemoryAction::Forget { id } => Some(*id),
+        _ => None,
+    };
 
     let (read_half, mut write_half) = stream.into_split();
     let req = args.action.into_request(Uuid::new_v4().to_string());
@@ -156,6 +176,43 @@ pub async fn run(args: MemoryArgs) -> Result<()> {
                 for k in keys {
                     println!("{k}");
                 }
+            }
+            Event::MemoryRow {
+                memory_id,
+                key,
+                value,
+                ..
+            } => {
+                // Tab-separated id, key, value. Collapse newlines in
+                // value so a multi-line memory doesn't break the row
+                // boundary in shell pipelines.
+                let single_line = value.replace('\n', " ");
+                println!("{memory_id}\t{key}\t{single_line}");
+            }
+            Event::MemoryForgetResult {
+                deleted: true,
+                key: Some(k),
+                ..
+            } => {
+                let id = forget_target.unwrap_or(0);
+                println!("forgot id={id} key={k}");
+            }
+            Event::MemoryForgetResult { deleted: false, .. } => {
+                let id = forget_target.unwrap_or(0);
+                eprintln!("no memory with id={id}");
+                std::process::exit(2);
+            }
+            // `MemoryForgetResult { deleted: true, key: None }` is not
+            // produced by the daemon (a delete-by-id always has a key
+            // when it hits a row), but the type allows it; treat it as
+            // a successful no-op so we don't trip the missing-id exit.
+            Event::MemoryForgetResult {
+                deleted: true,
+                key: None,
+                ..
+            } => {
+                let id = forget_target.unwrap_or(0);
+                println!("forgot id={id}");
             }
             Event::Done { .. } => return Ok(()),
             Event::Error { message, .. } => {

--- a/crates/assistd/src/ptt.rs
+++ b/crates/assistd/src/ptt.rs
@@ -101,7 +101,9 @@ pub async fn run(action: PttAction) -> Result<()> {
             Event::MemoryHit { .. }
             | Event::SemanticHit { .. }
             | Event::MemoryValue { .. }
-            | Event::MemoryKeys { .. } => {}
+            | Event::MemoryKeys { .. }
+            | Event::MemoryRow { .. }
+            | Event::MemoryForgetResult { .. } => {}
             Event::Done { .. } => {
                 if wrote_delta {
                     writeln!(stdout)?;

--- a/crates/assistd/src/query.rs
+++ b/crates/assistd/src/query.rs
@@ -145,7 +145,9 @@ pub async fn run(args: QueryArgs) -> Result<()> {
             Event::MemoryHit { .. }
             | Event::SemanticHit { .. }
             | Event::MemoryValue { .. }
-            | Event::MemoryKeys { .. } => {}
+            | Event::MemoryKeys { .. }
+            | Event::MemoryRow { .. }
+            | Event::MemoryForgetResult { .. } => {}
             Event::Done { .. } => {
                 if wrote_anything {
                     writeln!(stdout)?;


### PR DESCRIPTION
- added MemoryRecord { id, key, value } struct and two trait methods (list_full, delete_by_id) plus NoMemoryStore impls.                                                                
- added WriteOp::DeleteMemoryById and delete_memory_by_id() using DELETE ... RETURNING key (FK cascade cleans the embedding row).                                                
- implemented list_full (lex-ordered id, key, value rows) and delete_by_id on SqliteMemoryStore.                                                                    
- added MemoryOps::list_full and MemoryOps::forget pass-throughs.                
- added Request::MemoryListAll, Request::MemoryForget, Event::MemoryRow, Event::MemoryForgetResult.               
- added handle_memory_list_all and handle_memory_forget, dispatched from new Request arms.                   
- added forget <id> action, switched list to MemoryListAll (prints id<TAB>key<TAB>value), changed search defaults to --mode semantic --limit 5, added event arms with proper exit codes.