### PR TITLE
Memory system refinement

### DIFF
--- a/config/config.sample.toml
+++ b/config/config.sample.toml
@@ -418,7 +418,8 @@ hotkey = "Super+Escape"
 # Independent of the chat router — embeddings keep working when chat
 # is Drowsy/Sleeping. Each user query auto-injects the top-K most
 # similar past chunks as a "Relevant past context: …" system message,
-# and the LLM gets `recall(mode="semantic")` and `search_memory` tools.
+# and the LLM gets the `recall` (saved facts) and `reminisce` (past
+# conversation) tools, both backed by semantic search.
 #
 # Master switch. When false the daemon binds NoEmbedder + NoSemanticStore
 # and the retrieval-touching tools register but no-op silently.
@@ -441,7 +442,7 @@ hotkey = "Super+Escape"
 # Per-request HTTP timeout against /v1/embeddings.
 # request_timeout_secs = 30
 # How many nearest-neighbor matches to retrieve per query for
-# auto-injection and the search_memory tool's default.
+# auto-injection and the reminisce tool's default.
 # top_k = 5
 # Char-window size for chunking conversation messages. Messages
 # shorter than this become a single chunk.
@@ -451,5 +452,5 @@ hotkey = "Super+Escape"
 # chunk_overlap_chars = 64
 # When true, every user query auto-injects the top-K conversation
 # chunks as a "Relevant past context: …" system message. Set false
-# to require explicit `search_memory` tool invocations only.
+# to require explicit `reminisce` tool invocations only.
 # auto_inject = true

--- a/crates/assistd-config/src/embedding.rs
+++ b/crates/assistd-config/src/embedding.rs
@@ -23,8 +23,8 @@ use crate::defaults::{
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct EmbeddingConfig {
     /// Master switch. When `false` the daemon binds the `NoEmbedder`
-    /// placeholder, the `search_memory` tool returns empty, and
-    /// `recall(mode="semantic")` falls back to "(no memories)".
+    /// placeholder; the `recall` and `reminisce` tools both fall back
+    /// to "(no memories)" / "(no past conversations indexed)".
     #[serde(default = "default_embedding_enabled")]
     pub enabled: bool,
     /// HuggingFace model id passed verbatim to llama-server's
@@ -53,7 +53,7 @@ pub struct EmbeddingConfig {
     #[serde(default = "default_embedding_request_timeout_secs")]
     pub request_timeout_secs: u64,
     /// How many nearest-neighbor matches to retrieve per query for
-    /// auto-injection and the `search_memory` tool's default.
+    /// auto-injection and the `reminisce` tool's default.
     #[serde(default = "default_embedding_top_k")]
     pub top_k: u32,
     /// Char-window size for chunking conversation messages. Messages
@@ -68,8 +68,8 @@ pub struct EmbeddingConfig {
     pub chunk_overlap_chars: usize,
     /// When `true`, every user query embeds the prompt and prepends
     /// the top-K conversation chunks as a "Relevant past context:"
-    /// system message. Disable to require explicit `search_memory`
-    /// tool invocations instead.
+    /// system message. Disable to require explicit `reminisce` tool
+    /// invocations instead.
     #[serde(default = "default_embedding_auto_inject")]
     pub auto_inject: bool,
 }

--- a/crates/assistd-core/src/agent.rs
+++ b/crates/assistd-core/src/agent.rs
@@ -765,11 +765,14 @@ mod tests {
     async fn agent_loop_routes_remember_then_recall() {
         // Drive the full loop through the same `RememberTool` /
         // `RecallTool` impls the daemon registers, against a real
-        // SQLite-backed `MemoryOps`. Remember the pair on the first
-        // step, recall it on the second, then assert the recall's
-        // tool_result event surfaces the saved key:value to the model.
-        // Pins AC #1 + AC #2 wire-level: the pair is round-trippable
-        // through one agent turn.
+        // SQLite-backed `MemoryOps`. Remember on the first step, recall
+        // on the second, then assert both calls were routed and that
+        // the save landed in the underlying store. With the embedding
+        // subsystem disabled (NoEmbedder/NoSemanticStore + empty model
+        // name), recall short-circuits to the `(no memories)` sentinel —
+        // the agent-loop wiring is what's under test here, not the
+        // semantic round-trip (which is exercised in the embedder
+        // integration tests).
         use assistd_memory::{
             ConversationStore, MemoryStore, SqliteConversationStore, SqliteHandle,
             SqliteMemoryStore,
@@ -787,28 +790,20 @@ mod tests {
         let handle = Arc::new(handle);
         let mem: Arc<dyn MemoryStore> = Arc::new(SqliteMemoryStore::new(handle.clone()));
         let conv: Arc<dyn ConversationStore> = Arc::new(SqliteConversationStore::new(handle));
-        let memory_ops = Arc::new(MemoryOps::new(mem, conv));
+        let memory_ops = Arc::new(MemoryOps::new(mem.clone(), conv));
 
         let mut tools = ToolRegistry::new();
-        // Closed embed channel + NoEmbedder/NoSemanticStore — the test
-        // exercises the prefix path only, so we don't need the embed
-        // subsystem wired up.
         let (embed_tx, embed_rx) = tokio::sync::mpsc::channel::<assistd_embed::EmbedJob>(1);
         drop(embed_rx);
         let no_embedder: Arc<dyn assistd_embed::Embedder> = Arc::new(assistd_embed::NoEmbedder);
         let no_semantic: Arc<dyn assistd_memory::SemanticStore> =
             Arc::new(assistd_memory::NoSemanticStore);
-        tools.register(RememberTool::new(memory_ops.clone(), embed_tx));
-        tools.register(RecallTool::new(
-            memory_ops,
-            no_embedder,
-            no_semantic,
-            String::new(),
-        ));
+        tools.register(RememberTool::new(memory_ops, embed_tx));
+        tools.register(RecallTool::new(no_embedder, no_semantic, String::new()));
         let tools = Arc::new(tools);
 
         // Step 1: model calls remember(...) — Step 2: model calls
-        // recall(query="", mode="prefix") — Step 3: Final.
+        // recall(...) — Step 3: Final.
         let backend = MockBackend::with(vec![
             StepOutcome::ToolCalls(vec![ToolCall {
                 id: "c-1".into(),
@@ -821,7 +816,7 @@ mod tests {
             StepOutcome::ToolCalls(vec![ToolCall {
                 id: "c-2".into(),
                 name: "recall".into(),
-                arguments: serde_json::json!({"query": "", "mode": "prefix"}),
+                arguments: serde_json::json!({"query": "what editor do I prefer"}),
             }]),
             StepOutcome::Final,
         ]);
@@ -850,7 +845,19 @@ mod tests {
             .collect();
         assert_eq!(names, vec!["remember", "recall"]);
 
-        // The recall ToolResult must carry the saved pair in `output`.
+        // Save landed in the underlying SQLite store (the wire-level
+        // contract for `remember`).
+        assert_eq!(
+            mem.load("editor_preference").await.unwrap().as_deref(),
+            Some("vim")
+        );
+
+        // Recall's ToolResult and the second push_tool_results carry
+        // the no-memories sentinel — the embedder is disabled, so
+        // semantic search has nothing to return. The point of this
+        // assertion is that the recall result *was* round-tripped back
+        // to the model on the next step (proving the loop wiring), not
+        // that the data was actually retrievable.
         let recall_output = events
             .iter()
             .find_map(|e| match e {
@@ -864,20 +871,11 @@ mod tests {
                 _ => None,
             })
             .expect("expected a recall ToolResult");
-        assert!(
-            recall_output.contains("editor_preference: vim"),
-            "recall must surface saved pair to the model: {recall_output:?}"
-        );
+        assert_eq!(recall_output, "(no memories)");
 
-        // And the model saw the recall's content pushed back as a
-        // tool_result on the second step's pushed_results.
         let pushed = backend.pushed_results.lock().unwrap();
         assert_eq!(pushed.len(), 2);
-        assert!(
-            pushed[1][0].content.contains("editor_preference: vim"),
-            "second push_tool_results should carry the recall's body: {:?}",
-            pushed[1][0].content
-        );
+        assert_eq!(pushed[1][0].content, "(no memories)");
     }
 
     #[tokio::test]

--- a/crates/assistd-core/src/lib.rs
+++ b/crates/assistd-core/src/lib.rs
@@ -82,8 +82,7 @@ use anyhow::{Context, Result};
 use assistd_embed::{EmbedJob, Embedder};
 use assistd_memory::SemanticStore;
 use assistd_tools::{
-    ConfirmationGate, MemoryOps, RecallTool, RememberTool, RunTool, SandboxRequest,
-    SearchMemoryTool,
+    ConfirmationGate, MemoryOps, RecallTool, RememberTool, ReminisceTool, RunTool, SandboxRequest,
     commands::{
         BashCommand, BashPolicyCfg, CatCommand, EchoCommand, GrepCommand, LsCommand,
         ScreenshotBackendKind, ScreenshotCommand, ScreenshotPolicyCfg, SeeCommand, WcCommand,
@@ -238,18 +237,17 @@ pub fn build_tools(
     ));
     // LLM-callable cross-conversation memory. `RememberTool` queues an
     // embed job for the saved value so semantic recall finds memories
-    // by paraphrase. `RecallTool` supports both prefix browsing
-    // (cheap, deterministic) and semantic match (requires embedder +
-    // semantic store). `SearchMemoryTool` is a sibling that searches
-    // *past conversation history* rather than saved facts.
-    tools.register(RememberTool::new(memory_ops.clone(), embed_tx));
+    // by paraphrase. `RecallTool` ranks saved facts by semantic
+    // similarity to the query (single-mode; the embedder is always
+    // co-resident). `ReminisceTool` is the sibling that searches *past
+    // conversation history* rather than saved facts.
+    tools.register(RememberTool::new(memory_ops, embed_tx));
     tools.register(RecallTool::new(
-        memory_ops,
         embedder.clone(),
         semantic.clone(),
         embedding_model.clone(),
     ));
-    tools.register(SearchMemoryTool::new(embedder, semantic, embedding_model));
+    tools.register(ReminisceTool::new(embedder, semantic, embedding_model));
     Ok(Arc::new(tools))
 }
 

--- a/crates/assistd-core/src/state.rs
+++ b/crates/assistd-core/src/state.rs
@@ -306,6 +306,7 @@ impl AppState {
                 self.handle_memory_semantic_search(id, query, limit, tx)
                     .await
             }
+            Request::MemoryReindex { id } => self.handle_memory_reindex(id, tx).await,
         }
     }
 
@@ -687,6 +688,157 @@ impl AppState {
                 Err(e)
             }
         }
+    }
+
+    /// Embed every memory and every conversation chunk that has no
+    /// embedding under the daemon's currently-configured model. Streams
+    /// `ReindexProgress` events as items complete; finishes with `Done`
+    /// (or `Error` if no embedder is configured). Per-item failures
+    /// during embed/write are logged and counted as still-done so a
+    /// single bad row doesn't wedge the whole run — same log-and-drop
+    /// posture as the background embedder task.
+    async fn handle_memory_reindex(
+        self: Arc<Self>,
+        id: String,
+        tx: mpsc::Sender<Event>,
+    ) -> Result<()> {
+        let model = self.embedder.model().to_string();
+        if model.is_empty() {
+            let _ = tx
+                .send(Event::Error {
+                    id,
+                    message: "embedding subsystem disabled; cannot reindex".to_string(),
+                })
+                .await;
+            return Ok(());
+        }
+        let dim = self.embedder.dim() as i64;
+
+        let chunks = match self.semantic.chunks_missing_embedding(&model).await {
+            Ok(v) => v,
+            Err(e) => {
+                let _ = tx
+                    .send(Event::Error {
+                        id,
+                        message: format!("reindex: list missing chunks: {e:#}"),
+                    })
+                    .await;
+                return Err(e);
+            }
+        };
+        let memories = match self.semantic.memories_missing_embedding(&model).await {
+            Ok(v) => v,
+            Err(e) => {
+                let _ = tx
+                    .send(Event::Error {
+                        id,
+                        message: format!("reindex: list missing memories: {e:#}"),
+                    })
+                    .await;
+                return Err(e);
+            }
+        };
+        let chunks_total = chunks.len() as u32;
+        let memories_total = memories.len() as u32;
+
+        // Always emit a kickoff progress for each kind so a client that
+        // only sees `(0, 0)` still learns the totals before receiving
+        // `Done` — useful when the run has nothing to do.
+        let _ = tx
+            .send(Event::ReindexProgress {
+                id: id.clone(),
+                kind: "chunks".to_string(),
+                done: 0,
+                total: chunks_total,
+            })
+            .await;
+        let _ = tx
+            .send(Event::ReindexProgress {
+                id: id.clone(),
+                kind: "memories".to_string(),
+                done: 0,
+                total: memories_total,
+            })
+            .await;
+
+        let mut done = 0u32;
+        for (chunk_id, text) in chunks {
+            match self.embedder.embed(text).await {
+                Ok(vec) => {
+                    let blob = assistd_memory::vector_to_blob(&vec);
+                    if let Err(e) = self
+                        .semantic
+                        .store_chunk_embedding(chunk_id, model.clone(), dim, blob)
+                        .await
+                    {
+                        tracing::warn!(
+                            target: "assistd::memory",
+                            chunk_id,
+                            error = %e,
+                            "reindex: store_chunk_embedding failed"
+                        );
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        target: "assistd::memory",
+                        chunk_id,
+                        error = %e,
+                        "reindex: embed chunk failed"
+                    );
+                }
+            }
+            done = done.saturating_add(1);
+            let _ = tx
+                .send(Event::ReindexProgress {
+                    id: id.clone(),
+                    kind: "chunks".to_string(),
+                    done,
+                    total: chunks_total,
+                })
+                .await;
+        }
+
+        let mut done = 0u32;
+        for (memory_id, value) in memories {
+            match self.embedder.embed(value).await {
+                Ok(vec) => {
+                    let blob = assistd_memory::vector_to_blob(&vec);
+                    if let Err(e) = self
+                        .semantic
+                        .store_memory_embedding(memory_id, model.clone(), dim, blob)
+                        .await
+                    {
+                        tracing::warn!(
+                            target: "assistd::memory",
+                            memory_id,
+                            error = %e,
+                            "reindex: store_memory_embedding failed"
+                        );
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        target: "assistd::memory",
+                        memory_id,
+                        error = %e,
+                        "reindex: embed memory failed"
+                    );
+                }
+            }
+            done = done.saturating_add(1);
+            let _ = tx
+                .send(Event::ReindexProgress {
+                    id: id.clone(),
+                    kind: "memories".to_string(),
+                    done,
+                    total: memories_total,
+                })
+                .await;
+        }
+
+        let _ = tx.send(Event::Done { id }).await;
+        Ok(())
     }
 
     pub async fn handle_query(

--- a/crates/assistd-core/src/state.rs
+++ b/crates/assistd-core/src/state.rs
@@ -95,10 +95,10 @@ pub struct AppState {
     /// Identifier for this daemon process's session, set at startup by
     /// [`assistd_memory::ConversationStore::begin_session`]. Every row
     /// the persistence hook writes gets tagged with it so a future
-    /// `assistd memory search` knows which daemon run produced it.
+    /// `assistd memory reminisce` knows which daemon run produced it.
     pub session_id: Arc<SessionId>,
     /// Embedder used for query-side embedding (`inject_semantic_context`)
-    /// and for the LLM-callable `recall` / `search_memory` tools. The
+    /// and for the LLM-callable `recall` / `reminisce` tools. The
     /// background embedder task that processes [`Self::embed_tx`] holds
     /// its own clone of this `Arc`.
     pub embedder: Arc<dyn Embedder>,
@@ -290,9 +290,6 @@ impl AppState {
             Request::VoiceToggle { id } => self.handle_voice_toggle(id, tx).await,
             Request::VoiceSkip { id } => self.handle_voice_skip(id, tx).await,
             Request::GetVoiceState { id } => self.handle_get_voice_state(id, tx).await,
-            Request::MemorySearch { id, query, limit } => {
-                self.handle_memory_search(id, query, limit, tx).await
-            }
             Request::MemorySave { id, key, value } => {
                 self.handle_memory_save(id, key, value, tx).await
             }
@@ -337,8 +334,7 @@ impl AppState {
         // Snapshot what we need for chunking *before* moving `msg` into
         // append_message. Tool-call assistant rows and tool-result rows
         // skip chunking: the former have empty content, the latter are
-        // JSON-y noise that pollutes semantic search (FTS5 still covers
-        // them via the conversations table).
+        // JSON-y noise that pollutes semantic search.
         let should_embed = embedding_enabled
             && chunks_handle.is_some()
             && matches!(msg.role, PersistedRole::User | PersistedRole::Assistant)
@@ -457,9 +453,8 @@ impl AppState {
     ) -> Result<()> {
         let model = self.embedder.model().to_string();
         if model.is_empty() {
-            // Embedding subsystem disabled — emit Done with no hits.
-            // Mirrors the behavior of `MemorySearch` against an empty
-            // FTS5 index: clean stream, no error.
+            // Embedding subsystem disabled — emit Done with no hits so
+            // the CLI sees a clean empty stream, not an error.
             let _ = tx.send(Event::Done { id }).await;
             return Ok(());
         }
@@ -504,42 +499,6 @@ impl AppState {
                     .send(Event::Error {
                         id,
                         message: format!("semantic search failed: {e:#}"),
-                    })
-                    .await;
-                Err(e)
-            }
-        }
-    }
-
-    async fn handle_memory_search(
-        self: Arc<Self>,
-        id: String,
-        query: String,
-        limit: u32,
-        tx: mpsc::Sender<Event>,
-    ) -> Result<()> {
-        match self.memory_ops.search(&query, limit as usize).await {
-            Ok(hits) => {
-                for h in hits {
-                    let _ = tx
-                        .send(Event::MemoryHit {
-                            id: id.clone(),
-                            conversation_id: h.conversation_id,
-                            session_id: h.session_id,
-                            timestamp: h.timestamp,
-                            role: h.role.as_wire().into(),
-                            snippet: h.snippet,
-                        })
-                        .await;
-                }
-                let _ = tx.send(Event::Done { id }).await;
-                Ok(())
-            }
-            Err(e) => {
-                let _ = tx
-                    .send(Event::Error {
-                        id,
-                        message: format!("memory search failed: {e:#}"),
                     })
                     .await;
                 Err(e)
@@ -666,9 +625,10 @@ impl AppState {
     ) -> Result<()> {
         match self.memory_ops.list_full(&prefix).await {
             Ok(rows) => {
-                // `limit = 0` means no cap (matches the wire convention used
-                // by `MemorySearch`). Otherwise truncate after the SQL has
-                // already ordered lexicographically by key.
+                // `limit = 0` means no cap (matches the wire convention
+                // used by other search-style memory variants). Otherwise
+                // truncate after the SQL has already ordered
+                // lexicographically by key.
                 let cap = if limit == 0 {
                     rows.len()
                 } else {

--- a/crates/assistd-embed/src/client.rs
+++ b/crates/assistd-embed/src/client.rs
@@ -7,7 +7,7 @@
 //! callers size their `Vec<f32>` buffers without a downstream round-trip.
 //!
 //! L2 normalisation happens here, before the vector leaves the crate, so
-//! every consumer (chunk indexing, query injection, `recall`/`search_memory`)
+//! every consumer (chunk indexing, query injection, `recall`/`reminisce`)
 //! can compute cosine as a plain dot product against stored vectors that
 //! were normalised the same way.
 

--- a/crates/assistd-ipc/src/lib.rs
+++ b/crates/assistd-ipc/src/lib.rs
@@ -214,6 +214,14 @@ pub enum Request {
         #[serde(default)]
         limit: u32,
     },
+    /// Re-embed every memory and conversation-chunk row that has no
+    /// embedding under the daemon's currently-configured embedding
+    /// model. Used to recover after a model swap or after a run where
+    /// the embedding subsystem was unavailable. Emits one
+    /// [`Event::ReindexProgress`] per kind/transition plus per item
+    /// processed, then a terminal `Done` (or `Error` on a fatal
+    /// embedder failure). Backs `assistd memory reindex`.
+    MemoryReindex { id: String },
 }
 
 impl Request {
@@ -267,7 +275,8 @@ impl Request {
             | Request::MemoryListAll { id, .. }
             | Request::MemoryDelete { id, .. }
             | Request::MemoryForget { id, .. }
-            | Request::MemorySemanticSearch { id, .. } => id,
+            | Request::MemorySemanticSearch { id, .. }
+            | Request::MemoryReindex { id, .. } => id,
         }
     }
 
@@ -295,6 +304,7 @@ impl Request {
             Request::MemoryDelete { .. } => "memory_delete",
             Request::MemoryForget { .. } => "memory_forget",
             Request::MemorySemanticSearch { .. } => "memory_semantic_search",
+            Request::MemoryReindex { .. } => "memory_reindex",
         }
     }
 }
@@ -391,6 +401,17 @@ pub enum Event {
         deleted: bool,
         key: Option<String>,
     },
+    /// Progress update for a `MemoryReindex` run. `kind` is `"chunks"`
+    /// or `"memories"`; `done` is how many of `total` rows of that kind
+    /// have been embedded so far. The daemon emits these incrementally
+    /// (one per item) so the CLI can render a progress meter. The
+    /// stream terminates with `Done` after both kinds finish.
+    ReindexProgress {
+        id: String,
+        kind: String,
+        done: u32,
+        total: u32,
+    },
     /// Terminal error event — the stream is over.
     Error { id: String, message: String },
     /// Terminal success event — the stream is over.
@@ -419,6 +440,7 @@ impl Event {
             | Event::MemoryKeys { id, .. }
             | Event::MemoryRow { id, .. }
             | Event::MemoryForgetResult { id, .. }
+            | Event::ReindexProgress { id, .. }
             | Event::Error { id, .. }
             | Event::Done { id } => id,
         }
@@ -616,6 +638,31 @@ mod tests {
         };
         assert_eq!(req.id(), "r");
         assert_eq!(req.kind(), "memory_forget");
+    }
+
+    #[test]
+    fn memory_reindex_request_round_trips() {
+        let req = Request::MemoryReindex { id: "r".into() };
+        let json = serde_json::to_string(&req).unwrap();
+        assert_eq!(json, r#"{"type":"memory_reindex","id":"r"}"#);
+        let parsed: Request = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, req);
+        assert_eq!(req.kind(), "memory_reindex");
+    }
+
+    #[test]
+    fn reindex_progress_event_round_trips() {
+        let ev = Event::ReindexProgress {
+            id: "r".into(),
+            kind: "chunks".into(),
+            done: 3,
+            total: 10,
+        };
+        let json = serde_json::to_string(&ev).unwrap();
+        let parsed: Event = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, ev);
+        assert_eq!(ev.id(), "r");
+        assert!(!ev.is_terminal());
     }
 
     #[test]

--- a/crates/assistd-ipc/src/lib.rs
+++ b/crates/assistd-ipc/src/lib.rs
@@ -163,15 +163,6 @@ pub enum Request {
     /// Report whether TTS is currently enabled. Emits `VoiceOutputState`
     /// + `Done` with no state change.
     GetVoiceState { id: String },
-    /// Full-text search over persisted conversation content. Emits zero
-    /// or more `MemoryHit` events followed by `Done`. `limit = 0` is
-    /// treated as the daemon's default cap.
-    MemorySearch {
-        id: String,
-        query: String,
-        #[serde(default)]
-        limit: u32,
-    },
     /// Persist a string value under `key`. Overwrites any existing
     /// value at the same key. Emits `Done` (no payload) on success.
     MemorySave {
@@ -194,7 +185,7 @@ pub enum Request {
     /// Enumerate full `(id, key, value)` rows whose key starts with
     /// `prefix`. Streams one [`Event::MemoryRow`] per match in
     /// lexicographic key order, then a terminal `Done`. `limit = 0`
-    /// means "no cap" (matches the `MemorySearch` convention).
+    /// means "no cap".
     MemoryListAll {
         id: String,
         #[serde(default)]
@@ -214,8 +205,9 @@ pub enum Request {
     /// Semantic search over persisted conversation chunks. Embeds the
     /// query and ranks past messages by cosine similarity. Emits zero
     /// or more `SemanticHit` events ordered best-first, then `Done`.
-    /// `limit = 0` is treated as the daemon's default cap (matches the
-    /// `MemorySearch` FTS5 path).
+    /// `limit = 0` is treated as the daemon's default cap. Backs the
+    /// `assistd memory reminisce` CLI subcommand and the LLM-callable
+    /// `reminisce` tool.
     MemorySemanticSearch {
         id: String,
         query: String,
@@ -269,7 +261,6 @@ impl Request {
             | Request::VoiceToggle { id }
             | Request::VoiceSkip { id }
             | Request::GetVoiceState { id }
-            | Request::MemorySearch { id, .. }
             | Request::MemorySave { id, .. }
             | Request::MemoryLoad { id, .. }
             | Request::MemoryList { id, .. }
@@ -297,7 +288,6 @@ impl Request {
             Request::VoiceToggle { .. } => "voice_toggle",
             Request::VoiceSkip { .. } => "voice_skip",
             Request::GetVoiceState { .. } => "get_voice_state",
-            Request::MemorySearch { .. } => "memory_search",
             Request::MemorySave { .. } => "memory_save",
             Request::MemoryLoad { .. } => "memory_load",
             Request::MemoryList { .. } => "memory_list",
@@ -352,24 +342,12 @@ pub enum Event {
     /// / `VoiceSkip` / `GetVoiceState`. Skip leaves the flag unchanged
     /// (true if synthesis was on before the skip).
     VoiceOutputState { id: String, enabled: bool },
-    /// One full-text-search hit emitted by `MemorySearch`. The daemon
-    /// emits zero or more of these in score order, then a terminal
-    /// `Done`. `snippet` carries the FTS5 `snippet()` excerpt with
-    /// `<mark>match</mark>` highlighting around the matched terms.
-    MemoryHit {
-        id: String,
-        conversation_id: i64,
-        session_id: String,
-        timestamp: String,
-        role: String,
-        snippet: String,
-    },
     /// One semantic-search hit emitted by `MemorySemanticSearch`. The
     /// daemon emits zero or more of these ranked by cosine similarity
-    /// (best-first), then a terminal `Done`. Unlike `MemoryHit`,
-    /// `content` is the *full* parent message text (not a snippet) —
-    /// chunks may cut mid-sentence, so the surface message is the
-    /// useful unit for the model. `similarity` is in `[0.0, 1.0]`.
+    /// (best-first), then a terminal `Done`. `content` is the *full*
+    /// parent message text (not a snippet) — chunks may cut
+    /// mid-sentence, so the surface message is the useful unit for the
+    /// model. `similarity` is in `[0.0, 1.0]`.
     SemanticHit {
         id: String,
         conversation_id: i64,
@@ -436,7 +414,6 @@ impl Event {
             | Event::Transcription { id, .. }
             | Event::ListenState { id, .. }
             | Event::VoiceOutputState { id, .. }
-            | Event::MemoryHit { id, .. }
             | Event::SemanticHit { id, .. }
             | Event::MemoryValue { id, .. }
             | Event::MemoryKeys { id, .. }
@@ -578,22 +555,6 @@ mod tests {
     }
 
     #[test]
-    fn memory_search_request_roundtrip_with_default_limit() {
-        // Omitting `limit` should round-trip as 0; the daemon treats 0
-        // as "use default cap" — kept off the wire by `#[serde(default)]`.
-        let json = r#"{"type":"memory_search","id":"r","query":"foo"}"#;
-        let parsed: Request = serde_json::from_str(json).unwrap();
-        match parsed {
-            Request::MemorySearch { id, query, limit } => {
-                assert_eq!(id, "r");
-                assert_eq!(query, "foo");
-                assert_eq!(limit, 0);
-            }
-            _ => panic!("expected MemorySearch"),
-        }
-    }
-
-    #[test]
     fn memory_save_load_list_delete_request_roundtrip() {
         let cases = vec![
             Request::MemorySave {
@@ -660,14 +621,6 @@ mod tests {
     #[test]
     fn memory_event_roundtrip() {
         let cases = vec![
-            Event::MemoryHit {
-                id: "r".into(),
-                conversation_id: 42,
-                session_id: "s".into(),
-                timestamp: "2026-04-28T00:00:00Z".into(),
-                role: "assistant".into(),
-                snippet: "…the <mark>match</mark>…".into(),
-            },
             Event::SemanticHit {
                 id: "r".into(),
                 conversation_id: 42,
@@ -746,17 +699,6 @@ mod tests {
         assert_eq!(parsed, req);
         assert_eq!(req.id(), "ms-1");
         assert_eq!(req.kind(), "memory_semantic_search");
-    }
-
-    #[test]
-    fn memory_request_id_helper_returns_inner() {
-        let req = Request::MemorySearch {
-            id: "abc".into(),
-            query: "q".into(),
-            limit: 10,
-        };
-        assert_eq!(req.id(), "abc");
-        assert_eq!(req.kind(), "memory_search");
     }
 
     #[test]

--- a/crates/assistd-memory/src/sqlite/conversations.rs
+++ b/crates/assistd-memory/src/sqlite/conversations.rs
@@ -296,7 +296,14 @@ impl ConversationStore for SqliteConversationStore {
         // Reads bypass the writer channel — SQLite in WAL mode handles
         // concurrent readers fine, and routing them through the writer
         // would queue them behind any in-flight inserts.
-        let q = query.to_string();
+        //
+        // Wrap the user-supplied query in an FTS5 literal phrase so
+        // grammar metacharacters (`*`, `+`, `-`, `OR`, quotes, …) are
+        // matched as text rather than parsed as operators. Today only
+        // tests call this method, but future callers (CLI re-exposure,
+        // an LLM tool) inherit safe-by-default behaviour. A future
+        // `search_raw` sibling can opt back into FTS5 grammar.
+        let q = fts5_literal(query);
         let limit = limit as i64;
         self.handle
             .conn()
@@ -386,6 +393,25 @@ impl ConversationStore for SqliteConversationStore {
 // import lint via direct reference.
 #[allow(dead_code)]
 fn _force_oneshot_referenced(_: oneshot::Receiver<Result<()>>) {}
+
+/// Wrap a user-supplied query as an FTS5 literal phrase by surrounding
+/// it with double-quotes and doubling any internal quotes (per FTS5's
+/// quoted-string rules). The result is safe to paste into a `MATCH`
+/// expression as a single phrase token.
+fn fts5_literal(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('"');
+    for ch in s.chars() {
+        if ch == '"' {
+            out.push('"');
+            out.push('"');
+        } else {
+            out.push(ch);
+        }
+    }
+    out.push('"');
+    out
+}
 
 #[cfg(test)]
 mod tests {
@@ -491,5 +517,35 @@ mod tests {
         let store = NoConversationStore;
         assert!(store.search("anything", 10).await.unwrap().is_empty());
         assert!(store.recent_turns(10).await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn search_handles_fts5_grammar_safely() {
+        // Inputs that would parse-error under raw FTS5 grammar must
+        // round-trip through the literal-phrase escape without
+        // surfacing as Err. We don't assert on hits — the default
+        // tokenizer's behaviour on these inputs is implementation
+        // detail; we only assert the call succeeds.
+        let (store, _w) = fresh_store().await;
+        let session = store.begin_session(1).await.unwrap();
+        let turn = store.begin_turn(&session, "ignore").await.unwrap();
+        store
+            .append_message(&session, Some(turn), PersistedMessage::user("she said hi"))
+            .await
+            .unwrap();
+
+        // Unmatched quote — would be a parse error pre-escape.
+        store.search("say \"hi", 10).await.unwrap();
+        // Operator-looking input — would be parsed as boolean OR.
+        store.search("apple OR banana", 10).await.unwrap();
+        // Wildcard star — would be a prefix match pre-escape.
+        store.search("foo*", 10).await.unwrap();
+    }
+
+    #[test]
+    fn fts5_literal_doubles_internal_quotes() {
+        assert_eq!(fts5_literal("foo"), "\"foo\"");
+        assert_eq!(fts5_literal("say \"hi\""), "\"say \"\"hi\"\"\"");
+        assert_eq!(fts5_literal(""), "\"\"");
     }
 }

--- a/crates/assistd-memory/src/sqlite/embeddings.rs
+++ b/crates/assistd-memory/src/sqlite/embeddings.rs
@@ -84,6 +84,49 @@ pub trait SemanticStore: Send + Sync + 'static {
     /// configured model? Returned as `(chunks, memories)`. Useful in
     /// tests and a future `assistd memory stats` view.
     async fn count_for_model(&self, model: &str) -> Result<(i64, i64)>;
+
+    /// Diagnostic: rows whose `model` does NOT equal `current`. Used by
+    /// the daemon at startup to warn when a config change has stranded
+    /// pre-existing embeddings under a different model name (the
+    /// retrieval queries filter by model, so stale rows are invisible
+    /// until reindexed). Returns total stale row count + the distinct
+    /// model names that own them, sorted lexicographically.
+    async fn count_stale(&self, current: &str) -> Result<(i64, Vec<String>)>;
+
+    /// Memories that have no embedding under `current`. The reindex
+    /// handler embeds and stores each `(id, value)` to bring them back
+    /// into the recall index. A row appears here when (a) the memory
+    /// was saved while the embedder subsystem was down, or (b) the
+    /// configured embedding model has changed since the row was
+    /// indexed.
+    async fn memories_missing_embedding(&self, current: &str) -> Result<Vec<(i64, String)>>;
+
+    /// Conversation chunks that have no embedding under `current`.
+    /// Symmetric to [`SemanticStore::memories_missing_embedding`].
+    async fn chunks_missing_embedding(&self, current: &str) -> Result<Vec<(i64, String)>>;
+
+    /// Persist a freshly-computed embedding for a `conversation_chunks`
+    /// row. Idempotent on `(chunk_id)` via the same UPSERT the
+    /// background embedder task uses. Used by the reindex handler so
+    /// it can dispatch directly without going through the embedder
+    /// task's mpsc.
+    async fn store_chunk_embedding(
+        &self,
+        chunk_id: i64,
+        model: String,
+        dim: i64,
+        vector: Vec<u8>,
+    ) -> Result<()>;
+
+    /// Persist a freshly-computed embedding for a `memories` row.
+    /// Symmetric to [`SemanticStore::store_chunk_embedding`].
+    async fn store_memory_embedding(
+        &self,
+        memory_id: i64,
+        model: String,
+        dim: i64,
+        vector: Vec<u8>,
+    ) -> Result<()>;
 }
 
 /// Successful-no-op fallback used when the embedding subsystem is
@@ -110,6 +153,33 @@ impl SemanticStore for NoSemanticStore {
     }
     async fn count_for_model(&self, _model: &str) -> Result<(i64, i64)> {
         Ok((0, 0))
+    }
+    async fn count_stale(&self, _current: &str) -> Result<(i64, Vec<String>)> {
+        Ok((0, Vec::new()))
+    }
+    async fn memories_missing_embedding(&self, _current: &str) -> Result<Vec<(i64, String)>> {
+        Ok(Vec::new())
+    }
+    async fn chunks_missing_embedding(&self, _current: &str) -> Result<Vec<(i64, String)>> {
+        Ok(Vec::new())
+    }
+    async fn store_chunk_embedding(
+        &self,
+        _chunk_id: i64,
+        _model: String,
+        _dim: i64,
+        _vector: Vec<u8>,
+    ) -> Result<()> {
+        Ok(())
+    }
+    async fn store_memory_embedding(
+        &self,
+        _memory_id: i64,
+        _model: String,
+        _dim: i64,
+        _vector: Vec<u8>,
+    ) -> Result<()> {
+        Ok(())
     }
 }
 
@@ -327,6 +397,118 @@ impl SemanticStore for SqliteSemanticStore {
             })
             .await
             .context("count_for_model")
+    }
+
+    async fn count_stale(&self, current: &str) -> Result<(i64, Vec<String>)> {
+        let current = current.to_string();
+        self.handle
+            .conn()
+            .call(move |c| {
+                let mut total: i64 = 0;
+                let mut models: std::collections::BTreeSet<String> =
+                    std::collections::BTreeSet::new();
+                let sql = "SELECT model, count(*)
+                           FROM embeddings WHERE model != ?1 GROUP BY model
+                           UNION ALL
+                           SELECT model, count(*)
+                           FROM memory_embeddings WHERE model != ?1 GROUP BY model";
+                let mut stmt = c.prepare(sql)?;
+                let rows = stmt.query_map(rusqlite::params![current], |row| {
+                    Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+                })?;
+                for r in rows {
+                    let (model, n) = r?;
+                    total += n;
+                    models.insert(model);
+                }
+                Ok((total, models.into_iter().collect::<Vec<_>>()))
+            })
+            .await
+            .context("count_stale")
+    }
+
+    async fn memories_missing_embedding(&self, current: &str) -> Result<Vec<(i64, String)>> {
+        let current = current.to_string();
+        self.handle
+            .conn()
+            .call(move |c| {
+                let mut stmt = c.prepare(
+                    "SELECT m.id, m.value
+                     FROM memories m
+                     LEFT JOIN memory_embeddings e
+                       ON e.memory_id = m.id AND e.model = ?1
+                     WHERE e.id IS NULL
+                     ORDER BY m.id",
+                )?;
+                let rows = stmt
+                    .query_map(rusqlite::params![current], |r| {
+                        Ok((r.get::<_, i64>(0)?, r.get::<_, String>(1)?))
+                    })?
+                    .collect::<std::result::Result<Vec<_>, _>>()?;
+                Ok(rows)
+            })
+            .await
+            .context("memories_missing_embedding")
+    }
+
+    async fn chunks_missing_embedding(&self, current: &str) -> Result<Vec<(i64, String)>> {
+        let current = current.to_string();
+        self.handle
+            .conn()
+            .call(move |c| {
+                let mut stmt = c.prepare(
+                    "SELECT cc.id, cc.content
+                     FROM conversation_chunks cc
+                     LEFT JOIN embeddings e
+                       ON e.conversation_chunk_id = cc.id AND e.model = ?1
+                     WHERE e.id IS NULL
+                     ORDER BY cc.id",
+                )?;
+                let rows = stmt
+                    .query_map(rusqlite::params![current], |r| {
+                        Ok((r.get::<_, i64>(0)?, r.get::<_, String>(1)?))
+                    })?
+                    .collect::<std::result::Result<Vec<_>, _>>()?;
+                Ok(rows)
+            })
+            .await
+            .context("chunks_missing_embedding")
+    }
+
+    async fn store_chunk_embedding(
+        &self,
+        chunk_id: i64,
+        model: String,
+        dim: i64,
+        vector: Vec<u8>,
+    ) -> Result<()> {
+        use super::writer::{WriteCall, WriteOp};
+        WriteCall::run(self.handle.writer(), |ack| WriteOp::StoreChunkEmbedding {
+            chunk_id,
+            model,
+            dim,
+            vector,
+            ack,
+        })
+        .await
+    }
+
+    async fn store_memory_embedding(
+        &self,
+        memory_id: i64,
+        model: String,
+        dim: i64,
+        vector: Vec<u8>,
+    ) -> Result<()> {
+        use super::writer::{WriteCall, WriteOp};
+        WriteCall::run(self.handle.writer(), |ack| WriteOp::StoreMemoryEmbedding {
+            memory_id,
+            model,
+            dim,
+            vector,
+            ack,
+        })
+        .await
     }
 }
 
@@ -685,6 +867,198 @@ mod tests {
                 .is_empty()
         );
         assert_eq!(s.count_for_model("m").await.unwrap(), (0, 0));
+        let (n, models) = s.count_stale("m").await.unwrap();
+        assert_eq!(n, 0);
+        assert!(models.is_empty());
+    }
+
+    #[tokio::test]
+    async fn missing_embedding_lists_only_unindexed_rows_for_current_model() {
+        let (handle, _w) = fresh().await;
+        let (tx, rx) = oneshot::channel();
+        handle
+            .writer()
+            .send(WriteOp::BeginSession {
+                session_id: "sess-mx".into(),
+                daemon_pid: 1,
+                ack: tx,
+            })
+            .await
+            .unwrap();
+        rx.await.unwrap().unwrap();
+        let (tx, rx) = oneshot::channel();
+        handle
+            .writer()
+            .send(WriteOp::AppendMessage {
+                session_id: "sess-mx".into(),
+                turn_id: None,
+                msg: PersistedMessage::user("x"),
+                ack: tx,
+            })
+            .await
+            .unwrap();
+        let conv_id = rx.await.unwrap().unwrap();
+
+        // Two chunks: one indexed under "new", one indexed under "old".
+        let _ = insert_chunk_with_vec(&handle, conv_id, 0, &unit_vec(0.0), "new").await;
+        let _ = insert_chunk_with_vec(&handle, conv_id, 1, &unit_vec(0.5), "old").await;
+        // One unindexed chunk (no embedding row at all).
+        let (tx, rx) = oneshot::channel();
+        handle
+            .writer()
+            .send(WriteOp::StoreChunk {
+                conversation_id: conv_id,
+                chunk_index: 2,
+                content: "naked-chunk".into(),
+                token_count: None,
+                ack: tx,
+            })
+            .await
+            .unwrap();
+        let naked_chunk = rx.await.unwrap().unwrap();
+
+        // Two memories: one indexed under "new", one bare.
+        let (tx, rx) = oneshot::channel();
+        handle
+            .writer()
+            .send(WriteOp::SaveMemory {
+                key: "indexed".into(),
+                value: "v1".into(),
+                source_conversation_id: None,
+                ack: tx,
+            })
+            .await
+            .unwrap();
+        let indexed_mem = rx.await.unwrap().unwrap();
+        let (tx, rx) = oneshot::channel();
+        handle
+            .writer()
+            .send(WriteOp::StoreMemoryEmbedding {
+                memory_id: indexed_mem,
+                model: "new".into(),
+                dim: 2,
+                vector: vector_to_blob(&unit_vec(0.0)),
+                ack: tx,
+            })
+            .await
+            .unwrap();
+        rx.await.unwrap().unwrap();
+        let (tx, rx) = oneshot::channel();
+        handle
+            .writer()
+            .send(WriteOp::SaveMemory {
+                key: "bare".into(),
+                value: "v2".into(),
+                source_conversation_id: None,
+                ack: tx,
+            })
+            .await
+            .unwrap();
+        let bare_mem = rx.await.unwrap().unwrap();
+
+        let s = SqliteSemanticStore::new(handle);
+        // Under current = "new":
+        // - Chunks missing: the "old"-indexed chunk + the naked one.
+        // - Memories missing: just the bare memory.
+        let chunks = s.chunks_missing_embedding("new").await.unwrap();
+        assert_eq!(chunks.len(), 2);
+        let chunk_contents: Vec<&str> = chunks.iter().map(|(_, t)| t.as_str()).collect();
+        assert!(chunk_contents.contains(&"chunk1")); // old-indexed
+        assert!(chunk_contents.contains(&"naked-chunk"));
+        assert!(chunks.iter().any(|(id, _)| *id == naked_chunk));
+
+        let memories = s.memories_missing_embedding("new").await.unwrap();
+        assert_eq!(memories.len(), 1);
+        assert_eq!(memories[0].0, bare_mem);
+        assert_eq!(memories[0].1, "v2");
+
+        // store_*_embedding should be idempotent: write under "new"
+        // and the row drops out of the missing list.
+        s.store_memory_embedding(
+            bare_mem,
+            "new".to_string(),
+            2,
+            vector_to_blob(&unit_vec(0.0)),
+        )
+        .await
+        .unwrap();
+        let memories = s.memories_missing_embedding("new").await.unwrap();
+        assert!(memories.is_empty());
+    }
+
+    #[tokio::test]
+    async fn count_stale_aggregates_across_chunks_and_memories() {
+        let (handle, _w) = fresh().await;
+        // Create a conversation row to FK chunk inserts.
+        let (tx, rx) = oneshot::channel();
+        handle
+            .writer()
+            .send(WriteOp::BeginSession {
+                session_id: "sess-stale".into(),
+                daemon_pid: 1,
+                ack: tx,
+            })
+            .await
+            .unwrap();
+        rx.await.unwrap().unwrap();
+        let (tx, rx) = oneshot::channel();
+        handle
+            .writer()
+            .send(WriteOp::AppendMessage {
+                session_id: "sess-stale".into(),
+                turn_id: None,
+                msg: PersistedMessage::user("x"),
+                ack: tx,
+            })
+            .await
+            .unwrap();
+        let conv_id = rx.await.unwrap().unwrap();
+
+        // Two chunks under "old-A", one under "old-B", one under "new".
+        let _ = insert_chunk_with_vec(&handle, conv_id, 0, &unit_vec(0.0), "old-A").await;
+        let _ = insert_chunk_with_vec(&handle, conv_id, 1, &unit_vec(0.5), "old-A").await;
+        let _ = insert_chunk_with_vec(&handle, conv_id, 2, &unit_vec(1.0), "old-B").await;
+        let _ = insert_chunk_with_vec(&handle, conv_id, 3, &unit_vec(1.5), "new").await;
+
+        // One memory embedding under "old-A".
+        let (tx, rx) = oneshot::channel();
+        handle
+            .writer()
+            .send(WriteOp::SaveMemory {
+                key: "k".into(),
+                value: "v".into(),
+                source_conversation_id: None,
+                ack: tx,
+            })
+            .await
+            .unwrap();
+        let mem_id = rx.await.unwrap().unwrap();
+        let (tx, rx) = oneshot::channel();
+        handle
+            .writer()
+            .send(WriteOp::StoreMemoryEmbedding {
+                memory_id: mem_id,
+                model: "old-A".into(),
+                dim: 2,
+                vector: vector_to_blob(&unit_vec(0.0)),
+                ack: tx,
+            })
+            .await
+            .unwrap();
+        rx.await.unwrap().unwrap();
+
+        let s = SqliteSemanticStore::new(handle);
+        // Current = "new" → 2 chunk rows under old-A + 1 chunk under old-B
+        // + 1 memory under old-A = 4 stale rows, two distinct models.
+        let (n, models) = s.count_stale("new").await.unwrap();
+        assert_eq!(n, 4);
+        assert_eq!(models, vec!["old-A".to_string(), "old-B".to_string()]);
+
+        // Switching current to "old-A" should leave only the "old-B"
+        // chunk + the "new" chunk as stale = 2 rows, two models.
+        let (n, models) = s.count_stale("old-A").await.unwrap();
+        assert_eq!(n, 2);
+        assert_eq!(models, vec!["new".to_string(), "old-B".to_string()]);
     }
 
     #[test]

--- a/crates/assistd-memory/src/sqlite/writer.rs
+++ b/crates/assistd-memory/src/sqlite/writer.rs
@@ -320,17 +320,19 @@ async fn append_message(
     let turn_id = turn.map(|t| t.0);
     let id = conn
         .call(move |c| {
-            // seq is per-session monotonic. Compute it inside the same
-            // implicit transaction as the INSERT so concurrent writers
-            // (none today, but cheap insurance) cannot collide.
-            let seq: i64 = c
-                .query_row(
-                    "SELECT COALESCE(MAX(seq), -1) + 1 FROM conversations WHERE session_id = ?1",
-                    rusqlite::params![session],
-                    |r| r.get(0),
-                )
-                .unwrap_or(0);
-            c.execute(
+            // seq is per-session monotonic. Wrap the SELECT + INSERT in
+            // an explicit transaction so the two statements observe a
+            // consistent snapshot of `conversations` and so a SELECT
+            // failure surfaces as itself rather than as a UNIQUE
+            // collision on the follow-up INSERT (which is what the old
+            // `.unwrap_or(0)` produced).
+            let tx = c.transaction()?;
+            let seq: i64 = tx.query_row(
+                "SELECT COALESCE(MAX(seq), -1) + 1 FROM conversations WHERE session_id = ?1",
+                rusqlite::params![session],
+                |r| r.get(0),
+            )?;
+            tx.execute(
                 "INSERT INTO conversations
                     (session_id, turn_id, seq, timestamp, role, content, tool_calls, tool_call_id, tool_name)
                  VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
@@ -346,7 +348,9 @@ async fn append_message(
                     msg.tool_name,
                 ],
             )?;
-            Ok(c.last_insert_rowid())
+            let id = tx.last_insert_rowid();
+            tx.commit()?;
+            Ok(id)
         })
         .await
         .context("append_message")?;

--- a/crates/assistd-memory/tests/round_trip.rs
+++ b/crates/assistd-memory/tests/round_trip.rs
@@ -82,8 +82,10 @@ async fn turn_persists_across_store_reopen() {
         let convs = SqliteConversationStore::new(handle.clone());
         let mems = SqliteMemoryStore::new(handle);
 
-        // FTS5 search over message content — the predicate that
-        // `assistd memory search` will run.
+        // FTS5 search over message content. The CLI no longer exposes
+        // this path (semantic-only), but the index/query is still
+        // exercised here as the storage-layer contract until the FTS5
+        // schema is removed in a follow-up.
         let hits = convs.search("rust", 10).await.unwrap();
         assert!(
             hits.iter()

--- a/crates/assistd-tools/src/lib.rs
+++ b/crates/assistd-tools/src/lib.rs
@@ -33,7 +33,7 @@ pub use attachment::{LoadImageError, load_image_attachment};
 pub use chain::{Chain, ParseError, execute, parse_chain};
 pub use command::{Attachment, Command, CommandInput, CommandOutput, CommandRegistry};
 pub use memory::{DEFAULT_SEARCH_LIMIT, MemoryOps};
-pub use memory_tools::{RecallTool, RememberTool, SearchMemoryTool};
+pub use memory_tools::{RecallTool, RememberTool, ReminisceTool};
 pub use policy::{
     AlwaysAllowGate, ConfirmationGate, ConfirmationRequest, DenyAllGate, ResolvedSandboxMode,
     SandboxInfo, SandboxRequest, matches_denylist, matches_destructive, probe_sandbox,

--- a/crates/assistd-tools/src/memory.rs
+++ b/crates/assistd-tools/src/memory.rs
@@ -12,15 +12,14 @@
 use std::sync::Arc;
 
 use anyhow::Result;
-use assistd_memory::{ConversationStore, MemoryStore, SearchHit, TurnSummary};
+use assistd_memory::{ConversationStore, MemoryStore, TurnSummary};
 
 pub use assistd_memory::MemoryRecord;
 
-/// Default cap on `search` / `list` result sizes when the IPC client
-/// asks for `limit = 0` (the wire default for the `MemorySearch`
-/// variant). Big enough to be useful for casual `assistd memory search`
-/// runs; the LLM-facing path will likely want to pass an explicit
-/// smaller limit.
+/// Default cap on `recent_turns` / semantic-search result sizes when
+/// the IPC client asks for `limit = 0` (the wire default for variants
+/// that omit a cap). Big enough to be useful for casual inspection;
+/// the LLM-facing path passes an explicit smaller limit.
 pub const DEFAULT_SEARCH_LIMIT: usize = 50;
 
 /// Combined CRUD handle over both the flat KV store and the richer
@@ -76,37 +75,6 @@ impl MemoryOps {
         self.store.list_full(prefix).await
     }
 
-    pub async fn search(&self, query: &str, limit: usize) -> Result<Vec<SearchHit>> {
-        let limit = if limit == 0 {
-            DEFAULT_SEARCH_LIMIT
-        } else {
-            limit
-        };
-        self.conversations.search(query, limit).await
-    }
-
-    /// List `(key, value)` pairs for keys matching `prefix`, capped at
-    /// `limit`. Returned in the order [`MemoryStore::list`] yields keys
-    /// (lexicographic for the SQLite impl). Used by the LLM-facing
-    /// `recall` tool to fetch a batch of memories in one call.
-    ///
-    /// Implementation is N+1 (`list` + a `load` per key). That's fine
-    /// here: reads bypass the writer queue (`conn.call` direct), N is
-    /// small (the default cap is ~50), and a future hot path can lift
-    /// this into a single SQL by widening the [`MemoryStore`] trait.
-    /// Keys whose `load` returns `None` (raced delete) are silently
-    /// skipped so a transient inconsistency never surfaces as an error.
-    pub async fn list_pairs(&self, prefix: &str, limit: usize) -> Result<Vec<(String, String)>> {
-        let keys = self.store.list(prefix).await?;
-        let mut pairs = Vec::with_capacity(keys.len().min(limit));
-        for key in keys.into_iter().take(limit) {
-            if let Some(value) = self.store.load(&key).await? {
-                pairs.push((key, value));
-            }
-        }
-        Ok(pairs)
-    }
-
     pub async fn recent_turns(&self, limit: usize) -> Result<Vec<TurnSummary>> {
         let limit = if limit == 0 {
             DEFAULT_SEARCH_LIMIT
@@ -137,45 +105,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn no_backend_search_and_list_return_empty() {
+    async fn no_backend_list_and_recent_turns_return_empty() {
         let ops = no_ops();
         assert!(ops.list("pref:").await.unwrap().is_empty());
-        assert!(ops.search("anything", 10).await.unwrap().is_empty());
         assert!(ops.recent_turns(0).await.unwrap().is_empty());
-    }
-
-    #[tokio::test]
-    async fn search_zero_limit_falls_back_to_default() {
-        // Use a SqliteConversationStore so the limit handling is real.
-        // Path: write enough rows that DEFAULT_SEARCH_LIMIT actually
-        // bounds the result. Verifies the façade rewrites `0` to a sane
-        // default before delegating.
-        use assistd_memory::{
-            PersistedMessage, SqliteConversationStore, SqliteHandle, SqliteMemoryStore,
-        };
-        use tokio::sync::watch;
-
-        let temp = tempfile::tempdir().unwrap();
-        let path = temp.path().join("memory.db");
-        let (_tx, rx) = watch::channel(false);
-        let (handle, _writer) = SqliteHandle::open(&path, rx).await.unwrap();
-        let handle = Arc::new(handle);
-        let conv = SqliteConversationStore::new(handle.clone());
-        let mem = SqliteMemoryStore::new(handle);
-
-        let session = conv.begin_session(0).await.unwrap();
-        for i in 0..(DEFAULT_SEARCH_LIMIT + 5) {
-            conv.append_message(
-                &session,
-                None,
-                PersistedMessage::user(format!("alpha message {i}")),
-            )
-            .await
-            .unwrap();
-        }
-
-        let ops = MemoryOps::new(Arc::new(mem), Arc::new(conv));
-        let hits = ops.search("alpha", 0).await.unwrap();
-        assert_eq!(hits.len(), DEFAULT_SEARCH_LIMIT);
     }
 }

--- a/crates/assistd-tools/src/memory_tools.rs
+++ b/crates/assistd-tools/src/memory_tools.rs
@@ -1,10 +1,13 @@
-//! LLM-callable memory tools: `remember` and `recall`.
+//! LLM-callable memory tools: `remember`, `recall`, and `reminisce`.
 //!
-//! Both tools sit alongside [`crate::RunTool`] in the daemon's
-//! [`crate::ToolRegistry`]. The model decides when to invoke them; both
-//! delegate straight to [`MemoryOps`], which writes through the same
-//! single SQLite writer the chat-turn persistence path uses (so saves
-//! never block the agent thread for disk).
+//! All three sit alongside [`crate::RunTool`] in the daemon's
+//! [`crate::ToolRegistry`]. The model decides when to invoke them.
+//! `remember`/`recall` operate on saved key/value facts via [`MemoryOps`],
+//! which writes through the same single SQLite writer the chat-turn
+//! persistence path uses (so saves never block the agent thread for
+//! disk). `reminisce` is the parallel verb for *past dialogue* — it
+//! runs semantic search over the chunked conversation history, not over
+//! saved facts.
 //!
 //! Dedup is by key: the `memories` table has `key TEXT NOT NULL UNIQUE`
 //! and `save_memory` does `ON CONFLICT(key) DO UPDATE`, so re-saving the
@@ -159,22 +162,16 @@ impl Tool for RememberTool {
     }
 }
 
-/// LLM-callable tool that returns previously-saved memories.
+/// LLM-callable tool that returns previously-saved memories ranked by
+/// semantic similarity to the query. Embeds the query and ranks
+/// memories by cosine similarity against the saved values' embeddings,
+/// so the user can describe a fact in different words than the stored
+/// key/value text and still hit it. Falls back to the no-memories
+/// sentinel when the embedding subsystem is disabled (or no memories
+/// have been embedded yet).
 ///
-/// Supports two query modes:
-/// - `prefix`: list keys starting with the query string (`""` lists all).
-///   Cheap, deterministic, ideal for hierarchical browsing like `user.*`.
-/// - `semantic`: embed the query and rank memories by cosine similarity
-///   against the saved values' embeddings. Robust to paraphrase — works
-///   even when the user describes the fact in different words than the
-///   stored key/value text. Falls back to the no-memories sentinel when
-///   the embedding subsystem is disabled (or no memories have been
-///   embedded yet).
-///
-/// Both modes return `<key>: <value>` lines so the model's downstream
-/// formatting stays uniform.
+/// Returns `<key>: <value>` lines.
 pub struct RecallTool {
-    ops: Arc<MemoryOps>,
     embedder: Arc<dyn Embedder>,
     semantic: Arc<dyn SemanticStore>,
     /// Embedding model name used to filter `memory_embeddings` rows by
@@ -185,63 +182,15 @@ pub struct RecallTool {
 
 impl RecallTool {
     pub fn new(
-        ops: Arc<MemoryOps>,
         embedder: Arc<dyn Embedder>,
         semantic: Arc<dyn SemanticStore>,
         embedding_model: String,
     ) -> Self {
         Self {
-            ops,
             embedder,
             semantic,
             embedding_model,
         }
-    }
-
-    async fn recall_prefix(&self, prefix: &str) -> Result<(String, bool, usize)> {
-        // Probe `list` first so we can detect overflow vs. exactly-cap.
-        let total_keys = self.ops.list(prefix).await?.len();
-        let mut pairs = self.ops.list_pairs(prefix, RECALL_LIMIT).await?;
-        pairs.sort_by(|a, b| a.0.cmp(&b.0));
-        let truncated = total_keys > RECALL_LIMIT;
-        Ok((format_pairs(&pairs), truncated, pairs.len()))
-    }
-
-    async fn recall_semantic(&self, query: &str) -> Result<(String, bool, usize)> {
-        if self.embedding_model.is_empty() {
-            // Embedding subsystem disabled — degrade gracefully so the
-            // model can fall back to prefix mode without erroring.
-            return Ok(("(no memories)".to_string(), false, 0));
-        }
-        let vec = match self.embedder.embed(query.to_string()).await {
-            Ok(v) => v,
-            Err(e) => {
-                // Best-effort: log and return empty rather than
-                // surfacing as a tool error. The LLM can retry with
-                // prefix mode if it cares.
-                tracing::debug!(
-                    target: "assistd::embed",
-                    error = %e,
-                    "recall(semantic) embed failed; returning empty"
-                );
-                return Ok(("(no memories)".to_string(), false, 0));
-            }
-        };
-        let hits = self
-            .semantic
-            .nearest_memories(vec, RECALL_LIMIT, &self.embedding_model)
-            .await?;
-        if hits.is_empty() {
-            return Ok(("(no memories)".to_string(), false, 0));
-        }
-        // Render the same `<key>: <value>` shape as the prefix path so
-        // downstream formatting in the model stays uniform.
-        let pairs: Vec<(String, String)> = hits
-            .iter()
-            .map(|h| (h.key.clone(), h.value.clone()))
-            .collect();
-        let n = pairs.len();
-        Ok((format_pairs(&pairs), false, n))
     }
 }
 
@@ -255,44 +204,30 @@ impl Tool for RecallTool {
         "Retrieve previously remembered facts and preferences about the user. \
          Call this when prior context might help (e.g. answering \"what editor \
          should I use?\", personalizing a response, or whenever the user \
-         references something they told you before). \
-         Two query modes: \
-         (1) `mode=\"prefix\"` lists keys starting with `query` — pass `query=\"\"` \
-         to list every memory, or `query=\"user.\"` to filter by namespace. \
-         (2) `mode=\"semantic\"` embeds `query` and ranks memories by meaning. \
-         Use semantic for natural-language questions like \"what editor do I \
-         prefer?\"; use prefix for hierarchical browsing. \
-         Returns up to 50 `<key>: <value>` lines. If no memories match, the \
-         output is `(no memories)`."
+         references something they told you before). Embeds `query` and ranks \
+         memories by semantic similarity, so paraphrased questions still match \
+         the stored fact (e.g. \"what editor do I prefer?\" finds an \
+         `editor_preference` memory). Returns up to 50 `<key>: <value>` lines. \
+         If no memories match, the output is `(no memories)`."
     }
 
     fn parameters_schema(&self) -> Value {
-        // `query` and `mode` are both required because
-        // `ToolRegistry::openai_schemas` hardcodes `strict: true`, which
-        // requires every declared property to appear in `required`.
         json!({
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "query": {
                     "type": "string",
-                    "description": "Either a key prefix (when mode=\"prefix\") or \
-                                    a natural-language question (when mode=\"semantic\"). \
-                                    Pass \"\" with mode=\"prefix\" to list every memory."
-                },
-                "mode": {
-                    "type": "string",
-                    "enum": ["prefix", "semantic"],
-                    "description": "How to match. \"prefix\" lists keys starting with \
-                                    `query`. \"semantic\" embeds `query` and ranks memories \
-                                    by meaning (use for paraphrase-tolerant lookup)."
+                    "description": "Natural-language question. The model embeds \
+                                    this and ranks memories by cosine similarity \
+                                    against their stored values."
                 }
             },
-            "required": ["query", "mode"]
+            "required": ["query"]
         })
     }
 
-    #[tracing::instrument(skip(self, args), fields(mode = tracing::field::Empty))]
+    #[tracing::instrument(skip(self, args))]
     async fn invoke(&self, args: Value) -> Result<Value> {
         let start = Instant::now();
         let query = args
@@ -300,37 +235,53 @@ impl Tool for RecallTool {
             .and_then(|v| v.as_str())
             .ok_or_else(|| anyhow!("`query` (string) is required"))?
             .to_string();
-        let mode = args
-            .get("mode")
-            .and_then(|v| v.as_str())
-            .ok_or_else(|| anyhow!("`mode` (string, \"prefix\" or \"semantic\") is required"))?
-            .to_string();
-        tracing::Span::current().record("mode", mode.as_str());
 
-        let (output, truncated, returned) = match mode.as_str() {
-            "prefix" => self.recall_prefix(&query).await?,
-            "semantic" => self.recall_semantic(&query).await?,
-            other => {
-                return Err(anyhow!(
-                    "`mode` must be \"prefix\" or \"semantic\" (got {other:?})"
-                ));
+        let (output, returned) = if self.embedding_model.is_empty() {
+            // Embedding subsystem disabled — no semantic index to search.
+            ("(no memories)".to_string(), 0)
+        } else {
+            match self.embedder.embed(query).await {
+                Ok(vec) => {
+                    let hits = self
+                        .semantic
+                        .nearest_memories(vec, RECALL_LIMIT, &self.embedding_model)
+                        .await?;
+                    if hits.is_empty() {
+                        ("(no memories)".to_string(), 0)
+                    } else {
+                        let pairs: Vec<(String, String)> = hits
+                            .iter()
+                            .map(|h| (h.key.clone(), h.value.clone()))
+                            .collect();
+                        let n = pairs.len();
+                        (format_pairs(&pairs), n)
+                    }
+                }
+                Err(e) => {
+                    // Best-effort: log and return empty rather than
+                    // surfacing as a tool error. The LLM can retry next turn.
+                    tracing::debug!(
+                        target: "assistd::embed",
+                        error = %e,
+                        "recall embed failed; returning empty"
+                    );
+                    ("(no memories)".to_string(), 0)
+                }
             }
         };
 
         let duration_ms = start.elapsed().as_millis();
         tracing::info!(
             target: "assistd::memory",
-            mode = %mode,
             returned = returned,
-            truncated = truncated,
             duration_ms = duration_ms,
-            "recall returned pairs"
+            "recall returned"
         );
         Ok(json!({
             "output":      output,
             "exit_code":   0,
             "duration_ms": duration_ms,
-            "truncated":   truncated,
+            "truncated":   false,
         }))
     }
 }
@@ -353,18 +304,18 @@ fn format_pairs(pairs: &[(String, String)]) -> String {
 }
 
 /// LLM-callable tool that searches *past conversation history* for
-/// messages similar in meaning to the query. Different data source from
-/// `recall`, which works over saved key/value facts. Use this when the
-/// user references something they "discussed before" or "worked on
-/// last month" — paraphrase-tolerant semantic search over the chunked
-/// conversation log.
-pub struct SearchMemoryTool {
+/// messages similar in meaning to the query. Complement to `recall`:
+/// `recall` looks up saved key/value facts, `reminisce` looks up past
+/// dialogue. Use this when the user references something they
+/// "discussed before" or "worked on last month" — paraphrase-tolerant
+/// semantic search over the chunked conversation log.
+pub struct ReminisceTool {
     embedder: Arc<dyn Embedder>,
     semantic: Arc<dyn SemanticStore>,
     embedding_model: String,
 }
 
-impl SearchMemoryTool {
+impl ReminisceTool {
     pub fn new(
         embedder: Arc<dyn Embedder>,
         semantic: Arc<dyn SemanticStore>,
@@ -379,17 +330,17 @@ impl SearchMemoryTool {
 }
 
 #[async_trait]
-impl Tool for SearchMemoryTool {
+impl Tool for ReminisceTool {
     fn name(&self) -> &str {
-        "search_memory"
+        "reminisce"
     }
 
     fn description(&self) -> &str {
         "Search past conversation history (across sessions) for messages \
-         similar in meaning to a query. Differs from `recall`: `recall` \
-         looks up *saved facts* (key/value), while `search_memory` searches \
-         *past dialogue text* — use it when the user references something \
-         they 'discussed before' or 'worked on last month'. Robust to \
+         similar in meaning to a query. Complement to `recall`: `recall` \
+         looks up *saved facts* (key/value), `reminisce` searches *past \
+         dialogue text* — use it when the user references something they \
+         'discussed before' or 'worked on last month'. Robust to \
          paraphrase: a query like \"that rust project we discussed\" will \
          match a past message about \"the assistd embedding daemon in Rust\". \
          Returns up to `limit` ranked snippets with timestamps and roles."
@@ -449,7 +400,7 @@ impl Tool for SearchMemoryTool {
                 tracing::debug!(
                     target: "assistd::embed",
                     error = %e,
-                    "search_memory embed failed; returning empty"
+                    "reminisce embed failed; returning empty"
                 );
                 return Ok(json!({
                     "output":      "(embedding unavailable)",
@@ -490,7 +441,7 @@ impl Tool for SearchMemoryTool {
             target: "assistd::embed",
             returned = hits.len(),
             duration_ms = duration_ms,
-            "search_memory returned chunks"
+            "reminisce returned chunks"
         );
         Ok(json!({
             "output":      output,
@@ -639,138 +590,42 @@ mod tests {
     // --- Recall ----------------------------------------------------------
 
     #[tokio::test]
-    async fn recall_returns_pairs_sorted() {
-        let (ops, _w) = fresh_ops().await;
-        ops.save("user.name", "Ben".into()).await.unwrap();
-        ops.save("editor_preference", "vim".into()).await.unwrap();
-        ops.save("user.timezone", "PST".into()).await.unwrap();
-        let tool = RecallTool::new(ops, no_embedder(), no_semantic(), String::new());
+    async fn recall_with_disabled_embedder_returns_no_memories() {
+        // NoEmbedder + empty model name → invoke short-circuits to the
+        // no-memories sentinel. Matches the behavior the LLM sees when
+        // embedding is turned off in config.
+        let tool = RecallTool::new(no_embedder(), no_semantic(), String::new());
         let result = tool
-            .invoke(json!({"query": "", "mode": "prefix"}))
+            .invoke(json!({"query": "what editor do I prefer"}))
             .await
             .unwrap();
+        assert_eq!(result["output"], "(no memories)");
         assert_eq!(result["exit_code"], 0);
         assert_eq!(result["truncated"], false);
-        let output = result["output"].as_str().unwrap();
-        let lines: Vec<&str> = output.lines().collect();
-        assert_eq!(
-            lines,
-            vec![
-                "editor_preference: vim",
-                "user.name: Ben",
-                "user.timezone: PST",
-            ]
-        );
     }
 
     #[tokio::test]
-    async fn recall_filters_by_prefix() {
-        let (ops, _w) = fresh_ops().await;
-        ops.save("user.name", "Ben".into()).await.unwrap();
-        ops.save("user.timezone", "PST".into()).await.unwrap();
-        ops.save("editor_preference", "vim".into()).await.unwrap();
-        let tool = RecallTool::new(ops, no_embedder(), no_semantic(), String::new());
-        let result = tool
-            .invoke(json!({"query": "user.", "mode": "prefix"}))
-            .await
-            .unwrap();
-        let output = result["output"].as_str().unwrap();
-        assert!(output.contains("user.name: Ben"), "{output}");
-        assert!(output.contains("user.timezone: PST"), "{output}");
-        assert!(
-            !output.contains("editor_preference"),
-            "prefix filter should exclude editor_preference: {output}"
-        );
-    }
-
-    #[tokio::test]
-    async fn recall_empty_returns_no_memories_marker() {
-        let (ops, _w) = fresh_ops().await;
-        let tool = RecallTool::new(ops, no_embedder(), no_semantic(), String::new());
-        let result = tool
-            .invoke(json!({"query": "", "mode": "prefix"}))
-            .await
-            .unwrap();
-        assert_eq!(result["output"], "(no memories)");
-        assert_eq!(result["truncated"], false);
-    }
-
-    #[tokio::test]
-    async fn recall_caps_at_limit() {
-        // Save more than RECALL_LIMIT entries; recall returns exactly
-        // RECALL_LIMIT and reports truncated.
-        let (ops, _w) = fresh_ops().await;
-        for i in 0..(RECALL_LIMIT + 5) {
-            // Zero-pad the index so lexicographic sort matches numeric
-            // — otherwise key.10 sorts before key.2, and the bookkeeping
-            // about which 50 we kept becomes confusing.
-            ops.save(&format!("k.{i:03}"), format!("v{i}"))
-                .await
-                .unwrap();
-        }
-        let tool = RecallTool::new(ops, no_embedder(), no_semantic(), String::new());
-        let result = tool
-            .invoke(json!({"query": "k.", "mode": "prefix"}))
-            .await
-            .unwrap();
-        assert_eq!(result["truncated"], true);
-        let output = result["output"].as_str().unwrap();
-        assert_eq!(output.lines().count(), RECALL_LIMIT);
-    }
-
-    #[tokio::test]
-    async fn recall_with_no_memory_store_no_ops() {
-        // TUI graceful path: NoMemoryStore returns empty for `list`, so
-        // recall reports the no-memories marker rather than erroring.
-        let tool = RecallTool::new(no_ops(), no_embedder(), no_semantic(), String::new());
-        let result = tool
-            .invoke(json!({"query": "", "mode": "prefix"}))
-            .await
-            .unwrap();
+    async fn recall_with_no_semantic_hits_returns_marker() {
+        // Embedder is wired (model name non-empty) but the semantic
+        // store has no memories indexed → still the no-memories sentinel.
+        // NoSemanticStore returns empty for nearest_memories regardless
+        // of the model name, so we just need a non-empty model string to
+        // get past the disabled short-circuit.
+        let tool = RecallTool::new(no_embedder(), no_semantic(), "some-model".into());
+        let result = tool.invoke(json!({"query": "anything"})).await.unwrap();
         assert_eq!(result["output"], "(no memories)");
     }
 
     #[tokio::test]
-    async fn recall_rejects_missing_args() {
-        // strict-mode schema requires `query` and `mode` — a missing
-        // arg is a protocol error from the model and surfaces as Err.
-        let tool = RecallTool::new(no_ops(), no_embedder(), no_semantic(), String::new());
+    async fn recall_rejects_missing_query() {
+        // strict-mode schema requires `query` — a missing arg is a
+        // protocol error from the model and surfaces as Err.
+        let tool = RecallTool::new(no_embedder(), no_semantic(), String::new());
         let err = tool.invoke(json!({})).await.unwrap_err();
         assert!(
             err.to_string().contains("query"),
             "expected error to mention `query`: {err}"
         );
-        let err = tool.invoke(json!({"query": "anything"})).await.unwrap_err();
-        assert!(
-            err.to_string().contains("mode"),
-            "expected error to mention `mode`: {err}"
-        );
-    }
-
-    #[tokio::test]
-    async fn recall_rejects_invalid_mode() {
-        let tool = RecallTool::new(no_ops(), no_embedder(), no_semantic(), String::new());
-        let err = tool
-            .invoke(json!({"query": "x", "mode": "bogus"}))
-            .await
-            .unwrap_err();
-        assert!(
-            err.to_string().contains("prefix") || err.to_string().contains("semantic"),
-            "expected error to list valid modes: {err}"
-        );
-    }
-
-    #[tokio::test]
-    async fn recall_semantic_with_disabled_embedder_returns_no_memories() {
-        // NoEmbedder + empty model name → recall_semantic short-circuits
-        // to the no-memories sentinel (matches the behavior the LLM
-        // sees when embedding is turned off in config).
-        let tool = RecallTool::new(no_ops(), no_embedder(), no_semantic(), String::new());
-        let result = tool
-            .invoke(json!({"query": "what editor do I prefer", "mode": "semantic"}))
-            .await
-            .unwrap();
-        assert_eq!(result["output"], "(no memories)");
     }
 
     // --- Schema sanity ---------------------------------------------------
@@ -782,13 +637,8 @@ mod tests {
         // contract that every property is required.
         let mut reg = ToolRegistry::new();
         reg.register(RememberTool::new(no_ops(), closed_embed_tx()));
-        reg.register(RecallTool::new(
-            no_ops(),
-            no_embedder(),
-            no_semantic(),
-            String::new(),
-        ));
-        reg.register(SearchMemoryTool::new(
+        reg.register(RecallTool::new(no_embedder(), no_semantic(), String::new()));
+        reg.register(ReminisceTool::new(
             no_embedder(),
             no_semantic(),
             String::new(),
@@ -809,13 +659,12 @@ mod tests {
         assert_eq!(recall["strict"], true);
         let req = recall["parameters"]["required"].as_array().unwrap();
         let names: Vec<&str> = req.iter().filter_map(|v| v.as_str()).collect();
-        assert!(names.contains(&"query"));
-        assert!(names.contains(&"mode"));
+        assert_eq!(names, vec!["query"]);
 
-        let search = &schemas[2]["function"];
-        assert_eq!(search["name"], "search_memory");
-        assert_eq!(search["strict"], true);
-        let req = search["parameters"]["required"].as_array().unwrap();
+        let reminisce = &schemas[2]["function"];
+        assert_eq!(reminisce["name"], "reminisce");
+        assert_eq!(reminisce["strict"], true);
+        let req = reminisce["parameters"]["required"].as_array().unwrap();
         let names: Vec<&str> = req.iter().filter_map(|v| v.as_str()).collect();
         assert!(names.contains(&"query"));
         assert!(names.contains(&"limit"));
@@ -848,26 +697,27 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn remember_then_recall_round_trip() {
-        // Belt-and-suspenders: drive both tools end-to-end against the
-        // same MemoryOps and verify the saved pair shows up in recall.
+    async fn remember_then_recall_round_trip_no_embedder() {
+        // Belt-and-suspenders: drive both tools end-to-end. With the
+        // embedding subsystem disabled, recall reports the no-memories
+        // sentinel even though the save did land in SQLite — proves the
+        // wire-up is sane in the disabled-embedder configuration.
+        // Semantic-on round-trip lives in the embedder integration test.
         let (ops, _w) = fresh_ops().await;
         let remember = RememberTool::new(ops.clone(), closed_embed_tx());
-        let recall = RecallTool::new(ops, no_embedder(), no_semantic(), String::new());
+        let recall = RecallTool::new(no_embedder(), no_semantic(), String::new());
         remember
             .invoke(json!({"key": "editor_preference", "value": "vim"}))
             .await
             .unwrap();
-        let result = recall
-            .invoke(json!({"query": "", "mode": "prefix"}))
-            .await
-            .unwrap();
-        assert!(
-            result["output"]
-                .as_str()
-                .unwrap()
-                .contains("editor_preference: vim"),
-            "recall should surface the saved pair: {result:#}"
+        // The save must hit the underlying store regardless of the
+        // embedder state — verify directly rather than through recall,
+        // which would short-circuit on the empty model name.
+        assert_eq!(
+            ops.load("editor_preference").await.unwrap().as_deref(),
+            Some("vim")
         );
+        let result = recall.invoke(json!({"query": "vim"})).await.unwrap();
+        assert_eq!(result["output"], "(no memories)");
     }
 }

--- a/crates/assistd-tools/src/memory_tools.rs
+++ b/crates/assistd-tools/src/memory_tools.rs
@@ -18,7 +18,7 @@
 //! `^[a-z0-9._]+$` validator below rejects whitespace/uppercase so two
 //! turns about the same concept don't drift onto different keys.
 
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 use std::time::Instant;
 
 use anyhow::{Result, anyhow};
@@ -37,10 +37,10 @@ use crate::memory::MemoryOps;
 /// context small. 50 is plenty for a single user's preferences.
 const RECALL_LIMIT: usize = 50;
 
-/// Validation regex for memory keys. `lazy_static`-free: built once per
-/// invoke, which is fine here (one tool call per turn) — and avoids a
-/// new `OnceLock` for a single-line regex.
+/// Validation regex for memory keys.
 const KEY_PATTERN: &str = r"^[a-z0-9._]+$";
+static KEY_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(KEY_PATTERN).expect("KEY_PATTERN compiles"));
 
 /// LLM-callable tool that saves a `(key, value)` pair into persistent
 /// memory. Holds a clone of [`MemoryOps`] so it can write through the
@@ -118,8 +118,7 @@ impl Tool for RememberTool {
             .to_string();
         tracing::Span::current().record("key", key.as_str());
 
-        let re = Regex::new(KEY_PATTERN).expect("KEY_PATTERN compiles");
-        if !re.is_match(&key) {
+        if !KEY_RE.is_match(&key) {
             return Err(anyhow!(
                 "`key` must match {KEY_PATTERN} (snake_case + dot \
                  namespacing, e.g. editor_preference or user.name)"

--- a/crates/assistd/src/chat/mod.rs
+++ b/crates/assistd/src/chat/mod.rs
@@ -143,7 +143,7 @@ pub async fn run(args: ChatArgs) -> Result<()> {
         Arc::new(NoConversationStore),
     ));
     // The TUI also doesn't run the embed subsystem — pass No-Op
-    // fallbacks so `recall`/`search_memory` register but no-op.
+    // fallbacks so `recall`/`reminisce` register but no-op.
     let no_embedder: Arc<dyn assistd_embed::Embedder> = Arc::new(assistd_embed::NoEmbedder);
     let no_semantic: Arc<dyn assistd_memory::SemanticStore> =
         Arc::new(assistd_memory::NoSemanticStore);

--- a/crates/assistd/src/daemon.rs
+++ b/crates/assistd/src/daemon.rs
@@ -406,6 +406,26 @@ pub async fn run(args: DaemonArgs) -> Result<()> {
                             embedder_arc.dim(),
                             config.embedding.port,
                         );
+                        // Surface stranded embeddings (rows under a
+                        // different model than the current config) at
+                        // startup so a model swap is visible instead of
+                        // silently producing `(no memories)` from
+                        // `recall` / `reminisce`. Failures are best-effort
+                        // — a warning here must not gate daemon startup.
+                        match semantic.count_stale(&model_name).await {
+                            Ok((n, models)) if n > 0 => {
+                                tracing::warn!(
+                                    "embedding: {n} rows exist under non-current model(s) {models:?}; \
+                                     run `assistd memory reindex` to rebuild against {model_name}"
+                                );
+                            }
+                            Ok(_) => {}
+                            Err(e) => {
+                                tracing::debug!(
+                                    "embedding: count_stale check failed ({e:#}); skipping diagnostic"
+                                );
+                            }
+                        }
                         (
                             embedder_arc,
                             semantic,

--- a/crates/assistd/src/memory_cli.rs
+++ b/crates/assistd/src/memory_cli.rs
@@ -9,7 +9,7 @@
 
 use anyhow::{Context, Result};
 use assistd_ipc::{Event, Request, socket_path};
-use clap::{Args, Subcommand, ValueEnum};
+use clap::{Args, Subcommand};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::UnixStream;
 use uuid::Uuid;
@@ -22,23 +22,18 @@ pub struct MemoryArgs {
 
 #[derive(Subcommand)]
 pub enum MemoryAction {
-    /// Search persisted conversation content. Two modes:
-    /// - `semantic` (default): cosine-similarity search over embedded
-    ///   chunks. Robust to paraphrase. Requires the embedding
-    ///   subsystem.
-    /// - `fts`: SQLite FTS5 full-text search. Supports phrase queries
-    ///   (`"foo bar"`), boolean ops (`foo AND bar`), and prefix matches
-    ///   (`foo*`).
-    Search {
-        /// Query string. Interpretation depends on `--mode`.
+    /// Semantic search over persisted conversation content. Embeds the
+    /// query and ranks past messages by cosine similarity, so
+    /// paraphrased phrasings still hit. Requires the embedding
+    /// subsystem; with embeddings disabled the daemon emits zero hits
+    /// and a clean Done.
+    Reminisce {
+        /// Natural-language query. The daemon embeds this and finds
+        /// the top-`limit` most semantically similar past messages.
         query: String,
         /// Cap on number of hits returned.
         #[arg(long, default_value = "5")]
         limit: u32,
-        /// Search mode. Defaults to `semantic` (the most-relevant
-        /// ranking; pass `--mode fts` for keyword/exact-phrase work).
-        #[arg(long, value_enum, default_value_t = SearchMode::Semantic)]
-        mode: SearchMode,
     },
     /// Persist a value under `key`. Overwrites any prior value.
     Save { key: String, value: String },
@@ -58,27 +53,12 @@ pub enum MemoryAction {
     Delete { key: String },
 }
 
-#[derive(Copy, Clone, Debug, ValueEnum)]
-pub enum SearchMode {
-    /// SQLite FTS5 keyword search. Fast, exact, deterministic.
-    Fts,
-    /// Cosine-similarity over embeddings. Paraphrase-tolerant.
-    Semantic,
-}
-
 impl MemoryAction {
     fn into_request(self, id: String) -> Request {
         match self {
-            MemoryAction::Search {
-                query,
-                limit,
-                mode: SearchMode::Fts,
-            } => Request::MemorySearch { id, query, limit },
-            MemoryAction::Search {
-                query,
-                limit,
-                mode: SearchMode::Semantic,
-            } => Request::MemorySemanticSearch { id, query, limit },
+            MemoryAction::Reminisce { query, limit } => {
+                Request::MemorySemanticSearch { id, query, limit }
+            }
             MemoryAction::Save { key, value } => Request::MemorySave { id, key, value },
             MemoryAction::Load { key } => Request::MemoryLoad { id, key },
             MemoryAction::List { prefix } => Request::MemoryListAll {
@@ -128,23 +108,6 @@ pub async fn run(args: MemoryArgs) -> Result<()> {
             .with_context(|| format!("invalid JSON from daemon: {}", line.trim()))?;
 
         match event {
-            Event::MemoryHit {
-                conversation_id,
-                session_id,
-                timestamp,
-                role,
-                snippet,
-                ..
-            } => {
-                // One line per hit: timestamp, role, conversation row
-                // id, snippet (with FTS5 `<mark>` highlights). Short
-                // session-id prefix gives users a stable handle for
-                // follow-up queries without wasting columns.
-                let session_short = session_id.chars().take(8).collect::<String>();
-                println!(
-                    "{timestamp}  {role:9}  conv={conversation_id:<6}  sess={session_short}  {snippet}"
-                );
-            }
             Event::SemanticHit {
                 conversation_id,
                 session_id,
@@ -154,10 +117,12 @@ pub async fn run(args: MemoryArgs) -> Result<()> {
                 similarity,
                 ..
             } => {
-                // Same column layout as MemoryHit but with similarity
-                // score instead of `<mark>` highlighting. `content` is
-                // the full message text (single line — collapse newlines
-                // so columns stay aligned).
+                // One line per hit: timestamp, role, conversation row
+                // id, similarity score, full message content. Short
+                // session-id prefix gives users a stable handle for
+                // follow-up queries without wasting columns. `content`
+                // is the full message text (single line — collapse
+                // newlines so columns stay aligned).
                 let session_short = session_id.chars().take(8).collect::<String>();
                 let single_line = content.replace('\n', " ");
                 println!(

--- a/crates/assistd/src/memory_cli.rs
+++ b/crates/assistd/src/memory_cli.rs
@@ -51,6 +51,17 @@ pub enum MemoryAction {
     Forget { id: i64 },
     /// Remove `key` from the store. No-op if absent.
     Delete { key: String },
+    /// Re-embed every memory and conversation chunk that has no
+    /// embedding under the daemon's currently-configured model.
+    /// Recovers from a model swap or from runs where the embedding
+    /// subsystem was unavailable. Prints one progress line per kind
+    /// (chunks, memories) updated as each item completes.
+    Reindex {
+        /// Suppress the per-item progress lines; print only the final
+        /// summary. Useful in scripts.
+        #[arg(long)]
+        quiet: bool,
+    },
 }
 
 impl MemoryAction {
@@ -68,6 +79,7 @@ impl MemoryAction {
             },
             MemoryAction::Forget { id: memory_id } => Request::MemoryForget { id, memory_id },
             MemoryAction::Delete { key } => Request::MemoryDelete { id, key },
+            MemoryAction::Reindex { .. } => Request::MemoryReindex { id },
         }
     }
 }
@@ -89,6 +101,9 @@ pub async fn run(args: MemoryArgs) -> Result<()> {
         MemoryAction::Forget { id } => Some(*id),
         _ => None,
     };
+    // Same idea for the reindex progress printer: capture `--quiet`
+    // before `into_request` moves the action.
+    let reindex_quiet = matches!(&args.action, MemoryAction::Reindex { quiet: true });
 
     let (read_half, mut write_half) = stream.into_split();
     let req = args.action.into_request(Uuid::new_v4().to_string());
@@ -98,6 +113,10 @@ pub async fn run(args: MemoryArgs) -> Result<()> {
     write_half.shutdown().await?;
 
     let mut reader = BufReader::new(read_half);
+    // Track the last reindex kind so a kind change emits a newline
+    // before the new kind's progress line — keeps the chunks → memories
+    // transition from clobbering the chunks total under `\r` rewrites.
+    let mut last_reindex_kind: Option<String> = None;
     loop {
         let mut line = String::new();
         let n = reader.read_line(&mut line).await?;
@@ -167,6 +186,24 @@ pub async fn run(args: MemoryArgs) -> Result<()> {
                 eprintln!("no memory with id={id}");
                 std::process::exit(2);
             }
+            Event::ReindexProgress {
+                kind, done, total, ..
+            } => {
+                if !reindex_quiet {
+                    use std::io::Write;
+                    let mut err = std::io::stderr();
+                    let kind_changed = last_reindex_kind.as_deref() != Some(kind.as_str());
+                    if kind_changed && last_reindex_kind.is_some() {
+                        let _ = writeln!(err);
+                    }
+                    last_reindex_kind = Some(kind.clone());
+                    // `\r` rewrites the same line for successive ticks
+                    // within one kind; the newline above moves to a
+                    // fresh line on transitions.
+                    let _ = write!(err, "\rreindex {kind}: {done}/{total}");
+                    let _ = err.flush();
+                }
+            }
             // `MemoryForgetResult { deleted: true, key: None }` is not
             // produced by the daemon (a delete-by-id always has a key
             // when it hits a row), but the type allows it; treat it as
@@ -179,7 +216,12 @@ pub async fn run(args: MemoryArgs) -> Result<()> {
                 let id = forget_target.unwrap_or(0);
                 println!("forgot id={id}");
             }
-            Event::Done { .. } => return Ok(()),
+            Event::Done { .. } => {
+                if last_reindex_kind.is_some() && !reindex_quiet {
+                    eprintln!();
+                }
+                return Ok(());
+            }
             Event::Error { message, .. } => {
                 eprintln!("daemon error: {message}");
                 std::process::exit(1);

--- a/crates/assistd/src/memory_cli.rs
+++ b/crates/assistd/src/memory_cli.rs
@@ -188,21 +188,19 @@ pub async fn run(args: MemoryArgs) -> Result<()> {
             }
             Event::ReindexProgress {
                 kind, done, total, ..
-            } => {
-                if !reindex_quiet {
-                    use std::io::Write;
-                    let mut err = std::io::stderr();
-                    let kind_changed = last_reindex_kind.as_deref() != Some(kind.as_str());
-                    if kind_changed && last_reindex_kind.is_some() {
-                        let _ = writeln!(err);
-                    }
-                    last_reindex_kind = Some(kind.clone());
-                    // `\r` rewrites the same line for successive ticks
-                    // within one kind; the newline above moves to a
-                    // fresh line on transitions.
-                    let _ = write!(err, "\rreindex {kind}: {done}/{total}");
-                    let _ = err.flush();
+            } if !reindex_quiet => {
+                use std::io::Write;
+                let mut err = std::io::stderr();
+                let kind_changed = last_reindex_kind.as_deref() != Some(kind.as_str());
+                if kind_changed && last_reindex_kind.is_some() {
+                    let _ = writeln!(err);
                 }
+                last_reindex_kind = Some(kind.clone());
+                // `\r` rewrites the same line for successive ticks
+                // within one kind; the newline above moves to a
+                // fresh line on transitions.
+                let _ = write!(err, "\rreindex {kind}: {done}/{total}");
+                let _ = err.flush();
             }
             // `MemoryForgetResult { deleted: true, key: None }` is not
             // produced by the daemon (a delete-by-id always has a key

--- a/crates/assistd/src/ptt.rs
+++ b/crates/assistd/src/ptt.rs
@@ -98,8 +98,7 @@ pub async fn run(action: PttAction) -> Result<()> {
             Event::Presence { .. } => {}
             Event::ListenState { .. } => {}
             Event::VoiceOutputState { .. } => {}
-            Event::MemoryHit { .. }
-            | Event::SemanticHit { .. }
+            Event::SemanticHit { .. }
             | Event::MemoryValue { .. }
             | Event::MemoryKeys { .. }
             | Event::MemoryRow { .. }

--- a/crates/assistd/src/ptt.rs
+++ b/crates/assistd/src/ptt.rs
@@ -102,7 +102,8 @@ pub async fn run(action: PttAction) -> Result<()> {
             | Event::MemoryValue { .. }
             | Event::MemoryKeys { .. }
             | Event::MemoryRow { .. }
-            | Event::MemoryForgetResult { .. } => {}
+            | Event::MemoryForgetResult { .. }
+            | Event::ReindexProgress { .. } => {}
             Event::Done { .. } => {
                 if wrote_delta {
                     writeln!(stdout)?;

--- a/crates/assistd/src/query.rs
+++ b/crates/assistd/src/query.rs
@@ -146,7 +146,8 @@ pub async fn run(args: QueryArgs) -> Result<()> {
             | Event::MemoryValue { .. }
             | Event::MemoryKeys { .. }
             | Event::MemoryRow { .. }
-            | Event::MemoryForgetResult { .. } => {}
+            | Event::MemoryForgetResult { .. }
+            | Event::ReindexProgress { .. } => {}
             Event::Done { .. } => {
                 if wrote_anything {
                     writeln!(stdout)?;

--- a/crates/assistd/src/query.rs
+++ b/crates/assistd/src/query.rs
@@ -142,8 +142,7 @@ pub async fn run(args: QueryArgs) -> Result<()> {
             // Memory* events shouldn't appear on a Query stream — the
             // daemon only emits them on `Request::Memory*`. Tolerate
             // them silently in case a future feature reuses the wire.
-            Event::MemoryHit { .. }
-            | Event::SemanticHit { .. }
+            Event::SemanticHit { .. }
             | Event::MemoryValue { .. }
             | Event::MemoryKeys { .. }
             | Event::MemoryRow { .. }


### PR DESCRIPTION
Refining the existing memory system, along with various improvements.
- Renamed search_memory to Reminisce, to follow naming format for other memory tools (and to avoid referring to conversation search as "memory")
- transaction wrapping 
- FTS5 escape
- LazyLock regex 
- stale-embedding warning, 
- memory reindexing command (in the event of ever changing the embedding model)