### PR TITLE
Add wm commands to the command router

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,6 +297,7 @@ dependencies = [
  "assistd-embed",
  "assistd-ipc",
  "assistd-memory",
+ "assistd-wm",
  "async-trait",
  "base64",
  "infer",

--- a/crates/assistd-core/src/lib.rs
+++ b/crates/assistd-core/src/lib.rs
@@ -92,7 +92,7 @@ use assistd_tools::{
     commands::{
         BashCommand, BashPolicyCfg, CatCommand, EchoCommand, GrepCommand, LsCommand,
         ScreenshotBackendKind, ScreenshotCommand, ScreenshotPolicyCfg, SeeCommand, WcCommand,
-        WebCommand, WriteCommand, WritePolicyCfg,
+        WebCommand, WmCommand, WriteCommand, WritePolicyCfg,
     },
     probe_sandbox,
 };
@@ -102,18 +102,18 @@ use std::time::Duration;
 use tokio::sync::mpsc;
 use tracing::warn;
 
-/// Build the shared tool registry used by both the daemon and the chat
-/// TUI. Clears and recreates `overflow_dir` so per-process spill files
-/// land in a known-empty location at every startup.
+/// Build the tool registry consumed by the daemon. Clears and recreates
+/// `overflow_dir` so per-process spill files land in a known-empty
+/// location at every startup.
 ///
-/// `overflow_dir` is taken as an owned parameter so callers (daemon vs
-/// TUI) can use different paths — sharing one directory would race
-/// when both processes try to reset it.
+/// `overflow_dir` is taken as an owned parameter so the caller chooses
+/// the path — kept for future call sites that need a different spill
+/// directory.
 ///
-/// `gate` is consulted by destructive bash commands. The daemon passes a
-/// `DenyAllGate` (headless path: no interactive confirmation available);
-/// the chat TUI passes a `TuiGate` that forwards prompts to the user via
-/// a modal overlay.
+/// `gate` is consulted by destructive bash commands. The daemon passes
+/// an `IpcConfirmationGate` that forwards prompts to the active IPC
+/// client (the TUI is one such client) and falls through to deny when
+/// no router is in scope.
 ///
 /// `vision_gate` is a shared, runtime-mutable flag (see
 /// [`assistd_tools::VisionGate`]) initialised from a `/props` probe of
@@ -128,13 +128,17 @@ use tracing::warn;
 ///
 /// `memory_ops` is the combined CRUD façade backing the LLM-callable
 /// `remember` and `recall` tools. The daemon passes a SQLite-backed
-/// handle; the chat TUI (no persistence today) passes one built over
-/// [`assistd_memory::NoMemoryStore`] so the same tools register but
-/// silently no-op there.
-// Subsystem injection point — every call site (daemon, TUI) wires the
-// same set of cross-cutting handles into the registered tools. The
-// alternative shape (a builder struct) saves nothing here because the
-// two real call sites both pass *all* params.
+/// handle.
+///
+/// `window_manager` backs the LLM-callable `wm` command. The daemon
+/// passes either a connected `I3Backend` (when `[compositor].type =
+/// "i3"` and the i3 socket is reachable) or [`NoWindowManager`] when
+/// the configured backend is unavailable; the latter makes every `wm`
+/// subcommand short-circuit with a uniform "compositor not connected"
+/// error rather than failing per-subcommand.
+// Subsystem injection point — the daemon wires the cross-cutting
+// handles into the registered tools. The alternative shape (a builder
+// struct) saves nothing here because there's only one real call site.
 #[allow(clippy::too_many_arguments)]
 pub fn build_tools(
     config: &Config,
@@ -146,6 +150,7 @@ pub fn build_tools(
     semantic: Arc<dyn SemanticStore>,
     embed_tx: mpsc::Sender<EmbedJob>,
     embedding_model: String,
+    window_manager: Arc<dyn WindowManager>,
 ) -> Result<Arc<ToolRegistry>> {
     if overflow_dir.exists() {
         std::fs::remove_dir_all(&overflow_dir).with_context(|| {
@@ -234,6 +239,7 @@ pub fn build_tools(
     commands.register(ScreenshotCommand::new(screenshot_cfg, vision_gate));
     commands.register(WebCommand::new());
     commands.register(BashCommand::new(bash_cfg, sandbox, gate));
+    commands.register(WmCommand::new(window_manager));
 
     let mut tools = ToolRegistry::new();
     tools.register(RunTool::new(

--- a/crates/assistd-tools/Cargo.toml
+++ b/crates/assistd-tools/Cargo.toml
@@ -11,6 +11,8 @@ assistd-memory = { workspace = true }
 # Wire-protocol types for the IpcConfirmationGate. Default features
 # only — no client/socket code, just the Event/Request enums.
 assistd-ipc = { workspace = true }
+# WindowManager trait + types, consumed by `commands::wm`.
+assistd-wm = { workspace = true }
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 serde = { workspace = true }

--- a/crates/assistd-tools/src/command.rs
+++ b/crates/assistd-tools/src/command.rs
@@ -271,8 +271,10 @@ mod tests {
     fn every_registered_command_emits_convention_compliant_error() {
         use crate::commands::{
             BashCommand, CatCommand, GrepCommand, LsCommand, ScreenshotCommand, SeeCommand,
-            WcCommand, WebCommand, WriteCommand,
+            WcCommand, WebCommand, WmCommand, WriteCommand,
         };
+        use assistd_wm::NoWindowManager;
+        use std::sync::Arc as StdArc;
 
         fn contains_hint(s: &str) -> bool {
             s.contains("Use:")
@@ -362,6 +364,17 @@ mod tests {
                     vec!["rm -rf /".into()],
                 )),
             ),
+            // wm against the disconnected NoWindowManager exercises the
+            // mock-mode short-circuit — every subcommand returns the
+            // same `[error] wm: compositor not connected. Check: …`
+            // line, so any subcommand argv works as the failure driver.
+            (
+                "wm",
+                rt.block_on(run_cmd(
+                    WmCommand::new(StdArc::new(NoWindowManager)),
+                    vec!["focus".into(), "Firefox".into()],
+                )),
+            ),
         ];
 
         for (name, out) in cases {
@@ -393,8 +406,10 @@ mod tests {
     fn every_registered_command_has_nonempty_help_and_summary() {
         use crate::commands::{
             BashCommand, CatCommand, EchoCommand, GrepCommand, LsCommand, ScreenshotCommand,
-            SeeCommand, WcCommand, WebCommand, WriteCommand,
+            SeeCommand, WcCommand, WebCommand, WmCommand, WriteCommand,
         };
+        use assistd_wm::NoWindowManager;
+        use std::sync::Arc as StdArc;
         let mut reg = CommandRegistry::new();
         reg.register(CatCommand);
         reg.register(LsCommand);
@@ -406,7 +421,8 @@ mod tests {
         reg.register(ScreenshotCommand::default());
         reg.register(WebCommand::new());
         reg.register(BashCommand::default());
-        assert_eq!(reg.len(), 10);
+        reg.register(WmCommand::new(StdArc::new(NoWindowManager)));
+        assert_eq!(reg.len(), 11);
         for (name, summary) in reg.sorted_summaries() {
             assert!(!summary.is_empty(), "{name} has empty summary");
             assert!(

--- a/crates/assistd-tools/src/commands/mod.rs
+++ b/crates/assistd-tools/src/commands/mod.rs
@@ -11,6 +11,7 @@ pub mod screenshot;
 pub mod see;
 pub mod wc;
 pub mod web;
+pub mod wm;
 pub mod write;
 
 pub use bash::{BashCommand, BashPolicyCfg};
@@ -22,4 +23,5 @@ pub use screenshot::{Backend as ScreenshotBackendKind, ScreenshotCommand, Screen
 pub use see::SeeCommand;
 pub use wc::WcCommand;
 pub use web::WebCommand;
+pub use wm::WmCommand;
 pub use write::{WriteCommand, WritePolicyCfg};

--- a/crates/assistd-tools/src/commands/wm.rs
+++ b/crates/assistd-tools/src/commands/wm.rs
@@ -1,0 +1,845 @@
+//! `wm <subcommand> [args]` — drive the active [`WindowManager`] backend
+//! from the LLM's `run` tool.
+//!
+//! Subcommand surface:
+//!
+//! - `wm focus <class>` — focus the named window
+//! - `wm move <class> <workspace>` — move window to workspace
+//! - `wm open <app> [args...]` — launch a process (does not go through
+//!   the WindowManager — i3/sway/hyprland don't spawn processes, they
+//!   only manage already-mapped windows)
+//! - `wm active` — class of the focused window
+//! - `wm resize <class> <grow|shrink> <px>` — width-only resize
+//! - `wm list` — TSV `<class>\t<workspace>\t<title>`
+//! - `wm workspaces` — TSV `<num>\t<name>\t<focused>\t<output>`
+//! - `wm layout <default|tabbed|stacking|splith|splitv>` — set the
+//!   focused container's layout
+//!
+//! Discovery: `wm` (no args) returns the help block on stdout (exit 2).
+//! Every subcommand with too few args returns its own usage block on
+//! stdout (exit 2). All real failures emit a convention-compliant
+//! `[error] wm: …. <Hint>: <recovery>` line on stderr.
+//!
+//! When the backend is [`assistd_wm::NoWindowManager`] (no compositor
+//! configured / connect failure / Sway+Hyprland not yet implemented),
+//! every subcommand short-circuits with `[error] wm: compositor not
+//! connected. …` so the LLM gets one uniform error to recover from.
+
+use std::process::Stdio;
+use std::sync::Arc;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use tokio::process::Command as ProcCommand;
+
+use assistd_wm::WindowManager;
+
+use crate::command::{Command, CommandInput, CommandOutput, error_line};
+
+const NAME: &str = "wm";
+const SUMMARY: &str = "manage windows and workspaces (focus, move, open, list, workspaces, etc.)";
+
+pub struct WmCommand {
+    wm: Arc<dyn WindowManager>,
+}
+
+impl WmCommand {
+    pub fn new(wm: Arc<dyn WindowManager>) -> Self {
+        Self { wm }
+    }
+}
+
+#[async_trait]
+impl Command for WmCommand {
+    fn name(&self) -> &str {
+        NAME
+    }
+
+    fn summary(&self) -> &'static str {
+        SUMMARY
+    }
+
+    fn help(&self) -> String {
+        "usage: wm <subcommand> [args...]\n\
+         \n\
+         Manage windows and workspaces via the active compositor backend \
+         (i3, sway, or hyprland). Window identifiers are X11 classes on \
+         i3 (e.g. \"Firefox\", \"code\") — see `wm list` for the exact \
+         strings to use.\n\
+         \n\
+         Subcommands:\n  \
+           focus <class>                          focus the named window\n  \
+           move <class> <workspace>               move window to workspace\n  \
+           open <app> [args...]                   launch an application\n  \
+           active                                 class of the focused window\n  \
+           resize <class> <grow|shrink> <px>      width-only resize\n  \
+           list                                   TSV: class, workspace, title\n  \
+           workspaces                             TSV: num, name, focused, output\n  \
+           layout <default|tabbed|stacking|splith|splitv>\n                                          \
+         set the focused container's layout\n\
+         \n\
+         Call any subcommand with no arguments to see its parameter \
+         help. When no compositor is connected, every subcommand emits \
+         `[error] wm: compositor not connected. …` instead.\n"
+            .to_string()
+    }
+
+    async fn run(&self, input: CommandInput) -> Result<CommandOutput> {
+        if input.args.is_empty() {
+            return Ok(help_output(self.help()));
+        }
+        if !self.wm.is_connected() {
+            return Ok(CommandOutput::failed(
+                1,
+                error_line(
+                    NAME,
+                    "compositor not connected",
+                    "Check",
+                    "[compositor] in config.toml and that i3/sway/hyprland is running",
+                )
+                .into_bytes(),
+            ));
+        }
+
+        let sub = input.args[0].as_str();
+        let rest = &input.args[1..];
+        match sub {
+            "focus" => handle_focus(self.wm.as_ref(), rest).await,
+            "move" => handle_move(self.wm.as_ref(), rest).await,
+            "open" => handle_open(rest).await,
+            "active" => handle_active(self.wm.as_ref()).await,
+            "resize" => handle_resize(self.wm.as_ref(), rest).await,
+            "list" => handle_list(self.wm.as_ref()).await,
+            "workspaces" => handle_workspaces(self.wm.as_ref()).await,
+            "layout" => handle_layout(self.wm.as_ref(), rest).await,
+            other => Ok(CommandOutput::failed(
+                2,
+                error_line(
+                    NAME,
+                    format_args!("unknown subcommand '{other}'"),
+                    "Available",
+                    "focus, move, open, active, resize, list, workspaces, layout",
+                )
+                .into_bytes(),
+            )),
+        }
+    }
+}
+
+/// Stdout-help with exit 2, matching the convention used by other
+/// commands that have argument-required modes (grep, write, …).
+fn help_output(text: String) -> CommandOutput {
+    CommandOutput {
+        stdout: text.into_bytes(),
+        stderr: Vec::new(),
+        exit_code: 2,
+        attachments: Vec::new(),
+    }
+}
+
+// --------- subcommand handlers ---------
+
+const FOCUS_HELP: &str = "usage: wm focus <class>\n\
+    \n\
+    Focus the window with the given class. Use `wm list` to see \
+    available windows.\n";
+
+async fn handle_focus(wm: &dyn WindowManager, args: &[String]) -> Result<CommandOutput> {
+    if args.is_empty() {
+        return Ok(help_output(FOCUS_HELP.to_string()));
+    }
+    let class = &args[0];
+    match wm.focus(class).await {
+        Ok(()) => Ok(CommandOutput::ok(Vec::new())),
+        Err(e) => Ok(CommandOutput::failed(
+            1,
+            error_line(
+                NAME,
+                format_args!("focus '{class}' failed: {e}"),
+                "Use",
+                "wm list to see available windows",
+            )
+            .into_bytes(),
+        )),
+    }
+}
+
+const MOVE_HELP: &str = "usage: wm move <class> <workspace>\n\
+    \n\
+    Move the window with the given class to the named workspace. \
+    Numeric workspace identifiers (e.g. `3`) match by number; \
+    non-numeric identifiers match by exact name.\n";
+
+async fn handle_move(wm: &dyn WindowManager, args: &[String]) -> Result<CommandOutput> {
+    if args.len() < 2 {
+        return Ok(help_output(MOVE_HELP.to_string()));
+    }
+    let class = &args[0];
+    let workspace = &args[1];
+    match wm.move_to_workspace(class, workspace).await {
+        Ok(()) => Ok(CommandOutput::ok(Vec::new())),
+        Err(e) => Ok(CommandOutput::failed(
+            1,
+            error_line(
+                NAME,
+                format_args!("move '{class}' to '{workspace}' failed: {e}"),
+                "Use",
+                "wm list and wm workspaces to verify both exist",
+            )
+            .into_bytes(),
+        )),
+    }
+}
+
+const OPEN_HELP: &str = "usage: wm open <app> [args...]\n\
+    \n\
+    Launch an application. <app> is resolved through PATH; remaining \
+    arguments are forwarded to the spawned process. The child is \
+    detached — stdin/stdout/stderr are nulled and the daemon does not \
+    wait for it to exit.\n";
+
+async fn handle_open(args: &[String]) -> Result<CommandOutput> {
+    if args.is_empty() {
+        return Ok(help_output(OPEN_HELP.to_string()));
+    }
+    let app = &args[0];
+    let extra = &args[1..];
+    let mut cmd = ProcCommand::new(app);
+    cmd.args(extra)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    match cmd.spawn() {
+        Ok(_child) => Ok(CommandOutput::ok(Vec::new())),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(CommandOutput::failed(
+            1,
+            error_line(
+                NAME,
+                format_args!("open: binary '{app}' not found on PATH"),
+                "Check",
+                format_args!("which {app}"),
+            )
+            .into_bytes(),
+        )),
+        Err(e) => Ok(CommandOutput::failed(
+            1,
+            error_line(
+                NAME,
+                format_args!("open '{app}' failed: {e}"),
+                "Try",
+                "a different binary or absolute path",
+            )
+            .into_bytes(),
+        )),
+    }
+}
+
+async fn handle_active(wm: &dyn WindowManager) -> Result<CommandOutput> {
+    match wm.focused_window().await {
+        Ok(Some(class)) => {
+            let mut out = class.into_bytes();
+            out.push(b'\n');
+            Ok(CommandOutput::ok(out))
+        }
+        Ok(None) => Ok(CommandOutput::ok(Vec::new())),
+        Err(e) => Ok(CommandOutput::failed(
+            1,
+            error_line(
+                NAME,
+                format_args!("active failed: {e}"),
+                "Check",
+                "compositor connection (see daemon logs)",
+            )
+            .into_bytes(),
+        )),
+    }
+}
+
+const RESIZE_HELP: &str = "usage: wm resize <class> <grow|shrink> <px>\n\
+    \n\
+    Resize the named window's width by the given pixel amount. \
+    Direction is one of `grow` or `shrink`; <px> is a non-negative \
+    integer count of pixels.\n";
+
+async fn handle_resize(wm: &dyn WindowManager, args: &[String]) -> Result<CommandOutput> {
+    if args.len() < 3 {
+        return Ok(help_output(RESIZE_HELP.to_string()));
+    }
+    let class = &args[0];
+    let direction = args[1].as_str();
+    if direction != "grow" && direction != "shrink" {
+        return Ok(CommandOutput::failed(
+            2,
+            error_line(
+                NAME,
+                format_args!("resize: direction must be 'grow' or 'shrink', got '{direction}'"),
+                "Use",
+                "wm resize <class> <grow|shrink> <px>",
+            )
+            .into_bytes(),
+        ));
+    }
+    let amount: u32 = match args[2].parse() {
+        Ok(n) => n,
+        Err(_) => {
+            return Ok(CommandOutput::failed(
+                2,
+                error_line(
+                    NAME,
+                    format_args!(
+                        "resize: pixel amount must be a non-negative integer, got '{}'",
+                        args[2]
+                    ),
+                    "Use",
+                    "wm resize <class> <grow|shrink> <px>",
+                )
+                .into_bytes(),
+            ));
+        }
+    };
+    let payload = format!(
+        r#"[class="{}"] resize {} width {} px or 0 ppt"#,
+        escape_for_criteria(class),
+        direction,
+        amount,
+    );
+    match wm.run_raw(&payload).await {
+        Ok(()) => Ok(CommandOutput::ok(Vec::new())),
+        Err(e) => Ok(CommandOutput::failed(
+            1,
+            error_line(
+                NAME,
+                format_args!("resize '{class}' failed: {e}"),
+                "Use",
+                "wm list to see available windows",
+            )
+            .into_bytes(),
+        )),
+    }
+}
+
+async fn handle_list(wm: &dyn WindowManager) -> Result<CommandOutput> {
+    match wm.list_windows().await {
+        Ok(mut windows) => {
+            windows.sort_by(|a, b| {
+                a.workspace
+                    .as_deref()
+                    .unwrap_or("")
+                    .cmp(b.workspace.as_deref().unwrap_or(""))
+                    .then_with(|| a.id.cmp(&b.id))
+            });
+            let mut out = String::new();
+            for w in windows {
+                out.push_str(&w.id);
+                out.push('\t');
+                out.push_str(w.workspace.as_deref().unwrap_or("-"));
+                out.push('\t');
+                out.push_str(w.title.as_deref().unwrap_or(""));
+                out.push('\n');
+            }
+            Ok(CommandOutput::ok(out.into_bytes()))
+        }
+        Err(e) => Ok(CommandOutput::failed(
+            1,
+            error_line(
+                NAME,
+                format_args!("list failed: {e}"),
+                "Check",
+                "compositor connection (see daemon logs)",
+            )
+            .into_bytes(),
+        )),
+    }
+}
+
+async fn handle_workspaces(wm: &dyn WindowManager) -> Result<CommandOutput> {
+    match wm.list_workspaces().await {
+        Ok(mut workspaces) => {
+            workspaces.sort_by_key(|w| w.num);
+            let mut out = String::new();
+            for w in workspaces {
+                out.push_str(&w.num.to_string());
+                out.push('\t');
+                out.push_str(&w.name);
+                out.push('\t');
+                out.push(if w.focused { '*' } else { '-' });
+                out.push('\t');
+                out.push_str(&w.output);
+                out.push('\n');
+            }
+            Ok(CommandOutput::ok(out.into_bytes()))
+        }
+        Err(e) => Ok(CommandOutput::failed(
+            1,
+            error_line(
+                NAME,
+                format_args!("workspaces failed: {e}"),
+                "Check",
+                "compositor connection (see daemon logs)",
+            )
+            .into_bytes(),
+        )),
+    }
+}
+
+const LAYOUT_HELP: &str = "usage: wm layout <default|tabbed|stacking|splith|splitv>\n\
+    \n\
+    Set the layout of the currently focused container. `default` \
+    toggles between split, tabbed, and stacking based on the \
+    container's previous layout.\n";
+
+async fn handle_layout(wm: &dyn WindowManager, args: &[String]) -> Result<CommandOutput> {
+    if args.is_empty() {
+        return Ok(help_output(LAYOUT_HELP.to_string()));
+    }
+    let name = args[0].as_str();
+    let valid = ["default", "tabbed", "stacking", "splith", "splitv"];
+    if !valid.contains(&name) {
+        return Ok(CommandOutput::failed(
+            2,
+            error_line(
+                NAME,
+                format_args!("layout: '{name}' is not a known layout"),
+                "Use",
+                "default | tabbed | stacking | splith | splitv",
+            )
+            .into_bytes(),
+        ));
+    }
+    let payload = format!("layout {name}");
+    match wm.run_raw(&payload).await {
+        Ok(()) => Ok(CommandOutput::ok(Vec::new())),
+        Err(e) => Ok(CommandOutput::failed(
+            1,
+            error_line(
+                NAME,
+                format_args!("layout '{name}' failed: {e}"),
+                "Check",
+                "compositor connection (see daemon logs)",
+            )
+            .into_bytes(),
+        )),
+    }
+}
+
+/// Escape `\` and `"` for inclusion inside an i3 criteria value
+/// (`[class="…"]`). Mirrors the helper in `assistd_wm::i3`; duplicated
+/// here because the trait surface uses [`WindowManager::run_raw`] for
+/// resize/layout and the caller is responsible for syntax. Backslashes
+/// are escaped first so we don't double-escape the slash inserted in
+/// front of quotes.
+fn escape_for_criteria(s: &str) -> String {
+    s.replace('\\', r"\\").replace('"', r#"\""#)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assistd_wm::{NoWindowManager, Window, WindowId, WorkspaceId, WorkspaceInfo};
+    use std::sync::Mutex;
+
+    /// Test fixture for [`WindowManager`]. Records every call so tests
+    /// can assert on the i3 payload that would be dispatched, and lets
+    /// each operation be wired to fail with a canned error message.
+    #[derive(Default)]
+    struct StubWm {
+        connected: bool,
+        windows: Vec<Window>,
+        workspaces: Vec<WorkspaceInfo>,
+        focused: Option<WindowId>,
+        focus_calls: Mutex<Vec<WindowId>>,
+        move_calls: Mutex<Vec<(WindowId, WorkspaceId)>>,
+        raw_calls: Mutex<Vec<String>>,
+        focus_err: Option<String>,
+        move_err: Option<String>,
+        raw_err: Option<String>,
+        list_windows_err: Option<String>,
+        list_workspaces_err: Option<String>,
+        focused_err: Option<String>,
+    }
+
+    impl StubWm {
+        fn connected() -> Self {
+            Self {
+                connected: true,
+                ..Self::default()
+            }
+        }
+    }
+
+    #[async_trait]
+    impl WindowManager for StubWm {
+        async fn focus(&self, window: &WindowId) -> Result<()> {
+            self.focus_calls.lock().unwrap().push(window.clone());
+            if let Some(msg) = &self.focus_err {
+                anyhow::bail!("{msg}");
+            }
+            Ok(())
+        }
+        async fn move_to_workspace(
+            &self,
+            window: &WindowId,
+            workspace: &WorkspaceId,
+        ) -> Result<()> {
+            self.move_calls
+                .lock()
+                .unwrap()
+                .push((window.clone(), workspace.clone()));
+            if let Some(msg) = &self.move_err {
+                anyhow::bail!("{msg}");
+            }
+            Ok(())
+        }
+        async fn focused_window(&self) -> Result<Option<WindowId>> {
+            if let Some(msg) = &self.focused_err {
+                anyhow::bail!("{msg}");
+            }
+            Ok(self.focused.clone())
+        }
+        async fn list_windows(&self) -> Result<Vec<Window>> {
+            if let Some(msg) = &self.list_windows_err {
+                anyhow::bail!("{msg}");
+            }
+            Ok(self.windows.clone())
+        }
+        async fn list_workspaces(&self) -> Result<Vec<WorkspaceInfo>> {
+            if let Some(msg) = &self.list_workspaces_err {
+                anyhow::bail!("{msg}");
+            }
+            Ok(self.workspaces.clone())
+        }
+        async fn run_raw(&self, payload: &str) -> Result<()> {
+            self.raw_calls.lock().unwrap().push(payload.to_string());
+            if let Some(msg) = &self.raw_err {
+                anyhow::bail!("{msg}");
+            }
+            Ok(())
+        }
+        fn is_connected(&self) -> bool {
+            self.connected
+        }
+    }
+
+    async fn run_wm(wm: Arc<dyn WindowManager>, args: &[&str]) -> CommandOutput {
+        WmCommand::new(wm)
+            .run(CommandInput {
+                args: args.iter().map(|s| s.to_string()).collect(),
+                stdin: Vec::new(),
+            })
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn no_args_returns_help() {
+        let out = run_wm(Arc::new(StubWm::connected()), &[]).await;
+        assert_eq!(out.exit_code, 2);
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        assert!(stdout.starts_with("usage: wm <subcommand>"), "{stdout}");
+        assert!(stdout.contains("focus"), "{stdout}");
+        assert!(stdout.contains("workspaces"), "{stdout}");
+    }
+
+    #[tokio::test]
+    async fn unknown_subcommand_errors_with_available_list() {
+        let out = run_wm(Arc::new(StubWm::connected()), &["bogus"]).await;
+        assert_eq!(out.exit_code, 2);
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            stderr.contains("[error] wm: unknown subcommand 'bogus'"),
+            "{stderr}"
+        );
+        assert!(stderr.contains("Available:"), "{stderr}");
+    }
+
+    #[tokio::test]
+    async fn disconnected_short_circuits() {
+        // StubWm::default() has connected = false.
+        let out = run_wm(Arc::new(StubWm::default()), &["focus", "Firefox"]).await;
+        assert_eq!(out.exit_code, 1);
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            stderr.contains("[error] wm: compositor not connected"),
+            "{stderr}"
+        );
+        assert!(stderr.contains("Check:"), "{stderr}");
+    }
+
+    #[tokio::test]
+    async fn no_window_manager_short_circuits_on_focus() {
+        // Ensures the production `NoWindowManager` produces the same
+        // behavior as the StubWm disconnected path — this is the gate
+        // for the "mock mode" acceptance criterion.
+        let out = run_wm(Arc::new(NoWindowManager), &["focus", "Firefox"]).await;
+        assert_eq!(out.exit_code, 1);
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            stderr.contains("[error] wm: compositor not connected"),
+            "{stderr}"
+        );
+    }
+
+    #[tokio::test]
+    async fn focus_no_args_returns_subcommand_help() {
+        let out = run_wm(Arc::new(StubWm::connected()), &["focus"]).await;
+        assert_eq!(out.exit_code, 2);
+        assert!(String::from_utf8_lossy(&out.stdout).contains("usage: wm focus"));
+    }
+
+    #[tokio::test]
+    async fn focus_calls_backend_with_class() {
+        let stub = Arc::new(StubWm::connected());
+        let out = run_wm(stub.clone(), &["focus", "Firefox"]).await;
+        assert_eq!(out.exit_code, 0);
+        let calls = stub.focus_calls.lock().unwrap();
+        assert_eq!(*calls, vec!["Firefox".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn focus_translates_backend_error() {
+        let stub = Arc::new(StubWm {
+            connected: true,
+            focus_err: Some("i3 socket dropped".into()),
+            ..Default::default()
+        });
+        let out = run_wm(stub, &["focus", "Firefox"]).await;
+        assert_eq!(out.exit_code, 1);
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            stderr.contains("[error] wm: focus 'Firefox' failed"),
+            "{stderr}"
+        );
+        assert!(stderr.contains("Use:"), "{stderr}");
+    }
+
+    #[tokio::test]
+    async fn move_needs_two_args() {
+        let out = run_wm(Arc::new(StubWm::connected()), &["move", "Firefox"]).await;
+        assert_eq!(out.exit_code, 2);
+        assert!(String::from_utf8_lossy(&out.stdout).contains("usage: wm move"));
+    }
+
+    #[tokio::test]
+    async fn move_calls_backend() {
+        let stub = Arc::new(StubWm::connected());
+        let out = run_wm(stub.clone(), &["move", "Firefox", "3"]).await;
+        assert_eq!(out.exit_code, 0);
+        let calls = stub.move_calls.lock().unwrap();
+        assert_eq!(*calls, vec![("Firefox".to_string(), "3".to_string())]);
+    }
+
+    #[tokio::test]
+    async fn open_no_args_returns_help() {
+        let out = run_wm(Arc::new(StubWm::connected()), &["open"]).await;
+        assert_eq!(out.exit_code, 2);
+        assert!(String::from_utf8_lossy(&out.stdout).contains("usage: wm open"));
+    }
+
+    #[tokio::test]
+    async fn open_missing_binary_returns_path_error() {
+        let out = run_wm(
+            Arc::new(StubWm::connected()),
+            &["open", "definitely-not-a-real-binary-xyzzy-12345"],
+        )
+        .await;
+        assert_eq!(out.exit_code, 1);
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            stderr.contains("[error] wm: open: binary 'definitely-not-a-real-binary-xyzzy-12345' not found on PATH"),
+            "{stderr}"
+        );
+        assert!(stderr.contains("Check:"), "{stderr}");
+    }
+
+    #[tokio::test]
+    async fn active_prints_focused_class() {
+        let stub = Arc::new(StubWm {
+            connected: true,
+            focused: Some("Firefox".into()),
+            ..Default::default()
+        });
+        let out = run_wm(stub, &["active"]).await;
+        assert_eq!(out.exit_code, 0);
+        assert_eq!(out.stdout, b"Firefox\n");
+    }
+
+    #[tokio::test]
+    async fn active_with_no_focus_is_empty_stdout() {
+        let stub = Arc::new(StubWm::connected());
+        let out = run_wm(stub, &["active"]).await;
+        assert_eq!(out.exit_code, 0);
+        assert!(out.stdout.is_empty());
+    }
+
+    #[tokio::test]
+    async fn resize_too_few_args_returns_help() {
+        let out = run_wm(
+            Arc::new(StubWm::connected()),
+            &["resize", "Firefox", "grow"],
+        )
+        .await;
+        assert_eq!(out.exit_code, 2);
+        assert!(String::from_utf8_lossy(&out.stdout).contains("usage: wm resize"));
+    }
+
+    #[tokio::test]
+    async fn resize_bad_direction_errors() {
+        let out = run_wm(
+            Arc::new(StubWm::connected()),
+            &["resize", "Firefox", "sideways", "10"],
+        )
+        .await;
+        assert_eq!(out.exit_code, 2);
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(stderr.contains("[error] wm: resize"), "{stderr}");
+        assert!(stderr.contains("Use:"), "{stderr}");
+    }
+
+    #[tokio::test]
+    async fn resize_bad_pixel_count_errors() {
+        let out = run_wm(
+            Arc::new(StubWm::connected()),
+            &["resize", "Firefox", "grow", "lots"],
+        )
+        .await;
+        assert_eq!(out.exit_code, 2);
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(stderr.contains("[error] wm: resize"), "{stderr}");
+    }
+
+    #[tokio::test]
+    async fn resize_dispatches_correct_payload() {
+        let stub = Arc::new(StubWm::connected());
+        let out = run_wm(stub.clone(), &["resize", "Firefox", "grow", "50"]).await;
+        assert_eq!(out.exit_code, 0);
+        let calls = stub.raw_calls.lock().unwrap();
+        assert_eq!(
+            *calls,
+            vec![r#"[class="Firefox"] resize grow width 50 px or 0 ppt"#.to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn resize_escapes_special_chars_in_class() {
+        let stub = Arc::new(StubWm::connected());
+        let _ = run_wm(stub.clone(), &["resize", r#"a"b\c"#, "shrink", "5"]).await;
+        let calls = stub.raw_calls.lock().unwrap();
+        assert_eq!(
+            *calls,
+            vec![r#"[class="a\"b\\c"] resize shrink width 5 px or 0 ppt"#.to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn list_emits_tsv_sorted_by_workspace_then_class() {
+        let stub = Arc::new(StubWm {
+            connected: true,
+            windows: vec![
+                Window {
+                    id: "Firefox".into(),
+                    title: Some("GitHub".into()),
+                    workspace: Some("3".into()),
+                },
+                Window {
+                    id: "code".into(),
+                    title: Some("wm.rs".into()),
+                    workspace: Some("1".into()),
+                },
+                Window {
+                    id: "Alacritty".into(),
+                    title: None,
+                    workspace: Some("1".into()),
+                },
+            ],
+            ..Default::default()
+        });
+        let out = run_wm(stub, &["list"]).await;
+        assert_eq!(out.exit_code, 0);
+        assert_eq!(
+            String::from_utf8_lossy(&out.stdout),
+            "Alacritty\t1\t\ncode\t1\twm.rs\nFirefox\t3\tGitHub\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn list_orphans_use_dash_for_workspace() {
+        let stub = Arc::new(StubWm {
+            connected: true,
+            windows: vec![Window {
+                id: "Scratch".into(),
+                title: Some("notes".into()),
+                workspace: None,
+            }],
+            ..Default::default()
+        });
+        let out = run_wm(stub, &["list"]).await;
+        assert_eq!(out.exit_code, 0);
+        assert_eq!(out.stdout, b"Scratch\t-\tnotes\n");
+    }
+
+    #[tokio::test]
+    async fn workspaces_emits_tsv_with_focus_marker() {
+        let stub = Arc::new(StubWm {
+            connected: true,
+            workspaces: vec![
+                WorkspaceInfo {
+                    num: 3,
+                    name: "3".into(),
+                    focused: false,
+                    output: "DP-1".into(),
+                },
+                WorkspaceInfo {
+                    num: 1,
+                    name: "1:web".into(),
+                    focused: true,
+                    output: "DP-1".into(),
+                },
+            ],
+            ..Default::default()
+        });
+        let out = run_wm(stub, &["workspaces"]).await;
+        assert_eq!(out.exit_code, 0);
+        assert_eq!(
+            String::from_utf8_lossy(&out.stdout),
+            "1\t1:web\t*\tDP-1\n3\t3\t-\tDP-1\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn layout_no_args_returns_help() {
+        let out = run_wm(Arc::new(StubWm::connected()), &["layout"]).await;
+        assert_eq!(out.exit_code, 2);
+        assert!(String::from_utf8_lossy(&out.stdout).contains("usage: wm layout"));
+    }
+
+    #[tokio::test]
+    async fn layout_unknown_name_errors() {
+        let out = run_wm(Arc::new(StubWm::connected()), &["layout", "spinning"]).await;
+        assert_eq!(out.exit_code, 2);
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(stderr.contains("[error] wm: layout"), "{stderr}");
+        assert!(stderr.contains("Use:"), "{stderr}");
+    }
+
+    #[tokio::test]
+    async fn layout_dispatches_payload() {
+        let stub = Arc::new(StubWm::connected());
+        let out = run_wm(stub.clone(), &["layout", "tabbed"]).await;
+        assert_eq!(out.exit_code, 0);
+        let calls = stub.raw_calls.lock().unwrap();
+        assert_eq!(*calls, vec!["layout tabbed".to_string()]);
+    }
+
+    #[test]
+    fn summary_fits_eighty_chars() {
+        assert!(SUMMARY.len() <= 80, "{} chars: {SUMMARY}", SUMMARY.len());
+    }
+
+    #[test]
+    fn escape_for_criteria_matches_i3_helper() {
+        assert_eq!(escape_for_criteria("Firefox"), "Firefox");
+        assert_eq!(escape_for_criteria(r#"a"b"#), r#"a\"b"#);
+        assert_eq!(escape_for_criteria(r"a\b"), r"a\\b");
+        assert_eq!(escape_for_criteria(r#"a"b\c"#), r#"a\"b\\c"#);
+    }
+}

--- a/crates/assistd-tools/src/run.rs
+++ b/crates/assistd-tools/src/run.rs
@@ -252,10 +252,12 @@ mod tests {
         Arc::new(r)
     }
 
-    /// Full 9-command registry matching the daemon's production set.
-    /// Used by Level-0 description tests that need to verify every
-    /// command name flows into the LLM-facing schema.
+    /// Full registry matching the daemon's production set. Used by
+    /// Level-0 description tests that need to verify every command
+    /// name flows into the LLM-facing schema.
     fn full_registry() -> Arc<CommandRegistry> {
+        use crate::commands::WmCommand;
+        use assistd_wm::NoWindowManager;
         let mut r = CommandRegistry::new();
         r.register(CatCommand);
         r.register(LsCommand);
@@ -267,6 +269,7 @@ mod tests {
         r.register(ScreenshotCommand::default());
         r.register(WebCommand::new());
         r.register(BashCommand::default());
+        r.register(WmCommand::new(Arc::new(NoWindowManager)));
         Arc::new(r)
     }
 
@@ -752,6 +755,7 @@ mod tests {
             "screenshot",
             "web",
             "bash",
+            "wm",
         ] {
             assert!(desc.contains(name), "description missing `{name}`: {desc}");
         }
@@ -830,6 +834,7 @@ mod tests {
             "screenshot",
             "web",
             "bash",
+            "wm",
         ] {
             assert!(desc.contains(name), "schema description missing `{name}`");
         }

--- a/crates/assistd-wm/src/i3.rs
+++ b/crates/assistd-wm/src/i3.rs
@@ -21,7 +21,7 @@ use tokio_i3ipc::{
     reply,
 };
 
-use crate::{WindowId, WindowManager, WorkspaceId};
+use crate::{Window, WindowId, WindowManager, WorkspaceId, WorkspaceInfo};
 
 /// Cached focus state. Seeded from `get_tree()` at startup, then updated
 /// by the event task on every `Window::Focus` event. The trait surface
@@ -168,6 +168,74 @@ impl WindowManager for I3Backend {
 
     async fn focused_window(&self) -> Result<Option<WindowId>> {
         Ok(self.snapshot.read().await.focused_window.clone())
+    }
+
+    async fn list_windows(&self) -> Result<Vec<Window>> {
+        let tree = self
+            .cmd
+            .lock()
+            .await
+            .get_tree()
+            .await
+            .context("i3 GET_TREE")?;
+        let mut out = Vec::new();
+        collect_windows(&tree, None, &mut out);
+        Ok(out)
+    }
+
+    async fn list_workspaces(&self) -> Result<Vec<WorkspaceInfo>> {
+        let ws = self
+            .cmd
+            .lock()
+            .await
+            .get_workspaces()
+            .await
+            .context("i3 GET_WORKSPACES")?;
+        Ok(ws
+            .into_iter()
+            .map(|w| WorkspaceInfo {
+                num: w.num,
+                name: w.name,
+                focused: w.focused,
+                output: w.output,
+            })
+            .collect())
+    }
+
+    async fn run_raw(&self, payload: &str) -> Result<()> {
+        self.run(payload).await
+    }
+}
+
+/// Walk the i3 tree recursively, emitting one [`Window`] per leaf node
+/// that has both an X11 window id and a class. Tracks the most recent
+/// `NodeType::Workspace` ancestor in `current_ws` so each window can be
+/// tagged with the workspace it lives on.
+///
+/// Children of a non-workspace node inherit the parent's workspace
+/// context; children of a workspace node use that workspace's name.
+/// Floating nodes are walked alongside tiling nodes — both are real
+/// windows the user can focus.
+fn collect_windows(node: &reply::Node, current_ws: Option<&str>, out: &mut Vec<Window>) {
+    let next_ws = if matches!(node.node_type, reply::NodeType::Workspace) {
+        node.name.as_deref()
+    } else {
+        current_ws
+    };
+
+    if node.window.is_some()
+        && let Some(props) = node.window_properties.as_ref()
+        && let Some(class) = props.class.clone()
+    {
+        out.push(Window {
+            id: class,
+            title: props.title.clone(),
+            workspace: next_ws.map(|s| s.to_string()),
+        });
+    }
+
+    for child in node.nodes.iter().chain(node.floating_nodes.iter()) {
+        collect_windows(child, next_ws, out);
     }
 }
 

--- a/crates/assistd-wm/src/lib.rs
+++ b/crates/assistd-wm/src/lib.rs
@@ -31,6 +31,41 @@ pub type WindowId = String;
 /// `workspace "<name>"`.
 pub type WorkspaceId = String;
 
+/// One row of [`WindowManager::list_windows`]. The trait's wider methods
+/// (`focus`, `move_to_workspace`) take a [`WindowId`] alone; this struct
+/// is the richer view returned to surfaces (the `wm list` command) that
+/// need title and workspace context to format human-readable output.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Window {
+    /// Identifier usable with [`WindowManager::focus`] /
+    /// [`WindowManager::move_to_workspace`]. For i3 this is the X11 class.
+    pub id: WindowId,
+    /// `_NET_WM_NAME` / `WM_NAME`. Missing on some transient or just-
+    /// mapped windows.
+    pub title: Option<String>,
+    /// Workspace this window currently lives on. `None` for scratchpad
+    /// or otherwise un-anchored windows.
+    pub workspace: Option<String>,
+}
+
+/// One row of [`WindowManager::list_workspaces`]. Named to avoid colliding
+/// with `tokio_i3ipc::reply::Workspace` at use sites; both backends will
+/// flatten their compositor's workspace shape into this common view.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkspaceInfo {
+    /// Numeric component (i3's `num`). `-1` when the workspace name does
+    /// not begin with a number.
+    pub num: i32,
+    /// User-visible label (e.g. `"1"`, `"1:web"`, `"scratch"`).
+    pub name: String,
+    /// True when this workspace currently holds the active focus on its
+    /// output. (Multi-monitor setups have one focused workspace per
+    /// output; this matches i3's `focused` field on `reply::Workspace`.)
+    pub focused: bool,
+    /// Monitor / output name (e.g. `"DP-1"`).
+    pub output: String,
+}
+
 #[async_trait]
 pub trait WindowManager: Send + Sync + 'static {
     /// Focus the window with the given id.
@@ -42,6 +77,28 @@ pub trait WindowManager: Send + Sync + 'static {
     /// Return the id of the currently focused window, or `None` when no
     /// window holds focus (e.g. an empty workspace).
     async fn focused_window(&self) -> Result<Option<WindowId>>;
+
+    /// Enumerate every mapped window the compositor knows about.
+    async fn list_windows(&self) -> Result<Vec<Window>>;
+
+    /// Enumerate every workspace the compositor knows about.
+    async fn list_workspaces(&self) -> Result<Vec<WorkspaceInfo>>;
+
+    /// Send a raw, backend-specific command payload. Used for operations
+    /// that have no typed return value and where adding a per-operation
+    /// trait method would be a thin wrapper around a string format
+    /// (resize, layout, …). Callers are responsible for the syntax —
+    /// keep this behind subcommands that document the expected dialect.
+    async fn run_raw(&self, payload: &str) -> Result<()>;
+
+    /// Report whether the backend is actually connected to a compositor.
+    /// The default `true` covers concrete backends; [`NoWindowManager`]
+    /// overrides to `false` so callers can short-circuit with a single
+    /// "compositor not connected" message instead of waiting for the
+    /// generic `bail!` from each operation.
+    fn is_connected(&self) -> bool {
+        true
+    }
 }
 
 /// Placeholder [`WindowManager`] that refuses every operation. Used by
@@ -59,6 +116,18 @@ impl WindowManager for NoWindowManager {
     }
     async fn focused_window(&self) -> Result<Option<WindowId>> {
         Ok(None)
+    }
+    async fn list_windows(&self) -> Result<Vec<Window>> {
+        anyhow::bail!("no window manager backend is configured")
+    }
+    async fn list_workspaces(&self) -> Result<Vec<WorkspaceInfo>> {
+        anyhow::bail!("no window manager backend is configured")
+    }
+    async fn run_raw(&self, _payload: &str) -> Result<()> {
+        anyhow::bail!("no window manager backend is configured")
+    }
+    fn is_connected(&self) -> bool {
+        false
     }
 }
 
@@ -88,6 +157,26 @@ mod tests {
                 .await
                 .is_err()
         );
+    }
+
+    #[tokio::test]
+    async fn no_window_manager_refuses_list_windows() {
+        assert!(NoWindowManager.list_windows().await.is_err());
+    }
+
+    #[tokio::test]
+    async fn no_window_manager_refuses_list_workspaces() {
+        assert!(NoWindowManager.list_workspaces().await.is_err());
+    }
+
+    #[tokio::test]
+    async fn no_window_manager_refuses_run_raw() {
+        assert!(NoWindowManager.run_raw("focus").await.is_err());
+    }
+
+    #[test]
+    fn no_window_manager_reports_disconnected() {
+        assert!(!NoWindowManager.is_connected());
     }
 
     #[test]

--- a/crates/assistd/src/daemon.rs
+++ b/crates/assistd/src/daemon.rs
@@ -555,6 +555,7 @@ pub async fn run(args: DaemonArgs) -> Result<()> {
         semantic_store.clone(),
         embed_tx.clone(),
         embedding_model_name.clone(),
+        window_manager.clone(),
     )?;
     info!(
         "tools: registered {} (overflow dir {})",


### PR DESCRIPTION
Added a `wm` command to the LLM's command router so it can drive i3 windows/workspaces via `run(command="wm …")`