### PR TITLE
Implement context aware behavior i3 events.

### DIFF
--- a/crates/assistd-core/src/state.rs
+++ b/crates/assistd-core/src/state.rs
@@ -440,29 +440,29 @@ impl AppState {
     }
 
     /// Embed the user query, find the top-K nearest conversation chunks,
-    /// and stash a "Relevant past context: …" system message on the LLM
-    /// backend's conversation. Consumed by the next `step` and cleared
-    /// so a follow-up turn re-runs retrieval.
+    /// and return a "Relevant past context: …" block to inject as a
+    /// transient system message. Returns `Ok(None)` when retrieval is a
+    /// no-op (short query, NoEmbedder, no hits).
     ///
-    /// Best-effort: returns errors but the caller treats every failure
-    /// (embedder down, no hits, dim mismatch, …) as "skip injection".
-    async fn inject_semantic_context(&self, query: &str) -> Result<()> {
+    /// Best-effort: errors propagate but the caller treats every failure
+    /// (embedder down, dim mismatch, …) as "skip injection".
+    async fn build_semantic_context(&self, query: &str) -> Result<Option<String>> {
         // Skip very short queries — no useful semantic signal in 1-2
         // chars, and the cost of a wasted embed call is non-zero.
         if query.trim().chars().count() < 3 {
-            return Ok(());
+            return Ok(None);
         }
         let vec = self.embedder.embed(query.to_string()).await?;
         let model = self.embedder.model().to_string();
         if model.is_empty() {
             // NoEmbedder path: model() == "" → never matches stored
             // rows. Bail without a write.
-            return Ok(());
+            return Ok(None);
         }
         let top_k = self.embedding_cfg.top_k as usize;
         let hits = self.semantic.nearest_chunks(vec, top_k, &model).await?;
         if hits.is_empty() {
-            return Ok(());
+            return Ok(None);
         }
         let mut block = String::from("Relevant past context:\n");
         for h in hits {
@@ -477,10 +477,88 @@ impl AppState {
                 snippet
             ));
         }
-        self.llm.set_transient_context(block).await?;
-        Ok(())
+        Ok(Some(block))
     }
 
+    /// Format the focused-window snapshot as a `Current desktop context`
+    /// block for the LLM's per-turn transient system message. Returns
+    /// `None` when the window manager has no opinion (no compositor
+    /// connected, nothing focused, all fields empty).
+    ///
+    /// Errors from the WM backend degrade silently to `None` so a flaky
+    /// compositor never blocks the user's turn.
+    async fn build_window_context(&self) -> Option<String> {
+        let ctx = match self.window_manager.focused_context().await {
+            Ok(Some(c)) => c,
+            Ok(None) => return None,
+            Err(e) => {
+                tracing::debug!(
+                    target: "assistd::context",
+                    error = %e,
+                    "WindowManager::focused_context failed; skipping window context",
+                );
+                return None;
+            }
+        };
+        format_window_context_block(&ctx)
+    }
+}
+
+/// Render a [`assistd_wm::FocusedWindowContext`] into the prompt
+/// fragment injected as a transient system message. Pure (no async,
+/// no `&self`) so it's directly unit-testable. Returns `None` when
+/// every field is empty.
+fn format_window_context_block(ctx: &assistd_wm::FocusedWindowContext) -> Option<String> {
+    if ctx.class.is_none() && ctx.title.is_none() && ctx.workspace.is_none() {
+        return None;
+    }
+    let mut block = String::from("Current desktop context:\n");
+    let class_for_line = ctx.class.as_deref();
+    let title_for_line = ctx.title.as_deref();
+    if class_for_line.is_some() || title_for_line.is_some() {
+        match (class_for_line, title_for_line) {
+            (Some(c), Some(t)) => block.push_str(&format!("- Focused window: {c} — {t}\n")),
+            (Some(c), None) => block.push_str(&format!("- Focused window: {c}\n")),
+            (None, Some(t)) => block.push_str(&format!("- Focused window: (unknown) — {t}\n")),
+            (None, None) => unreachable!(),
+        }
+    }
+    if let Some(ws) = ctx.workspace.as_deref() {
+        block.push_str(&format!("- Workspace: {ws}\n"));
+    }
+    let is_term = ctx
+        .class
+        .as_deref()
+        .map(assistd_wm::is_terminal_class)
+        .unwrap_or(false);
+    let kind = if is_term { "terminal" } else { "non-terminal" };
+    block.push_str(&format!("The user is interacting with a {kind} window."));
+    if is_term {
+        // Bias the LLM toward in-place execution. Phrasing references
+        // the actual `run` tool's sub-command names so the model maps
+        // the hint cleanly onto its tool schema.
+        block.push_str(
+            " If the user asks to run a command, build, or test, prefer calling `run` \
+             with `command: \"bash\"` (executing the command in this terminal context) over \
+             launching a new terminal via `run` with `command: \"wm\"`.",
+        );
+    }
+    Some(block)
+}
+
+/// Concatenate the semantic and window context blocks with a blank
+/// line between them. Returns `None` only when both inputs are `None`.
+/// Pure / unit-testable.
+fn combine_context_blocks(semantic: Option<String>, window: Option<String>) -> Option<String> {
+    match (semantic, window) {
+        (None, None) => None,
+        (Some(s), None) => Some(s),
+        (None, Some(w)) => Some(w),
+        (Some(s), Some(w)) => Some(format!("{}\n{}", s.trim_end(), w)),
+    }
+}
+
+impl AppState {
     async fn handle_memory_semantic_search(
         self: Arc<Self>,
         id: String,
@@ -966,19 +1044,40 @@ impl AppState {
         // never waits on disk.
         self.persist_message_fire_and_forget(turn_id, PersistedMessage::user(text.clone()));
 
-        // Auto-inject "Relevant past context: …" from semantic search
-        // before the LLM runs. AC #3: every query that hits an enabled
-        // embedder gets retrieval context as a transient system message.
-        // Best-effort: any failure (embedder down, dim mismatch, empty
-        // hits) downgrades to debug-log + no injection.
-        if self.embedding_cfg.enabled
-            && self.embedding_cfg.auto_inject
-            && let Err(e) = self.inject_semantic_context(&text).await
+        // Auto-inject the LLM's per-turn transient system message. Two
+        // sources, composed at the call site because the conversation's
+        // transient slot is a single `Option<String>` (a second
+        // `set_transient_context` call would clobber the first):
+        //   1. Semantic recall — top-K conversation chunks (gated on
+        //      embedding config, like before).
+        //   2. Window context — focused class/title/workspace from the
+        //      WM event task. Always-on; degrades to None when no
+        //      compositor is connected. Carries a terminal-bias hint
+        //      when the focused class is a known terminal emulator.
+        // Both are best-effort: any failure debug-logs and continues.
+        let semantic = if self.embedding_cfg.enabled && self.embedding_cfg.auto_inject {
+            match self.build_semantic_context(&text).await {
+                Ok(b) => b,
+                Err(e) => {
+                    tracing::debug!(
+                        target: "assistd::embed",
+                        error = %e,
+                        "semantic context injection failed; continuing without it",
+                    );
+                    None
+                }
+            }
+        } else {
+            None
+        };
+        let window = self.build_window_context().await;
+        if let Some(block) = combine_context_blocks(semantic, window)
+            && let Err(e) = self.llm.set_transient_context(block).await
         {
             tracing::debug!(
-                target: "assistd::embed",
+                target: "assistd::context",
                 error = %e,
-                "semantic context injection failed; continuing without it"
+                "set_transient_context failed; continuing without it",
             );
         }
 
@@ -2772,5 +2871,104 @@ mod tests {
         let _ = collect_events(rx).await;
         // wait_idle invoked exactly once after the channel closes.
         assert_eq!(recorder.wait_idle_count(), 1);
+    }
+
+    fn ctx(
+        class: Option<&str>,
+        title: Option<&str>,
+        ws: Option<&str>,
+    ) -> assistd_wm::FocusedWindowContext {
+        assistd_wm::FocusedWindowContext {
+            class: class.map(str::to_string),
+            title: title.map(str::to_string),
+            workspace: ws.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn format_window_context_block_full_terminal_includes_hint() {
+        let block = format_window_context_block(&ctx(
+            Some("Alacritty"),
+            Some("nvim ~ src/main.rs"),
+            Some("2"),
+        ))
+        .expect("Some block expected for non-empty ctx");
+        assert!(block.starts_with("Current desktop context:\n"));
+        assert!(block.contains("- Focused window: Alacritty — nvim ~ src/main.rs\n"));
+        assert!(block.contains("- Workspace: 2\n"));
+        assert!(block.contains("interacting with a terminal window."));
+        // AC#3: hint references the actual `run` sub-command names.
+        assert!(block.contains("`command: \"bash\"`"));
+        assert!(block.contains("`command: \"wm\"`"));
+    }
+
+    #[test]
+    fn format_window_context_block_non_terminal_omits_hint() {
+        let block = format_window_context_block(&ctx(
+            Some("firefox"),
+            Some("Anthropic - claude.ai"),
+            Some("3"),
+        ))
+        .expect("Some block expected for non-empty ctx");
+        assert!(block.contains("interacting with a non-terminal window."));
+        assert!(!block.contains("command: \"bash\""));
+        assert!(!block.contains("command: \"wm\""));
+    }
+
+    #[test]
+    fn format_window_context_block_omits_missing_fields() {
+        // Class only — no title bar, no workspace line.
+        let block = format_window_context_block(&ctx(Some("Alacritty"), None, None)).expect("Some");
+        assert!(block.contains("- Focused window: Alacritty\n"));
+        assert!(!block.contains(" — "));
+        assert!(!block.contains("- Workspace:"));
+    }
+
+    #[test]
+    fn format_window_context_block_returns_none_for_empty_ctx() {
+        assert!(format_window_context_block(&ctx(None, None, None)).is_none());
+    }
+
+    #[test]
+    fn format_window_context_block_workspace_only() {
+        // Edge case: focus event was cleared by a Close but the
+        // active workspace is still tracked. Should still produce a
+        // block (just the workspace line + non-terminal kind).
+        let block = format_window_context_block(&ctx(None, None, Some("scratch"))).expect("Some");
+        assert!(!block.contains("- Focused window:"));
+        assert!(block.contains("- Workspace: scratch\n"));
+        assert!(block.contains("non-terminal window."));
+    }
+
+    #[test]
+    fn combine_context_blocks_merges_with_blank_line() {
+        let merged = combine_context_blocks(
+            Some("Relevant past context:\n- foo\n".into()),
+            Some("Current desktop context:\n- bar".into()),
+        )
+        .expect("Some");
+        // Trailing newline of semantic block trimmed; blank line inserted
+        // between the two blocks so the LLM sees clean separation.
+        assert_eq!(
+            merged,
+            "Relevant past context:\n- foo\nCurrent desktop context:\n- bar"
+        );
+    }
+
+    #[test]
+    fn combine_context_blocks_passes_through_singletons() {
+        assert_eq!(
+            combine_context_blocks(Some("a".into()), None),
+            Some("a".into())
+        );
+        assert_eq!(
+            combine_context_blocks(None, Some("b".into())),
+            Some("b".into())
+        );
+    }
+
+    #[test]
+    fn combine_context_blocks_returns_none_for_both_none() {
+        assert!(combine_context_blocks(None, None).is_none());
     }
 }

--- a/crates/assistd-wm/src/i3.rs
+++ b/crates/assistd-wm/src/i3.rs
@@ -17,18 +17,22 @@ use tokio::sync::{Mutex, RwLock, watch};
 use tokio::task::JoinHandle;
 use tokio_i3ipc::{
     I3,
-    event::{Event, Subscribe, WindowChange},
+    event::{Event, Subscribe, WindowChange, WorkspaceChange},
     reply,
 };
 
-use crate::{Window, WindowId, WindowManager, WorkspaceId, WorkspaceInfo};
+use crate::{FocusedWindowContext, Window, WindowId, WindowManager, WorkspaceId, WorkspaceInfo};
 
-/// Cached focus state. Seeded from `get_tree()` at startup, then updated
-/// by the event task on every `Window::Focus` event. The trait surface
-/// only reads `focused_window`, so we don't track workspace focus.
+/// Cached focus state. Seeded from `get_tree()` + `get_workspaces()`
+/// at startup, then updated by the event task on each `Window::Focus`,
+/// `Window::Title`, `Window::Close`, and `Workspace::Focus` event so
+/// the synchronous reads in [`I3Backend::focused_window`] and
+/// [`I3Backend::focused_context`] hit memory rather than IPC.
 #[derive(Default, Clone)]
 struct Snapshot {
-    focused_window: Option<WindowId>,
+    focused_class: Option<WindowId>,
+    focused_title: Option<String>,
+    active_workspace: Option<String>,
 }
 
 /// `WindowManager` impl wrapping a single i3 IPC command socket.
@@ -73,9 +77,9 @@ impl I3Backend {
             .await
             .context("connect to i3 IPC (events socket)")?;
         events_conn
-            .subscribe([Subscribe::Window])
+            .subscribe([Subscribe::Window, Subscribe::Workspace])
             .await
-            .context("subscribe to i3 window events")?;
+            .context("subscribe to i3 window+workspace events")?;
 
         // Seed snapshot before wrapping cmd in the Mutex — reuses the
         // command socket since `get_tree()` needs `&mut`.
@@ -98,13 +102,17 @@ impl I3Backend {
                     }
                     evt = stream.next() => {
                         match evt {
-                            Some(Ok(Event::Window(w))) if matches!(w.change, WindowChange::Focus) => {
-                                let class = w
-                                    .container
-                                    .window_properties
-                                    .as_ref()
-                                    .and_then(|p| p.class.clone());
-                                snap_for_task.write().await.focused_window = class;
+                            Some(Ok(Event::Window(w))) => {
+                                handle_window_event(&w, &snap_for_task).await;
+                            }
+                            Some(Ok(Event::Workspace(d))) => {
+                                if matches!(d.change, WorkspaceChange::Focus) {
+                                    let ws = d
+                                        .current
+                                        .as_ref()
+                                        .and_then(|n| n.name.clone());
+                                    snap_for_task.write().await.active_workspace = ws;
+                                }
                             }
                             Some(Ok(_)) => {}
                             Some(Err(e)) => {
@@ -167,7 +175,19 @@ impl WindowManager for I3Backend {
     }
 
     async fn focused_window(&self) -> Result<Option<WindowId>> {
-        Ok(self.snapshot.read().await.focused_window.clone())
+        Ok(self.snapshot.read().await.focused_class.clone())
+    }
+
+    async fn focused_context(&self) -> Result<Option<FocusedWindowContext>> {
+        let s = self.snapshot.read().await;
+        if s.focused_class.is_none() && s.focused_title.is_none() && s.active_workspace.is_none() {
+            return Ok(None);
+        }
+        Ok(Some(FocusedWindowContext {
+            class: s.focused_class.clone(),
+            title: s.focused_title.clone(),
+            workspace: s.active_workspace.clone(),
+        }))
     }
 
     async fn list_windows(&self) -> Result<Vec<Window>> {
@@ -258,11 +278,68 @@ fn format_workspace_target(ws: &WorkspaceId) -> String {
 
 async fn seed_snapshot(cmd: &mut I3) -> Result<Snapshot> {
     let tree = cmd.get_tree().await.context("i3 GET_TREE")?;
+    let focused = walk_focused(&tree);
+    let focused_class = focused
+        .and_then(|n| n.window_properties.as_ref())
+        .and_then(|p| p.class.clone());
+    let focused_title = focused.and_then(|n| n.name.clone());
+    // Active workspace seeded from a separate query: walking the
+    // tree to the focused leaf's workspace ancestor would work, but
+    // GET_WORKSPACES is one round-trip and gives an authoritative
+    // `focused == true` row that already accounts for multi-output.
+    let active_workspace = match cmd.get_workspaces().await {
+        Ok(ws) => ws.into_iter().find(|w| w.focused).map(|w| w.name),
+        Err(e) => {
+            tracing::warn!("i3 GET_WORKSPACES on seed failed: {e:#}");
+            None
+        }
+    };
     Ok(Snapshot {
-        focused_window: walk_focused(&tree)
-            .and_then(|n| n.window_properties.as_ref())
-            .and_then(|p| p.class.clone()),
+        focused_class,
+        focused_title,
+        active_workspace,
     })
+}
+
+/// Apply one i3 `Window` event to the cached focus snapshot.
+///
+/// Race rules:
+/// - `Focus` overwrites both class and title from the new container.
+/// - `Title` only takes effect when the event's class matches the
+///   currently-focused class — title events from background windows
+///   must not overwrite the foreground title.
+/// - `Close` clears class + title only when the closed container is
+///   the focused one. Workspace is left intact.
+async fn handle_window_event(w: &tokio_i3ipc::event::WindowData, snap: &Arc<RwLock<Snapshot>>) {
+    let class = w
+        .container
+        .window_properties
+        .as_ref()
+        .and_then(|p| p.class.clone());
+    let title = w.container.name.clone();
+    match w.change {
+        WindowChange::Focus => {
+            let mut s = snap.write().await;
+            s.focused_class = class;
+            s.focused_title = title;
+        }
+        WindowChange::Title => {
+            let mut s = snap.write().await;
+            // Only honor title updates for the currently-focused class.
+            // (i3 emits Title events for background windows too.)
+            if s.focused_class == class && class.is_some() {
+                s.focused_title = title;
+            }
+        }
+        WindowChange::Close => {
+            let mut s = snap.write().await;
+            if s.focused_class == class && class.is_some() {
+                s.focused_class = None;
+                s.focused_title = None;
+            }
+        }
+        _ => {}
+    }
 }
 
 fn walk_focused(node: &reply::Node) -> Option<&reply::Node> {

--- a/crates/assistd-wm/src/lib.rs
+++ b/crates/assistd-wm/src/lib.rs
@@ -66,6 +66,57 @@ pub struct WorkspaceInfo {
     pub output: String,
 }
 
+/// Snapshot of what the user is currently looking at. Returned by
+/// [`WindowManager::focused_context`]. Each field is independently
+/// optional because compositors deliver focus / title / workspace
+/// state through separate events; a backend may have any subset.
+///
+/// Built from the backend's cached event snapshot — no IPC round-trip
+/// — so callers can read it cheaply on every LLM query.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct FocusedWindowContext {
+    /// X11 `WM_CLASS` of the focused window (or compositor-equivalent).
+    pub class: Option<String>,
+    /// `_NET_WM_NAME` / `WM_NAME` of the focused window.
+    pub title: Option<String>,
+    /// Name of the workspace currently holding focus.
+    pub workspace: Option<String>,
+}
+
+/// Best-effort allowlist of X11 `WM_CLASS` values for terminal
+/// emulators. Matched case-insensitively because compositors and apps
+/// disagree on capitalization (`xterm` vs `XTerm`, `alacritty` vs
+/// `Alacritty`). Future work: surface extra classes via config.
+const TERMINAL_CLASSES: &[&str] = &[
+    "Alacritty",
+    "kitty",
+    "XTerm",
+    "UXTerm",
+    "URxvt",
+    "rxvt-unicode",
+    "st-256color",
+    "st",
+    "Gnome-terminal",
+    "Konsole",
+    "Terminator",
+    "Tilix",
+    "foot",
+    "footclient",
+    "WezTerm",
+    "org.wezfurlong.wezterm",
+    "Xfce4-terminal",
+    "Termite",
+];
+
+/// Returns true when `class` looks like a terminal emulator. The list
+/// is intentionally conservative: emitters not in [`TERMINAL_CLASSES`]
+/// fall through as non-terminal (no hint emitted, but no wrong hint).
+pub fn is_terminal_class(class: &str) -> bool {
+    TERMINAL_CLASSES
+        .iter()
+        .any(|t| t.eq_ignore_ascii_case(class))
+}
+
 #[async_trait]
 pub trait WindowManager: Send + Sync + 'static {
     /// Focus the window with the given id.
@@ -83,6 +134,17 @@ pub trait WindowManager: Send + Sync + 'static {
 
     /// Enumerate every workspace the compositor knows about.
     async fn list_workspaces(&self) -> Result<Vec<WorkspaceInfo>>;
+
+    /// Return a snapshot of the currently focused window's class,
+    /// title, and the active workspace. Used by the daemon to inject
+    /// passive desktop context into the LLM's per-turn system prompt.
+    ///
+    /// Returns `Ok(None)` when nothing is focused or the backend has
+    /// no opinion. The default impl returns `Ok(None)` so backends
+    /// without event-snapshot support compile unchanged.
+    async fn focused_context(&self) -> Result<Option<FocusedWindowContext>> {
+        Ok(None)
+    }
 
     /// Send a raw, backend-specific command payload. Used for operations
     /// that have no typed return value and where adding a per-operation
@@ -182,5 +244,37 @@ mod tests {
     #[test]
     fn version_is_not_empty() {
         assert!(!version().is_empty());
+    }
+
+    #[test]
+    fn is_terminal_class_matches_known_emulators() {
+        assert!(is_terminal_class("Alacritty"));
+        assert!(is_terminal_class("kitty"));
+        assert!(is_terminal_class("WezTerm"));
+        assert!(is_terminal_class("foot"));
+    }
+
+    #[test]
+    fn is_terminal_class_is_case_insensitive() {
+        // X11 WM_CLASS capitalization varies in practice; users on
+        // `alacritty` vs `Alacritty` should both get the terminal hint.
+        assert!(is_terminal_class("alacritty"));
+        assert!(is_terminal_class("XTERM"));
+        assert!(is_terminal_class("xterm"));
+    }
+
+    #[test]
+    fn is_terminal_class_rejects_non_terminals() {
+        assert!(!is_terminal_class("firefox"));
+        assert!(!is_terminal_class("code"));
+        assert!(!is_terminal_class(""));
+        assert!(!is_terminal_class("Slack"));
+    }
+
+    #[tokio::test]
+    async fn no_window_manager_focused_context_is_none() {
+        // Default trait impl returns Ok(None); NoWindowManager inherits
+        // it because we don't override.
+        assert!(NoWindowManager.focused_context().await.unwrap().is_none());
     }
 }

--- a/crates/assistd-wm/tests/i3_live.rs
+++ b/crates/assistd-wm/tests/i3_live.rs
@@ -37,6 +37,22 @@ async fn connects_and_reads_focused_window() {
         "expected at least one focused window in the live i3 session"
     );
 
+    // Same snapshot, richer view: title + workspace seeded alongside
+    // the class. We don't assert title/workspace are Some — a freshly-
+    // mapped window or scratchpad can leave them None — but class
+    // should match `focused_window()` above.
+    let ctx = handle
+        .backend
+        .focused_context()
+        .await
+        .expect("focused_context query failed")
+        .expect("expected Some(FocusedWindowContext) for a focused session");
+    println!("focused context = {:?}", ctx);
+    assert_eq!(
+        ctx.class, focused,
+        "focused_context().class should agree with focused_window()"
+    );
+
     // Give the event task a brief window to confirm it's running and
     // subscribed (no assertion — just exercising the loop).
     tokio::time::sleep(Duration::from_millis(50)).await;


### PR DESCRIPTION
daemon now tracks focused window class/title/workspace via i3 events and injects them into the LLM's transient system prompt, with a terminal-bias hint. Hardcoded set of terminal applications for now which will either move to some programmatic discovery or config whitelist.