### PR TITLE
Window management refinement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -349,6 +349,7 @@ dependencies = [
  "async-trait",
  "futures-util",
  "swayipc-async",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-i3ipc",
  "tracing",

--- a/crates/assistd-core/src/state.rs
+++ b/crates/assistd-core/src/state.rs
@@ -2878,7 +2878,10 @@ mod tests {
         title: Option<&str>,
         ws: Option<&str>,
     ) -> assistd_wm::FocusedWindowContext {
+        // PR 3b adds an `id: Option<WindowId>` field; the prompt
+        // formatter doesn't render it, so the helper leaves it None.
         assistd_wm::FocusedWindowContext {
+            id: None,
             class: class.map(str::to_string),
             title: title.map(str::to_string),
             workspace: ws.map(str::to_string),

--- a/crates/assistd-tools/src/commands/wm.rs
+++ b/crates/assistd-tools/src/commands/wm.rs
@@ -308,9 +308,7 @@ async fn handle_active(wm: &dyn WindowManager) -> Result<CommandOutput> {
                 None => "-".into(),
             };
             let app = ctx.class.as_deref().unwrap_or("-");
-            Ok(CommandOutput::ok(
-                format!("{id_str}\t{app}\n").into_bytes(),
-            ))
+            Ok(CommandOutput::ok(format!("{id_str}\t{app}\n").into_bytes()))
         }
         Ok(None) => Ok(CommandOutput::ok(Vec::new())),
         Err(e) => {

--- a/crates/assistd-tools/src/commands/wm.rs
+++ b/crates/assistd-tools/src/commands/wm.rs
@@ -33,10 +33,35 @@ use anyhow::Result;
 use async_trait::async_trait;
 use tokio::process::Command as ProcCommand;
 
-use assistd_wm::WindowManager;
 use assistd_wm::criteria::escape_for_criteria;
+use assistd_wm::{WindowManager, WmError};
 
 use crate::command::{Command, CommandInput, CommandOutput, error_line};
+
+/// Pick the `(label, hint)` pair attached to a [`WmError`] for the
+/// `[error] wm: …. <label>: <hint>` line the LLM sees. The variant
+/// determines the recovery action; the handler-specific operation is
+/// already in the message body (`"focus 'Firefox' failed: …"`), so the
+/// hint stays per-variant rather than per-handler.
+fn hint_for(err: &WmError) -> (&'static str, &'static str) {
+    match err {
+        WmError::Disconnected => (
+            "Check",
+            "[compositor] in config.toml and that i3/sway/hyprland is running",
+        ),
+        WmError::NotFound(_) => ("Use", "wm list to find the right window"),
+        WmError::Rejected(_) => ("Try", "wm list to verify the window/workspace exists"),
+        WmError::Timeout(_) => (
+            "Note",
+            "compositor unresponsive; retry once before assuming it crashed",
+        ),
+        WmError::Unsupported(_) => (
+            "Note",
+            "the active backend may not support this operation (i3 does not list outputs)",
+        ),
+        WmError::Ipc(_) => ("Check", "compositor connection (see daemon logs)"),
+    }
+}
 
 const NAME: &str = "wm";
 const SUMMARY: &str = "manage windows and workspaces (focus, move, open, list, workspaces, etc.)";
@@ -155,16 +180,19 @@ async fn handle_focus(wm: &dyn WindowManager, args: &[String]) -> Result<Command
     let class = &args[0];
     match wm.focus(class).await {
         Ok(()) => Ok(CommandOutput::ok(Vec::new())),
-        Err(e) => Ok(CommandOutput::failed(
-            1,
-            error_line(
-                NAME,
-                format_args!("focus '{class}' failed: {e}"),
-                "Use",
-                "wm list to see available windows",
-            )
-            .into_bytes(),
-        )),
+        Err(e) => {
+            let (label, hint) = hint_for(&e);
+            Ok(CommandOutput::failed(
+                1,
+                error_line(
+                    NAME,
+                    format_args!("focus '{class}' failed: {e}"),
+                    label,
+                    hint,
+                )
+                .into_bytes(),
+            ))
+        }
     }
 }
 
@@ -182,16 +210,19 @@ async fn handle_move(wm: &dyn WindowManager, args: &[String]) -> Result<CommandO
     let workspace = &args[1];
     match wm.move_to_workspace(class, workspace).await {
         Ok(()) => Ok(CommandOutput::ok(Vec::new())),
-        Err(e) => Ok(CommandOutput::failed(
-            1,
-            error_line(
-                NAME,
-                format_args!("move '{class}' to '{workspace}' failed: {e}"),
-                "Use",
-                "wm list and wm workspaces to verify both exist",
-            )
-            .into_bytes(),
-        )),
+        Err(e) => {
+            let (label, hint) = hint_for(&e);
+            Ok(CommandOutput::failed(
+                1,
+                error_line(
+                    NAME,
+                    format_args!("move '{class}' to '{workspace}' failed: {e}"),
+                    label,
+                    hint,
+                )
+                .into_bytes(),
+            ))
+        }
     }
 }
 
@@ -246,16 +277,13 @@ async fn handle_active(wm: &dyn WindowManager) -> Result<CommandOutput> {
             Ok(CommandOutput::ok(out))
         }
         Ok(None) => Ok(CommandOutput::ok(Vec::new())),
-        Err(e) => Ok(CommandOutput::failed(
-            1,
-            error_line(
-                NAME,
-                format_args!("active failed: {e}"),
-                "Check",
-                "compositor connection (see daemon logs)",
-            )
-            .into_bytes(),
-        )),
+        Err(e) => {
+            let (label, hint) = hint_for(&e);
+            Ok(CommandOutput::failed(
+                1,
+                error_line(NAME, format_args!("active failed: {e}"), label, hint).into_bytes(),
+            ))
+        }
     }
 }
 
@@ -309,16 +337,19 @@ async fn handle_resize(wm: &dyn WindowManager, args: &[String]) -> Result<Comman
     );
     match wm.run_raw(&payload).await {
         Ok(()) => Ok(CommandOutput::ok(Vec::new())),
-        Err(e) => Ok(CommandOutput::failed(
-            1,
-            error_line(
-                NAME,
-                format_args!("resize '{class}' failed: {e}"),
-                "Use",
-                "wm list to see available windows",
-            )
-            .into_bytes(),
-        )),
+        Err(e) => {
+            let (label, hint) = hint_for(&e);
+            Ok(CommandOutput::failed(
+                1,
+                error_line(
+                    NAME,
+                    format_args!("resize '{class}' failed: {e}"),
+                    label,
+                    hint,
+                )
+                .into_bytes(),
+            ))
+        }
     }
 }
 
@@ -343,16 +374,13 @@ async fn handle_list(wm: &dyn WindowManager) -> Result<CommandOutput> {
             }
             Ok(CommandOutput::ok(out.into_bytes()))
         }
-        Err(e) => Ok(CommandOutput::failed(
-            1,
-            error_line(
-                NAME,
-                format_args!("list failed: {e}"),
-                "Check",
-                "compositor connection (see daemon logs)",
-            )
-            .into_bytes(),
-        )),
+        Err(e) => {
+            let (label, hint) = hint_for(&e);
+            Ok(CommandOutput::failed(
+                1,
+                error_line(NAME, format_args!("list failed: {e}"), label, hint).into_bytes(),
+            ))
+        }
     }
 }
 
@@ -394,16 +422,13 @@ async fn handle_outputs(wm: &dyn WindowManager) -> Result<CommandOutput> {
             }
             Ok(CommandOutput::ok(out.into_bytes()))
         }
-        Err(e) => Ok(CommandOutput::failed(
-            1,
-            error_line(
-                NAME,
-                format_args!("outputs failed: {e}"),
-                "Note",
-                "the active backend may not support output enumeration (i3 does not)",
-            )
-            .into_bytes(),
-        )),
+        Err(e) => {
+            let (label, hint) = hint_for(&e);
+            Ok(CommandOutput::failed(
+                1,
+                error_line(NAME, format_args!("outputs failed: {e}"), label, hint).into_bytes(),
+            ))
+        }
     }
 }
 
@@ -424,16 +449,13 @@ async fn handle_workspaces(wm: &dyn WindowManager) -> Result<CommandOutput> {
             }
             Ok(CommandOutput::ok(out.into_bytes()))
         }
-        Err(e) => Ok(CommandOutput::failed(
-            1,
-            error_line(
-                NAME,
-                format_args!("workspaces failed: {e}"),
-                "Check",
-                "compositor connection (see daemon logs)",
-            )
-            .into_bytes(),
-        )),
+        Err(e) => {
+            let (label, hint) = hint_for(&e);
+            Ok(CommandOutput::failed(
+                1,
+                error_line(NAME, format_args!("workspaces failed: {e}"), label, hint).into_bytes(),
+            ))
+        }
     }
 }
 
@@ -464,23 +486,28 @@ async fn handle_layout(wm: &dyn WindowManager, args: &[String]) -> Result<Comman
     let payload = format!("layout {name}");
     match wm.run_raw(&payload).await {
         Ok(()) => Ok(CommandOutput::ok(Vec::new())),
-        Err(e) => Ok(CommandOutput::failed(
-            1,
-            error_line(
-                NAME,
-                format_args!("layout '{name}' failed: {e}"),
-                "Check",
-                "compositor connection (see daemon logs)",
-            )
-            .into_bytes(),
-        )),
+        Err(e) => {
+            let (label, hint) = hint_for(&e);
+            Ok(CommandOutput::failed(
+                1,
+                error_line(
+                    NAME,
+                    format_args!("layout '{name}' failed: {e}"),
+                    label,
+                    hint,
+                )
+                .into_bytes(),
+            ))
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use assistd_wm::{NoWindowManager, OutputInfo, Window, WindowId, WorkspaceId, WorkspaceInfo};
+    use assistd_wm::{
+        NoWindowManager, OutputInfo, Window, WindowId, WmResult, WorkspaceId, WorkspaceInfo,
+    };
     use std::sync::Mutex;
 
     /// Test fixture for [`WindowManager`]. Records every call so tests
@@ -515,12 +542,21 @@ mod tests {
         }
     }
 
+    /// Wrap a `&Option<String>` as a `WmError::Ipc(anyhow!(msg))`. Tests
+    /// that want to inject a backend failure write `focus_err: Some("…")`;
+    /// without typed variants they used `anyhow::bail!`. The Ipc variant
+    /// preserves the message body (which the tests assert on) and routes
+    /// through the `Check: compositor connection` recovery hint.
+    fn ipc_err(msg: &str) -> WmError {
+        WmError::Ipc(anyhow::anyhow!("{msg}"))
+    }
+
     #[async_trait]
     impl WindowManager for StubWm {
-        async fn focus(&self, window: &WindowId) -> Result<()> {
+        async fn focus(&self, window: &WindowId) -> WmResult<()> {
             self.focus_calls.lock().unwrap().push(window.clone());
             if let Some(msg) = &self.focus_err {
-                anyhow::bail!("{msg}");
+                return Err(ipc_err(msg));
             }
             Ok(())
         }
@@ -528,52 +564,51 @@ mod tests {
             &self,
             window: &WindowId,
             workspace: &WorkspaceId,
-        ) -> Result<()> {
+        ) -> WmResult<()> {
             self.move_calls
                 .lock()
                 .unwrap()
                 .push((window.clone(), workspace.clone()));
             if let Some(msg) = &self.move_err {
-                anyhow::bail!("{msg}");
+                return Err(ipc_err(msg));
             }
             Ok(())
         }
-        async fn focused_window(&self) -> Result<Option<WindowId>> {
+        async fn focused_window(&self) -> WmResult<Option<WindowId>> {
             if let Some(msg) = &self.focused_err {
-                anyhow::bail!("{msg}");
+                return Err(ipc_err(msg));
             }
             Ok(self.focused.clone())
         }
-        async fn list_windows(&self) -> Result<Vec<Window>> {
+        async fn list_windows(&self) -> WmResult<Vec<Window>> {
             if let Some(msg) = &self.list_windows_err {
-                anyhow::bail!("{msg}");
+                return Err(ipc_err(msg));
             }
             Ok(self.windows.clone())
         }
-        async fn list_workspaces(&self) -> Result<Vec<WorkspaceInfo>> {
+        async fn list_workspaces(&self) -> WmResult<Vec<WorkspaceInfo>> {
             if let Some(msg) = &self.list_workspaces_err {
-                anyhow::bail!("{msg}");
+                return Err(ipc_err(msg));
             }
             Ok(self.workspaces.clone())
         }
-        async fn run_raw(&self, payload: &str) -> Result<()> {
+        async fn run_raw(&self, payload: &str) -> WmResult<()> {
             self.raw_calls.lock().unwrap().push(payload.to_string());
             if let Some(msg) = &self.raw_err {
-                anyhow::bail!("{msg}");
+                return Err(ipc_err(msg));
             }
             Ok(())
         }
-        async fn list_outputs(&self) -> Result<Vec<OutputInfo>> {
+        async fn list_outputs(&self) -> WmResult<Vec<OutputInfo>> {
             if self.list_outputs_unsupported {
                 // Mirror the trait default — backends that don't
-                // implement outputs should bubble up a "not supported"
-                // error rather than an empty Vec, so the wm tool can
-                // tell the LLM the difference between a connected
+                // implement outputs return Unsupported so the wm tool
+                // can tell the LLM the difference between a connected
                 // machine with zero monitors and an i3-class backend.
-                anyhow::bail!("backend does not support output enumeration");
+                return Err(WmError::Unsupported("output enumeration"));
             }
             if let Some(msg) = &self.list_outputs_err {
-                anyhow::bail!("{msg}");
+                return Err(ipc_err(msg));
             }
             Ok(self.outputs.clone())
         }
@@ -671,7 +706,50 @@ mod tests {
             stderr.contains("[error] wm: focus 'Firefox' failed"),
             "{stderr}"
         );
-        assert!(stderr.contains("Use:"), "{stderr}");
+        // Backend Ipc errors route through the "Check: compositor
+        // connection" hint — different from the static "Use: wm list"
+        // hint that the pre-WmError handler emitted unconditionally.
+        assert!(stderr.contains("Check:"), "{stderr}");
+    }
+
+    #[test]
+    fn hint_for_disconnected() {
+        let (label, hint) = hint_for(&WmError::Disconnected);
+        assert_eq!(label, "Check");
+        assert!(hint.contains("config.toml"), "{hint}");
+    }
+
+    #[test]
+    fn hint_for_not_found() {
+        let (label, hint) = hint_for(&WmError::NotFound("Firefox".into()));
+        assert_eq!(label, "Use");
+        assert!(hint.contains("wm list"), "{hint}");
+    }
+
+    #[test]
+    fn hint_for_rejected() {
+        let (label, _) = hint_for(&WmError::Rejected("focus: bad criteria".into()));
+        assert_eq!(label, "Try");
+    }
+
+    #[test]
+    fn hint_for_timeout() {
+        let (label, hint) = hint_for(&WmError::Timeout(std::time::Duration::from_secs(5)));
+        assert_eq!(label, "Note");
+        assert!(hint.contains("retry"), "{hint}");
+    }
+
+    #[test]
+    fn hint_for_unsupported() {
+        let (label, hint) = hint_for(&WmError::Unsupported("output enumeration"));
+        assert_eq!(label, "Note");
+        assert!(hint.contains("i3 does not"), "{hint}");
+    }
+
+    #[test]
+    fn hint_for_ipc() {
+        let (label, _) = hint_for(&WmError::Ipc(anyhow::anyhow!("socket dropped")));
+        assert_eq!(label, "Check");
     }
 
     #[tokio::test]

--- a/crates/assistd-tools/src/commands/wm.rs
+++ b/crates/assistd-tools/src/commands/wm.rs
@@ -33,7 +33,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use tokio::process::Command as ProcCommand;
 
-use assistd_wm::{Layout, ResizeDir, WindowManager, WmError};
+use assistd_wm::{Layout, ResizeDir, WindowId, WindowManager, WmError, WorkspaceId};
 
 use crate::command::{Command, CommandInput, CommandOutput, error_line};
 
@@ -176,8 +176,12 @@ async fn handle_focus(wm: &dyn WindowManager, args: &[String]) -> Result<Command
     if args.is_empty() {
         return Ok(help_output(FOCUS_HELP.to_string()));
     }
-    let class = &args[0];
-    match wm.focus(class).await {
+    // PR 3a: arg parsing into WindowId is currently infallible (any
+    // string is a valid id). PR 3b will tighten this to a decimal
+    // con_id parser and reject non-numeric input here.
+    let class_arg = &args[0];
+    let id: WindowId = class_arg.parse().expect("WindowId parser is infallible");
+    match wm.focus(&id).await {
         Ok(()) => Ok(CommandOutput::ok(Vec::new())),
         Err(e) => {
             let (label, hint) = hint_for(&e);
@@ -185,7 +189,7 @@ async fn handle_focus(wm: &dyn WindowManager, args: &[String]) -> Result<Command
                 1,
                 error_line(
                     NAME,
-                    format_args!("focus '{class}' failed: {e}"),
+                    format_args!("focus '{class_arg}' failed: {e}"),
                     label,
                     hint,
                 )
@@ -205,9 +209,13 @@ async fn handle_move(wm: &dyn WindowManager, args: &[String]) -> Result<CommandO
     if args.len() < 2 {
         return Ok(help_output(MOVE_HELP.to_string()));
     }
-    let class = &args[0];
-    let workspace = &args[1];
-    match wm.move_to_workspace(class, workspace).await {
+    let class_arg = &args[0];
+    let workspace_arg = &args[1];
+    let id: WindowId = class_arg.parse().expect("WindowId parser is infallible");
+    let workspace: WorkspaceId = workspace_arg
+        .parse()
+        .expect("WorkspaceId parser is infallible");
+    match wm.move_to_workspace(&id, &workspace).await {
         Ok(()) => Ok(CommandOutput::ok(Vec::new())),
         Err(e) => {
             let (label, hint) = hint_for(&e);
@@ -215,7 +223,7 @@ async fn handle_move(wm: &dyn WindowManager, args: &[String]) -> Result<CommandO
                 1,
                 error_line(
                     NAME,
-                    format_args!("move '{class}' to '{workspace}' failed: {e}"),
+                    format_args!("move '{class_arg}' to '{workspace_arg}' failed: {e}"),
                     label,
                     hint,
                 )
@@ -270,8 +278,8 @@ async fn handle_open(args: &[String]) -> Result<CommandOutput> {
 
 async fn handle_active(wm: &dyn WindowManager) -> Result<CommandOutput> {
     match wm.focused_window().await {
-        Ok(Some(class)) => {
-            let mut out = class.into_bytes();
+        Ok(Some(id)) => {
+            let mut out = String::from(id).into_bytes();
             out.push(b'\n');
             Ok(CommandOutput::ok(out))
         }
@@ -333,7 +341,8 @@ async fn handle_resize(wm: &dyn WindowManager, args: &[String]) -> Result<Comman
             ));
         }
     };
-    match wm.resize_width(class, direction, amount).await {
+    let id: WindowId = class.parse().expect("WindowId parser is infallible");
+    match wm.resize_width(&id, direction, amount).await {
         Ok(()) => Ok(CommandOutput::ok(Vec::new())),
         Err(e) => {
             let (label, hint) = hint_for(&e);
@@ -363,7 +372,7 @@ async fn handle_list(wm: &dyn WindowManager) -> Result<CommandOutput> {
             });
             let mut out = String::new();
             for w in windows {
-                out.push_str(&w.id);
+                out.push_str(w.id.as_str());
                 out.push('\t');
                 out.push_str(w.workspace.as_deref().unwrap_or("-"));
                 out.push('\t');
@@ -707,7 +716,7 @@ mod tests {
         let out = run_wm(stub.clone(), &["focus", "Firefox"]).await;
         assert_eq!(out.exit_code, 0);
         let calls = stub.focus_calls.lock().unwrap();
-        assert_eq!(*calls, vec!["Firefox".to_string()]);
+        assert_eq!(*calls, vec![WindowId::from("Firefox")]);
     }
 
     #[tokio::test]
@@ -783,7 +792,12 @@ mod tests {
         let out = run_wm(stub.clone(), &["move", "Firefox", "3"]).await;
         assert_eq!(out.exit_code, 0);
         let calls = stub.move_calls.lock().unwrap();
-        assert_eq!(*calls, vec![("Firefox".to_string(), "3".to_string())]);
+        // "3" parses as numeric → WorkspaceId::Num(3); the args are
+        // typed all the way through to the backend now.
+        assert_eq!(
+            *calls,
+            vec![(WindowId::from("Firefox"), WorkspaceId::Num(3))]
+        );
     }
 
     #[tokio::test]
@@ -876,7 +890,10 @@ mod tests {
         let out = run_wm(stub.clone(), &["resize", "Firefox", "grow", "50"]).await;
         assert_eq!(out.exit_code, 0);
         let calls = stub.resize_calls.lock().unwrap();
-        assert_eq!(*calls, vec![("Firefox".to_string(), ResizeDir::Grow, 50)]);
+        assert_eq!(
+            *calls,
+            vec![(WindowId::from("Firefox"), ResizeDir::Grow, 50)]
+        );
     }
 
     #[tokio::test]
@@ -890,7 +907,7 @@ mod tests {
         let calls = stub.resize_calls.lock().unwrap();
         assert_eq!(
             *calls,
-            vec![(r#"a"b\c"#.to_string(), ResizeDir::Shrink, 5)]
+            vec![(WindowId::from(r#"a"b\c"#), ResizeDir::Shrink, 5)]
         );
     }
 

--- a/crates/assistd-tools/src/commands/wm.rs
+++ b/crates/assistd-tools/src/commands/wm.rs
@@ -33,8 +33,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use tokio::process::Command as ProcCommand;
 
-use assistd_wm::criteria::escape_for_criteria;
-use assistd_wm::{WindowManager, WmError};
+use assistd_wm::{Layout, ResizeDir, WindowManager, WmError};
 
 use crate::command::{Command, CommandInput, CommandOutput, error_line};
 
@@ -298,19 +297,24 @@ async fn handle_resize(wm: &dyn WindowManager, args: &[String]) -> Result<Comman
         return Ok(help_output(RESIZE_HELP.to_string()));
     }
     let class = &args[0];
-    let direction = args[1].as_str();
-    if direction != "grow" && direction != "shrink" {
-        return Ok(CommandOutput::failed(
-            2,
-            error_line(
-                NAME,
-                format_args!("resize: direction must be 'grow' or 'shrink', got '{direction}'"),
-                "Use",
-                "wm resize <class> <grow|shrink> <px>",
-            )
-            .into_bytes(),
-        ));
-    }
+    let direction: ResizeDir = match args[1].parse() {
+        Ok(d) => d,
+        Err(_) => {
+            return Ok(CommandOutput::failed(
+                2,
+                error_line(
+                    NAME,
+                    format_args!(
+                        "resize: direction must be 'grow' or 'shrink', got '{}'",
+                        args[1]
+                    ),
+                    "Use",
+                    "wm resize <class> <grow|shrink> <px>",
+                )
+                .into_bytes(),
+            ));
+        }
+    };
     let amount: u32 = match args[2].parse() {
         Ok(n) => n,
         Err(_) => {
@@ -329,13 +333,7 @@ async fn handle_resize(wm: &dyn WindowManager, args: &[String]) -> Result<Comman
             ));
         }
     };
-    let payload = format!(
-        r#"[class="{}"] resize {} width {} px or 0 ppt"#,
-        escape_for_criteria(class),
-        direction,
-        amount,
-    );
-    match wm.run_raw(&payload).await {
+    match wm.resize_width(class, direction, amount).await {
         Ok(()) => Ok(CommandOutput::ok(Vec::new())),
         Err(e) => {
             let (label, hint) = hint_for(&e);
@@ -469,22 +467,23 @@ async fn handle_layout(wm: &dyn WindowManager, args: &[String]) -> Result<Comman
     if args.is_empty() {
         return Ok(help_output(LAYOUT_HELP.to_string()));
     }
-    let name = args[0].as_str();
-    let valid = ["default", "tabbed", "stacking", "splith", "splitv"];
-    if !valid.contains(&name) {
-        return Ok(CommandOutput::failed(
-            2,
-            error_line(
-                NAME,
-                format_args!("layout: '{name}' is not a known layout"),
-                "Use",
-                "default | tabbed | stacking | splith | splitv",
-            )
-            .into_bytes(),
-        ));
-    }
-    let payload = format!("layout {name}");
-    match wm.run_raw(&payload).await {
+    let raw = args[0].as_str();
+    let layout: Layout = match raw.parse() {
+        Ok(l) => l,
+        Err(_) => {
+            return Ok(CommandOutput::failed(
+                2,
+                error_line(
+                    NAME,
+                    format_args!("layout: '{raw}' is not a known layout"),
+                    "Use",
+                    "default | tabbed | stacking | splith | splitv",
+                )
+                .into_bytes(),
+            ));
+        }
+    };
+    match wm.set_layout(layout).await {
         Ok(()) => Ok(CommandOutput::ok(Vec::new())),
         Err(e) => {
             let (label, hint) = hint_for(&e);
@@ -492,7 +491,7 @@ async fn handle_layout(wm: &dyn WindowManager, args: &[String]) -> Result<Comman
                 1,
                 error_line(
                     NAME,
-                    format_args!("layout '{name}' failed: {e}"),
+                    format_args!("layout '{layout}' failed: {e}"),
                     label,
                     hint,
                 )
@@ -506,13 +505,15 @@ async fn handle_layout(wm: &dyn WindowManager, args: &[String]) -> Result<Comman
 mod tests {
     use super::*;
     use assistd_wm::{
-        NoWindowManager, OutputInfo, Window, WindowId, WmResult, WorkspaceId, WorkspaceInfo,
+        Layout, NoWindowManager, OutputInfo, ResizeDir, Window, WindowId, WmResult, WorkspaceId,
+        WorkspaceInfo,
     };
     use std::sync::Mutex;
 
     /// Test fixture for [`WindowManager`]. Records every call so tests
-    /// can assert on the i3 payload that would be dispatched, and lets
-    /// each operation be wired to fail with a canned error message.
+    /// can assert on the typed argument tuples that would be dispatched
+    /// to the backend, and lets each operation be wired to fail with a
+    /// canned error message.
     #[derive(Default)]
     struct StubWm {
         connected: bool,
@@ -522,10 +523,12 @@ mod tests {
         focused: Option<WindowId>,
         focus_calls: Mutex<Vec<WindowId>>,
         move_calls: Mutex<Vec<(WindowId, WorkspaceId)>>,
-        raw_calls: Mutex<Vec<String>>,
+        resize_calls: Mutex<Vec<(WindowId, ResizeDir, u32)>>,
+        layout_calls: Mutex<Vec<Layout>>,
         focus_err: Option<String>,
         move_err: Option<String>,
-        raw_err: Option<String>,
+        resize_err: Option<String>,
+        layout_err: Option<String>,
         list_windows_err: Option<String>,
         list_workspaces_err: Option<String>,
         list_outputs_err: Option<String>,
@@ -592,9 +595,24 @@ mod tests {
             }
             Ok(self.workspaces.clone())
         }
-        async fn run_raw(&self, payload: &str) -> WmResult<()> {
-            self.raw_calls.lock().unwrap().push(payload.to_string());
-            if let Some(msg) = &self.raw_err {
+        async fn resize_width(
+            &self,
+            window: &WindowId,
+            direction: ResizeDir,
+            pixels: u32,
+        ) -> WmResult<()> {
+            self.resize_calls
+                .lock()
+                .unwrap()
+                .push((window.clone(), direction, pixels));
+            if let Some(msg) = &self.resize_err {
+                return Err(ipc_err(msg));
+            }
+            Ok(())
+        }
+        async fn set_layout(&self, layout: Layout) -> WmResult<()> {
+            self.layout_calls.lock().unwrap().push(layout);
+            if let Some(msg) = &self.layout_err {
                 return Err(ipc_err(msg));
             }
             Ok(())
@@ -848,25 +866,31 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn resize_dispatches_correct_payload() {
+    async fn resize_dispatches_typed_args() {
+        // wm.rs passes the parsed direction + pixel count to the
+        // backend's typed `resize_width` method. The literal i3-syntax
+        // payload (`[class="…"] resize …`) and its escape semantics are
+        // tested in `assistd_wm::i3::tests` directly — wm.rs no longer
+        // formats the payload itself.
         let stub = Arc::new(StubWm::connected());
         let out = run_wm(stub.clone(), &["resize", "Firefox", "grow", "50"]).await;
         assert_eq!(out.exit_code, 0);
-        let calls = stub.raw_calls.lock().unwrap();
-        assert_eq!(
-            *calls,
-            vec![r#"[class="Firefox"] resize grow width 50 px or 0 ppt"#.to_string()]
-        );
+        let calls = stub.resize_calls.lock().unwrap();
+        assert_eq!(*calls, vec![("Firefox".to_string(), ResizeDir::Grow, 50)]);
     }
 
     #[tokio::test]
-    async fn resize_escapes_special_chars_in_class() {
+    async fn resize_passes_special_chars_unaltered() {
+        // The class arg flows through to the backend without
+        // transformation; backends own the escape step. This guards
+        // against a regression where wm.rs starts pre-escaping
+        // (which would double-escape once the backend escapes again).
         let stub = Arc::new(StubWm::connected());
         let _ = run_wm(stub.clone(), &["resize", r#"a"b\c"#, "shrink", "5"]).await;
-        let calls = stub.raw_calls.lock().unwrap();
+        let calls = stub.resize_calls.lock().unwrap();
         assert_eq!(
             *calls,
-            vec![r#"[class="a\"b\\c"] resize shrink width 5 px or 0 ppt"#.to_string()]
+            vec![(r#"a"b\c"#.to_string(), ResizeDir::Shrink, 5)]
         );
     }
 
@@ -962,12 +986,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn layout_dispatches_payload() {
+    async fn layout_dispatches_typed_arg() {
         let stub = Arc::new(StubWm::connected());
         let out = run_wm(stub.clone(), &["layout", "tabbed"]).await;
         assert_eq!(out.exit_code, 0);
-        let calls = stub.raw_calls.lock().unwrap();
-        assert_eq!(*calls, vec!["layout tabbed".to_string()]);
+        let calls = stub.layout_calls.lock().unwrap();
+        assert_eq!(*calls, vec![Layout::Tabbed]);
     }
 
     #[test]

--- a/crates/assistd-tools/src/commands/wm.rs
+++ b/crates/assistd-tools/src/commands/wm.rs
@@ -89,17 +89,18 @@ impl Command for WmCommand {
         "usage: wm <subcommand> [args...]\n\
          \n\
          Manage windows and workspaces via the active compositor backend \
-         (i3, sway, or hyprland). Window identifiers are X11 classes on \
-         i3 (e.g. \"Firefox\", \"code\") — see `wm list` for the exact \
-         strings to use.\n\
+         (i3, sway, or hyprland). Window identifiers are decimal con_ids \
+         (e.g. \"94567128432192\") — run `wm list` first to find the id \
+         for the window you want to act on; the second column is the \
+         application label.\n\
          \n\
          Subcommands:\n  \
-           focus <class>                          focus the named window\n  \
-           move <class> <workspace>               move window to workspace\n  \
+           focus <id>                             focus the window with this con_id\n  \
+           move <id> <workspace>                  move window to workspace\n  \
            open <app> [args...]                   launch an application\n  \
-           active                                 class of the focused window\n  \
-           resize <class> <grow|shrink> <px>      width-only resize\n  \
-           list                                   TSV: class, workspace, title\n  \
+           active                                 TSV: id, app of the focused window\n  \
+           resize <id> <grow|shrink> <px>         width-only resize\n  \
+           list                                   TSV: id, app, workspace, title\n  \
            workspaces                             TSV: num, name, focused, output\n  \
            outputs                                TSV: name, active, primary, mode, scale, focused_workspace\n  \
            layout <default|tabbed|stacking|splith|splitv>\n                                          \
@@ -167,20 +168,21 @@ fn help_output(text: String) -> CommandOutput {
 
 // --------- subcommand handlers ---------
 
-const FOCUS_HELP: &str = "usage: wm focus <class>\n\
+const FOCUS_HELP: &str = "usage: wm focus <id>\n\
     \n\
-    Focus the window with the given class. Use `wm list` to see \
-    available windows.\n";
+    Focus the window with the given decimal con_id. Run `wm list` \
+    first to find ids — the first column is the id, the second is \
+    the application label.\n";
 
 async fn handle_focus(wm: &dyn WindowManager, args: &[String]) -> Result<CommandOutput> {
     if args.is_empty() {
         return Ok(help_output(FOCUS_HELP.to_string()));
     }
-    // PR 3a: arg parsing into WindowId is currently infallible (any
-    // string is a valid id). PR 3b will tighten this to a decimal
-    // con_id parser and reject non-numeric input here.
-    let class_arg = &args[0];
-    let id: WindowId = class_arg.parse().expect("WindowId parser is infallible");
+    let id_arg = &args[0];
+    let id: WindowId = match id_arg.parse() {
+        Ok(i) => i,
+        Err(_) => return Ok(parse_id_error("focus", id_arg)),
+    };
     match wm.focus(&id).await {
         Ok(()) => Ok(CommandOutput::ok(Vec::new())),
         Err(e) => {
@@ -189,7 +191,7 @@ async fn handle_focus(wm: &dyn WindowManager, args: &[String]) -> Result<Command
                 1,
                 error_line(
                     NAME,
-                    format_args!("focus '{class_arg}' failed: {e}"),
+                    format_args!("focus {id_arg} failed: {e}"),
                     label,
                     hint,
                 )
@@ -199,9 +201,25 @@ async fn handle_focus(wm: &dyn WindowManager, args: &[String]) -> Result<Command
     }
 }
 
-const MOVE_HELP: &str = "usage: wm move <class> <workspace>\n\
+/// Render the `[error] wm: <op>: …` line for "user passed a non-numeric
+/// or non-positive id". Centralized so focus / move / resize stay in
+/// sync. Exit code 2 mirrors the validation errors elsewhere in `wm`.
+fn parse_id_error(op: &'static str, raw: &str) -> CommandOutput {
+    CommandOutput::failed(
+        2,
+        error_line(
+            NAME,
+            format_args!("{op}: '{raw}' is not a valid window id (positive decimal con_id)"),
+            "Use",
+            "wm list to see ids — first TSV column",
+        )
+        .into_bytes(),
+    )
+}
+
+const MOVE_HELP: &str = "usage: wm move <id> <workspace>\n\
     \n\
-    Move the window with the given class to the named workspace. \
+    Move the window with the given con_id to the named workspace. \
     Numeric workspace identifiers (e.g. `3`) match by number; \
     non-numeric identifiers match by exact name.\n";
 
@@ -209,9 +227,12 @@ async fn handle_move(wm: &dyn WindowManager, args: &[String]) -> Result<CommandO
     if args.len() < 2 {
         return Ok(help_output(MOVE_HELP.to_string()));
     }
-    let class_arg = &args[0];
+    let id_arg = &args[0];
     let workspace_arg = &args[1];
-    let id: WindowId = class_arg.parse().expect("WindowId parser is infallible");
+    let id: WindowId = match id_arg.parse() {
+        Ok(i) => i,
+        Err(_) => return Ok(parse_id_error("move", id_arg)),
+    };
     let workspace: WorkspaceId = workspace_arg
         .parse()
         .expect("WorkspaceId parser is infallible");
@@ -223,7 +244,7 @@ async fn handle_move(wm: &dyn WindowManager, args: &[String]) -> Result<CommandO
                 1,
                 error_line(
                     NAME,
-                    format_args!("move '{class_arg}' to '{workspace_arg}' failed: {e}"),
+                    format_args!("move {id_arg} to '{workspace_arg}' failed: {e}"),
                     label,
                     hint,
                 )
@@ -277,11 +298,19 @@ async fn handle_open(args: &[String]) -> Result<CommandOutput> {
 }
 
 async fn handle_active(wm: &dyn WindowManager) -> Result<CommandOutput> {
-    match wm.focused_window().await {
-        Ok(Some(id)) => {
-            let mut out = String::from(id).into_bytes();
-            out.push(b'\n');
-            Ok(CommandOutput::ok(out))
+    // Use focused_context (one snapshot read) so the LLM gets both the
+    // con_id (column 1, pipe-able to `wm focus`) and the human label
+    // (column 2, used to disambiguate id collisions when reading).
+    match wm.focused_context().await {
+        Ok(Some(ctx)) => {
+            let id_str = match ctx.id {
+                Some(i) => i.to_string(),
+                None => "-".into(),
+            };
+            let app = ctx.class.as_deref().unwrap_or("-");
+            Ok(CommandOutput::ok(
+                format!("{id_str}\t{app}\n").into_bytes(),
+            ))
         }
         Ok(None) => Ok(CommandOutput::ok(Vec::new())),
         Err(e) => {
@@ -294,7 +323,7 @@ async fn handle_active(wm: &dyn WindowManager) -> Result<CommandOutput> {
     }
 }
 
-const RESIZE_HELP: &str = "usage: wm resize <class> <grow|shrink> <px>\n\
+const RESIZE_HELP: &str = "usage: wm resize <id> <grow|shrink> <px>\n\
     \n\
     Resize the named window's width by the given pixel amount. \
     Direction is one of `grow` or `shrink`; <px> is a non-negative \
@@ -304,7 +333,11 @@ async fn handle_resize(wm: &dyn WindowManager, args: &[String]) -> Result<Comman
     if args.len() < 3 {
         return Ok(help_output(RESIZE_HELP.to_string()));
     }
-    let class = &args[0];
+    let id_arg = &args[0];
+    let id: WindowId = match id_arg.parse() {
+        Ok(i) => i,
+        Err(_) => return Ok(parse_id_error("resize", id_arg)),
+    };
     let direction: ResizeDir = match args[1].parse() {
         Ok(d) => d,
         Err(_) => {
@@ -317,7 +350,7 @@ async fn handle_resize(wm: &dyn WindowManager, args: &[String]) -> Result<Comman
                         args[1]
                     ),
                     "Use",
-                    "wm resize <class> <grow|shrink> <px>",
+                    "wm resize <id> <grow|shrink> <px>",
                 )
                 .into_bytes(),
             ));
@@ -335,13 +368,12 @@ async fn handle_resize(wm: &dyn WindowManager, args: &[String]) -> Result<Comman
                         args[2]
                     ),
                     "Use",
-                    "wm resize <class> <grow|shrink> <px>",
+                    "wm resize <id> <grow|shrink> <px>",
                 )
                 .into_bytes(),
             ));
         }
     };
-    let id: WindowId = class.parse().expect("WindowId parser is infallible");
     match wm.resize_width(&id, direction, amount).await {
         Ok(()) => Ok(CommandOutput::ok(Vec::new())),
         Err(e) => {
@@ -350,7 +382,7 @@ async fn handle_resize(wm: &dyn WindowManager, args: &[String]) -> Result<Comman
                 1,
                 error_line(
                     NAME,
-                    format_args!("resize '{class}' failed: {e}"),
+                    format_args!("resize {id_arg} failed: {e}"),
                     label,
                     hint,
                 )
@@ -361,18 +393,31 @@ async fn handle_resize(wm: &dyn WindowManager, args: &[String]) -> Result<Comman
 }
 
 async fn handle_list(wm: &dyn WindowManager) -> Result<CommandOutput> {
+    use std::fmt::Write;
     match wm.list_windows().await {
         Ok(mut windows) => {
+            // Group by workspace (ascending lexicographic), then by app
+            // label so two windows of the same app sit together. The
+            // LLM scans this list to find an id by app+title, so
+            // proximity matters more than chronological order.
             windows.sort_by(|a, b| {
                 a.workspace
                     .as_deref()
                     .unwrap_or("")
                     .cmp(b.workspace.as_deref().unwrap_or(""))
+                    .then_with(|| {
+                        a.app
+                            .as_deref()
+                            .unwrap_or("")
+                            .cmp(b.app.as_deref().unwrap_or(""))
+                    })
                     .then_with(|| a.id.cmp(&b.id))
             });
             let mut out = String::new();
             for w in windows {
-                out.push_str(w.id.as_str());
+                let _ = write!(&mut out, "{}", w.id);
+                out.push('\t');
+                out.push_str(w.app.as_deref().unwrap_or("-"));
                 out.push('\t');
                 out.push_str(w.workspace.as_deref().unwrap_or("-"));
                 out.push('\t');
@@ -514,10 +559,16 @@ async fn handle_layout(wm: &dyn WindowManager, args: &[String]) -> Result<Comman
 mod tests {
     use super::*;
     use assistd_wm::{
-        Layout, NoWindowManager, OutputInfo, ResizeDir, Window, WindowId, WmResult, WorkspaceId,
-        WorkspaceInfo,
+        FocusedWindowContext, Layout, NoWindowManager, OutputInfo, ResizeDir, Window, WindowId,
+        WmResult, WorkspaceId, WorkspaceInfo,
     };
     use std::sync::Mutex;
+
+    /// Test-only id constructor — every fixture id is non-zero by
+    /// construction, so this `expect` is unreachable at runtime.
+    fn id(n: u64) -> WindowId {
+        WindowId::new(n).expect("test ids are non-zero")
+    }
 
     /// Test fixture for [`WindowManager`]. Records every call so tests
     /// can assert on the typed argument tuples that would be dispatched
@@ -530,6 +581,10 @@ mod tests {
         workspaces: Vec<WorkspaceInfo>,
         outputs: Vec<OutputInfo>,
         focused: Option<WindowId>,
+        /// Human-readable label of the focused window — surfaced via
+        /// `focused_context().class`. Independent of `focused` so tests
+        /// can exercise "id present but app unknown" code paths.
+        focused_app: Option<String>,
         focus_calls: Mutex<Vec<WindowId>>,
         move_calls: Mutex<Vec<(WindowId, WorkspaceId)>>,
         resize_calls: Mutex<Vec<(WindowId, ResizeDir, u32)>>,
@@ -566,7 +621,7 @@ mod tests {
     #[async_trait]
     impl WindowManager for StubWm {
         async fn focus(&self, window: &WindowId) -> WmResult<()> {
-            self.focus_calls.lock().unwrap().push(window.clone());
+            self.focus_calls.lock().unwrap().push(*window);
             if let Some(msg) = &self.focus_err {
                 return Err(ipc_err(msg));
             }
@@ -580,7 +635,7 @@ mod tests {
             self.move_calls
                 .lock()
                 .unwrap()
-                .push((window.clone(), workspace.clone()));
+                .push((*window, workspace.clone()));
             if let Some(msg) = &self.move_err {
                 return Err(ipc_err(msg));
             }
@@ -590,7 +645,21 @@ mod tests {
             if let Some(msg) = &self.focused_err {
                 return Err(ipc_err(msg));
             }
-            Ok(self.focused.clone())
+            Ok(self.focused)
+        }
+        async fn focused_context(&self) -> WmResult<Option<FocusedWindowContext>> {
+            if let Some(msg) = &self.focused_err {
+                return Err(ipc_err(msg));
+            }
+            if self.focused.is_none() && self.focused_app.is_none() {
+                return Ok(None);
+            }
+            Ok(Some(FocusedWindowContext {
+                id: self.focused,
+                class: self.focused_app.clone(),
+                title: None,
+                workspace: None,
+            }))
         }
         async fn list_windows(&self) -> WmResult<Vec<Window>> {
             if let Some(msg) = &self.list_windows_err {
@@ -613,7 +682,7 @@ mod tests {
             self.resize_calls
                 .lock()
                 .unwrap()
-                .push((window.clone(), direction, pixels));
+                .push((*window, direction, pixels));
             if let Some(msg) = &self.resize_err {
                 return Err(ipc_err(msg));
             }
@@ -694,7 +763,7 @@ mod tests {
         // Ensures the production `NoWindowManager` produces the same
         // behavior as the StubWm disconnected path — this is the gate
         // for the "mock mode" acceptance criterion.
-        let out = run_wm(Arc::new(NoWindowManager), &["focus", "Firefox"]).await;
+        let out = run_wm(Arc::new(NoWindowManager), &["focus", "42"]).await;
         assert_eq!(out.exit_code, 1);
         let stderr = String::from_utf8_lossy(&out.stderr);
         assert!(
@@ -711,12 +780,26 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn focus_calls_backend_with_class() {
+    async fn focus_calls_backend_with_id() {
         let stub = Arc::new(StubWm::connected());
-        let out = run_wm(stub.clone(), &["focus", "Firefox"]).await;
+        let out = run_wm(stub.clone(), &["focus", "42"]).await;
         assert_eq!(out.exit_code, 0);
         let calls = stub.focus_calls.lock().unwrap();
-        assert_eq!(*calls, vec![WindowId::from("Firefox")]);
+        assert_eq!(*calls, vec![id(42)]);
+    }
+
+    #[tokio::test]
+    async fn focus_rejects_non_numeric_arg() {
+        // PR 3b: the LLM must use `wm list` to get a numeric con_id;
+        // passing the X11 class (the old PR 3a behavior) is now an
+        // explicit error.
+        let stub = Arc::new(StubWm::connected());
+        let out = run_wm(stub.clone(), &["focus", "Firefox"]).await;
+        assert_eq!(out.exit_code, 2);
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(stderr.contains("not a valid window id"), "{stderr}");
+        assert!(stderr.contains("wm list"), "{stderr}");
+        assert!(stub.focus_calls.lock().unwrap().is_empty());
     }
 
     #[tokio::test]
@@ -726,13 +809,10 @@ mod tests {
             focus_err: Some("i3 socket dropped".into()),
             ..Default::default()
         });
-        let out = run_wm(stub, &["focus", "Firefox"]).await;
+        let out = run_wm(stub, &["focus", "42"]).await;
         assert_eq!(out.exit_code, 1);
         let stderr = String::from_utf8_lossy(&out.stderr);
-        assert!(
-            stderr.contains("[error] wm: focus 'Firefox' failed"),
-            "{stderr}"
-        );
+        assert!(stderr.contains("[error] wm: focus 42 failed"), "{stderr}");
         // Backend Ipc errors route through the "Check: compositor
         // connection" hint — different from the static "Use: wm list"
         // hint that the pre-WmError handler emitted unconditionally.
@@ -748,7 +828,7 @@ mod tests {
 
     #[test]
     fn hint_for_not_found() {
-        let (label, hint) = hint_for(&WmError::NotFound("Firefox".into()));
+        let (label, hint) = hint_for(&WmError::NotFound(id(42)));
         assert_eq!(label, "Use");
         assert!(hint.contains("wm list"), "{hint}");
     }
@@ -781,7 +861,7 @@ mod tests {
 
     #[tokio::test]
     async fn move_needs_two_args() {
-        let out = run_wm(Arc::new(StubWm::connected()), &["move", "Firefox"]).await;
+        let out = run_wm(Arc::new(StubWm::connected()), &["move", "42"]).await;
         assert_eq!(out.exit_code, 2);
         assert!(String::from_utf8_lossy(&out.stdout).contains("usage: wm move"));
     }
@@ -789,15 +869,22 @@ mod tests {
     #[tokio::test]
     async fn move_calls_backend() {
         let stub = Arc::new(StubWm::connected());
-        let out = run_wm(stub.clone(), &["move", "Firefox", "3"]).await;
+        let out = run_wm(stub.clone(), &["move", "42", "3"]).await;
         assert_eq!(out.exit_code, 0);
         let calls = stub.move_calls.lock().unwrap();
         // "3" parses as numeric → WorkspaceId::Num(3); the args are
         // typed all the way through to the backend now.
-        assert_eq!(
-            *calls,
-            vec![(WindowId::from("Firefox"), WorkspaceId::Num(3))]
-        );
+        assert_eq!(*calls, vec![(id(42), WorkspaceId::Num(3))]);
+    }
+
+    #[tokio::test]
+    async fn move_rejects_non_numeric_id() {
+        let stub = Arc::new(StubWm::connected());
+        let out = run_wm(stub.clone(), &["move", "Firefox", "3"]).await;
+        assert_eq!(out.exit_code, 2);
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(stderr.contains("not a valid window id"), "{stderr}");
+        assert!(stub.move_calls.lock().unwrap().is_empty());
     }
 
     #[tokio::test]
@@ -824,15 +911,32 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn active_prints_focused_class() {
+    async fn active_prints_id_tab_app() {
+        // wm active emits `<id>\t<app>\n` so the LLM can pipe either
+        // column: `wm focus $(wm active | cut -f1)` or read the app
+        // label from column 2 to confirm what's focused.
         let stub = Arc::new(StubWm {
             connected: true,
-            focused: Some("Firefox".into()),
+            focused: Some(id(42)),
+            focused_app: Some("Firefox".into()),
             ..Default::default()
         });
         let out = run_wm(stub, &["active"]).await;
         assert_eq!(out.exit_code, 0);
-        assert_eq!(out.stdout, b"Firefox\n");
+        assert_eq!(out.stdout, b"42\tFirefox\n");
+    }
+
+    #[tokio::test]
+    async fn active_renders_dash_when_app_missing() {
+        let stub = Arc::new(StubWm {
+            connected: true,
+            focused: Some(id(7)),
+            focused_app: None,
+            ..Default::default()
+        });
+        let out = run_wm(stub, &["active"]).await;
+        assert_eq!(out.exit_code, 0);
+        assert_eq!(out.stdout, b"7\t-\n");
     }
 
     #[tokio::test]
@@ -845,11 +949,7 @@ mod tests {
 
     #[tokio::test]
     async fn resize_too_few_args_returns_help() {
-        let out = run_wm(
-            Arc::new(StubWm::connected()),
-            &["resize", "Firefox", "grow"],
-        )
-        .await;
+        let out = run_wm(Arc::new(StubWm::connected()), &["resize", "42", "grow"]).await;
         assert_eq!(out.exit_code, 2);
         assert!(String::from_utf8_lossy(&out.stdout).contains("usage: wm resize"));
     }
@@ -858,7 +958,7 @@ mod tests {
     async fn resize_bad_direction_errors() {
         let out = run_wm(
             Arc::new(StubWm::connected()),
-            &["resize", "Firefox", "sideways", "10"],
+            &["resize", "42", "sideways", "10"],
         )
         .await;
         assert_eq!(out.exit_code, 2);
@@ -871,7 +971,7 @@ mod tests {
     async fn resize_bad_pixel_count_errors() {
         let out = run_wm(
             Arc::new(StubWm::connected()),
-            &["resize", "Firefox", "grow", "lots"],
+            &["resize", "42", "grow", "lots"],
         )
         .await;
         assert_eq!(out.exit_code, 2);
@@ -882,52 +982,49 @@ mod tests {
     #[tokio::test]
     async fn resize_dispatches_typed_args() {
         // wm.rs passes the parsed direction + pixel count to the
-        // backend's typed `resize_width` method. The literal i3-syntax
-        // payload (`[class="…"] resize …`) and its escape semantics are
-        // tested in `assistd_wm::i3::tests` directly — wm.rs no longer
-        // formats the payload itself.
+        // backend's typed `resize_width` method. The literal con_id
+        // payload (`[con_id="…"] resize …`) is tested in
+        // `assistd_wm::i3::tests` / `sway::tests` directly.
         let stub = Arc::new(StubWm::connected());
-        let out = run_wm(stub.clone(), &["resize", "Firefox", "grow", "50"]).await;
+        let out = run_wm(stub.clone(), &["resize", "42", "grow", "50"]).await;
         assert_eq!(out.exit_code, 0);
         let calls = stub.resize_calls.lock().unwrap();
-        assert_eq!(
-            *calls,
-            vec![(WindowId::from("Firefox"), ResizeDir::Grow, 50)]
-        );
+        assert_eq!(*calls, vec![(id(42), ResizeDir::Grow, 50)]);
     }
 
     #[tokio::test]
-    async fn resize_passes_special_chars_unaltered() {
-        // The class arg flows through to the backend without
-        // transformation; backends own the escape step. This guards
-        // against a regression where wm.rs starts pre-escaping
-        // (which would double-escape once the backend escapes again).
+    async fn resize_rejects_non_numeric_id() {
         let stub = Arc::new(StubWm::connected());
-        let _ = run_wm(stub.clone(), &["resize", r#"a"b\c"#, "shrink", "5"]).await;
-        let calls = stub.resize_calls.lock().unwrap();
-        assert_eq!(
-            *calls,
-            vec![(WindowId::from(r#"a"b\c"#), ResizeDir::Shrink, 5)]
-        );
+        let out = run_wm(stub.clone(), &["resize", "Firefox", "grow", "5"]).await;
+        assert_eq!(out.exit_code, 2);
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(stderr.contains("not a valid window id"), "{stderr}");
+        assert!(stub.resize_calls.lock().unwrap().is_empty());
     }
 
     #[tokio::test]
-    async fn list_emits_tsv_sorted_by_workspace_then_class() {
+    async fn list_emits_tsv_sorted_by_workspace_then_app() {
+        // PR 3b list format: `<id>\t<app>\t<workspace>\t<title>`.
+        // Sorted by workspace, then app, then id — so two Firefox
+        // windows on the same workspace sit together.
         let stub = Arc::new(StubWm {
             connected: true,
             windows: vec![
                 Window {
-                    id: "Firefox".into(),
+                    id: id(1001),
+                    app: Some("Firefox".into()),
                     title: Some("GitHub".into()),
                     workspace: Some("3".into()),
                 },
                 Window {
-                    id: "code".into(),
+                    id: id(1002),
+                    app: Some("code".into()),
                     title: Some("wm.rs".into()),
                     workspace: Some("1".into()),
                 },
                 Window {
-                    id: "Alacritty".into(),
+                    id: id(1003),
+                    app: Some("Alacritty".into()),
                     title: None,
                     workspace: Some("1".into()),
                 },
@@ -938,16 +1035,17 @@ mod tests {
         assert_eq!(out.exit_code, 0);
         assert_eq!(
             String::from_utf8_lossy(&out.stdout),
-            "Alacritty\t1\t\ncode\t1\twm.rs\nFirefox\t3\tGitHub\n"
+            "1003\tAlacritty\t1\t\n1002\tcode\t1\twm.rs\n1001\tFirefox\t3\tGitHub\n"
         );
     }
 
     #[tokio::test]
-    async fn list_orphans_use_dash_for_workspace() {
+    async fn list_orphans_use_dash_for_missing_columns() {
         let stub = Arc::new(StubWm {
             connected: true,
             windows: vec![Window {
-                id: "Scratch".into(),
+                id: id(7),
+                app: None,
                 title: Some("notes".into()),
                 workspace: None,
             }],
@@ -955,7 +1053,7 @@ mod tests {
         });
         let out = run_wm(stub, &["list"]).await;
         assert_eq!(out.exit_code, 0);
-        assert_eq!(out.stdout, b"Scratch\t-\tnotes\n");
+        assert_eq!(out.stdout, b"7\t-\t-\tnotes\n");
     }
 
     #[tokio::test]

--- a/crates/assistd-wm/Cargo.toml
+++ b/crates/assistd-wm/Cargo.toml
@@ -4,14 +4,24 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[features]
+# Both backends ship by default so a fresh `cargo build` Just Works on
+# the developer's machine. Downstream packagers / niche-target builds
+# can opt out with `--no-default-features --features i3` (or sway).
+# Hyprland is a placeholder — the backend is not yet implemented.
+default = ["i3", "sway"]
+i3 = ["dep:tokio-i3ipc"]
+sway = ["dep:swayipc-async"]
+hyprland = []
+
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 futures-util = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["macros", "rt", "sync"] }
-tokio-i3ipc = { workspace = true }
-swayipc-async = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt", "sync", "time"] }
+tokio-i3ipc = { workspace = true, optional = true }
+swayipc-async = { workspace = true, optional = true }
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/crates/assistd-wm/Cargo.toml
+++ b/crates/assistd-wm/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 futures-util = { workspace = true }
+thiserror = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt", "sync"] }
 tokio-i3ipc = { workspace = true }
 swayipc-async = { workspace = true }

--- a/crates/assistd-wm/src/backoff.rs
+++ b/crates/assistd-wm/src/backoff.rs
@@ -1,0 +1,41 @@
+//! Exponential backoff for the WM-backend reconnection supervisor.
+//!
+//! The shape is `2^attempt` seconds, capped at 60s — same schedule as
+//! `assistd_embed::server::backoff` so both subsystems hit the same
+//! patience budget when their underlying daemon (llama-server / i3 /
+//! sway) churns. Duplicated here intentionally: pulling 12 lines into
+//! a separate workspace crate would cost more in plumbing than it
+//! saves in DRY.
+
+use std::time::Duration;
+
+/// Exponential backoff schedule: `2^attempt` seconds, capped at 60s.
+/// `attempt = 0` is the first retry — i.e. 1s after the first failure.
+pub fn backoff_delay(attempt: u32) -> Duration {
+    const CAP_SECS: u64 = 60;
+    let secs = 1u64.checked_shl(attempt).unwrap_or(CAP_SECS).min(CAP_SECS);
+    Duration::from_secs(secs)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn matches_spec_sequence() {
+        let expected = [1, 2, 4, 8, 16, 32, 60, 60, 60, 60];
+        for (i, want) in expected.iter().enumerate() {
+            assert_eq!(
+                backoff_delay(i as u32),
+                Duration::from_secs(*want),
+                "attempt {i}"
+            );
+        }
+    }
+
+    #[test]
+    fn caps_at_sixty_seconds_for_large_attempts() {
+        assert_eq!(backoff_delay(64), Duration::from_secs(60));
+        assert_eq!(backoff_delay(u32::MAX), Duration::from_secs(60));
+    }
+}

--- a/crates/assistd-wm/src/criteria.rs
+++ b/crates/assistd-wm/src/criteria.rs
@@ -15,12 +15,12 @@ pub fn escape_for_criteria(s: &str) -> String {
 }
 
 /// Numeric workspace IDs become `workspace number N` (robust to renames);
-/// non-numeric become `workspace "<escaped name>"`.
+/// named workspaces become `workspace "<escaped name>"`. The enum
+/// variant carries the choice — no parse round-trip on every call.
 pub fn format_workspace_target(ws: &WorkspaceId) -> String {
-    if let Ok(n) = ws.parse::<u32>() {
-        format!("workspace number {n}")
-    } else {
-        format!(r#"workspace "{}""#, escape_for_criteria(ws))
+    match ws {
+        WorkspaceId::Num(n) => format!("workspace number {n}"),
+        WorkspaceId::Name(s) => format!(r#"workspace "{}""#, escape_for_criteria(s)),
     }
 }
 
@@ -40,14 +40,20 @@ mod tests {
 
     #[test]
     fn format_workspace_target_numeric() {
-        assert_eq!(format_workspace_target(&"3".into()), "workspace number 3");
-        assert_eq!(format_workspace_target(&"10".into()), "workspace number 10");
+        assert_eq!(
+            format_workspace_target(&WorkspaceId::Num(3)),
+            "workspace number 3"
+        );
+        assert_eq!(
+            format_workspace_target(&WorkspaceId::Num(10)),
+            "workspace number 10"
+        );
     }
 
     #[test]
     fn format_workspace_target_named() {
         assert_eq!(
-            format_workspace_target(&"scratch".into()),
+            format_workspace_target(&WorkspaceId::name("scratch")),
             r#"workspace "scratch""#
         );
     }
@@ -55,16 +61,27 @@ mod tests {
     #[test]
     fn format_workspace_target_named_with_quote_is_escaped() {
         assert_eq!(
-            format_workspace_target(&r#"weird"name"#.into()),
+            format_workspace_target(&WorkspaceId::name(r#"weird"name"#)),
             r#"workspace "weird\"name""#
         );
     }
 
     #[test]
-    fn format_workspace_target_u32_parseable_is_numeric() {
-        // Any string that parses as `u32` becomes `workspace number N`,
-        // including zero-padded variants — `"03"` → `workspace number 3`.
-        // i3 normalizes the number, so the semantics match.
-        assert_eq!(format_workspace_target(&"03".into()), "workspace number 3");
+    fn workspace_id_parse_or_name() {
+        // Parse-or-name preserves the prior alias semantics: digits
+        // round-trip through u32 → Num, everything else → Name.
+        // Zero-padded numbers normalize: "03" parses to 3.
+        assert_eq!("3".parse::<WorkspaceId>().unwrap(), WorkspaceId::Num(3));
+        assert_eq!("03".parse::<WorkspaceId>().unwrap(), WorkspaceId::Num(3));
+        assert_eq!(
+            "scratch".parse::<WorkspaceId>().unwrap(),
+            WorkspaceId::Name("scratch".into())
+        );
+        // "1:web" doesn't parse as u32 → Named (this matches the old
+        // alias because i3 itself treats it as a name).
+        assert_eq!(
+            "1:web".parse::<WorkspaceId>().unwrap(),
+            WorkspaceId::Name("1:web".into())
+        );
     }
 }

--- a/crates/assistd-wm/src/error.rs
+++ b/crates/assistd-wm/src/error.rs
@@ -1,0 +1,72 @@
+//! Typed error for the [`WindowManager`](crate::WindowManager) trait.
+//!
+//! The trait used to return `anyhow::Result<T>` for every method, which
+//! collapses every failure mode into one opaque string at the call site.
+//! [`crate::commands::wm::WmCommand`]-class consumers can't pick a useful
+//! recovery hint from that ("compositor not connected" wants a different
+//! message than "window 17 not found"). [`WmError`] keeps the variants
+//! distinguishable while still letting backends propagate underlying
+//! `anyhow::Error`s through `?` via the [`From<anyhow::Error>`] impl
+//! provided by `#[error(transparent)]`.
+
+use std::fmt::Display;
+use std::time::Duration;
+
+use crate::WindowId;
+
+/// Errors produced by [`WindowManager`](crate::WindowManager) methods.
+///
+/// The `Ipc` variant is the catch-all for unexpected backend errors;
+/// prefer the typed variants when the caller can act on them differently
+/// (a `Disconnected` is recoverable by waiting for reconnect, a
+/// `NotFound` means the LLM should re-run `wm list`, …).
+#[derive(thiserror::Error, Debug)]
+pub enum WmError {
+    /// The backend is not currently connected to a compositor. Either no
+    /// backend was configured (`NoWindowManager`), the initial connect
+    /// failed, or a previously-connected backend's reconnection
+    /// supervisor (PR 5) is mid-backoff.
+    #[error("compositor IPC disconnected")]
+    Disconnected,
+
+    /// The requested window doesn't exist (or no longer exists). Holds
+    /// the id we attempted to act on so the caller can include it in
+    /// the recovery hint.
+    #[error("window {0:?} not found")]
+    NotFound(WindowId),
+
+    /// The compositor accepted the IPC frame but rejected the command
+    /// itself (e.g. i3's per-result `success: false` reply).
+    #[error("compositor rejected command: {0}")]
+    Rejected(String),
+
+    /// An IPC call did not complete within the configured timeout.
+    /// Consumers should retry once, then assume `Disconnected`.
+    #[error("IPC timed out after {0:?}")]
+    Timeout(Duration),
+
+    /// The active backend doesn't implement this operation (e.g. i3 has
+    /// no rich `GET_OUTPUTS` reply, so [`crate::WindowManager::list_outputs`]
+    /// surfaces this variant). The string names the operation so the
+    /// caller can render a precise message.
+    #[error("backend does not support {0}")]
+    Unsupported(&'static str),
+
+    /// Catch-all for unexpected backend errors. Wraps an [`anyhow::Error`]
+    /// so backends can keep using `?` and `.context(...)` over their
+    /// underlying `io::Result` / library errors.
+    #[error(transparent)]
+    Ipc(#[from] anyhow::Error),
+}
+
+/// Convenience `Result` alias used by every [`WindowManager`](crate::WindowManager)
+/// method.
+pub type WmResult<T> = std::result::Result<T, WmError>;
+
+/// Wrap a foreign error (typically `io::Error` from `tokio-i3ipc` or a
+/// `swayipc::Error` Display impl) with a human-readable context string,
+/// producing a [`WmError::Ipc`]. Saves backends from repeating
+/// `anyhow::anyhow!("...: {e}")` everywhere.
+pub fn ipc_ctx<E: Display>(err: E, ctx: &'static str) -> WmError {
+    WmError::Ipc(anyhow::anyhow!("{ctx}: {err}"))
+}

--- a/crates/assistd-wm/src/i3.rs
+++ b/crates/assistd-wm/src/i3.rs
@@ -23,28 +23,18 @@ use tokio_i3ipc::{
 
 use crate::criteria::format_workspace_target;
 use crate::error::ipc_ctx;
+use crate::snapshot::{
+    self, Snapshot, WindowChangeKind, apply_window_event, apply_workspace_focus,
+};
 use crate::{
     FocusedWindowContext, Layout, ResizeDir, WindowId, WindowManager, WmError, WmResult, Window,
     WorkspaceId, WorkspaceInfo,
 };
 
-/// Cached focus state. Seeded from `get_tree()` + `get_workspaces()`
-/// at startup, then updated by the event task on each `Window::Focus`,
-/// `Window::Title`, `Window::Close`, and `Workspace::Focus` event so
-/// the synchronous reads in [`I3Backend::focused_window`] and
-/// [`I3Backend::focused_context`] hit memory rather than IPC.
-///
-/// PR 3b stores both the compositor con_id (the [`WindowId`] returned
-/// to callers) and the raw X11 class string (used for the system-prompt
-/// context block). The id is what changes on every `Focus` event; the
-/// class is what the model sees when it asks "what app is in front".
-#[derive(Default, Clone)]
-struct Snapshot {
-    focused_id: Option<WindowId>,
-    focused_class: Option<String>,
-    focused_title: Option<String>,
-    active_workspace: Option<String>,
-}
+// PR 4: the Snapshot struct + apply-event race rules now live in
+// `crate::snapshot` so the i3 and Sway backends share them. This file
+// only owns the i3-specific connection plumbing and reply-to-snapshot
+// projection.
 
 /// `WindowManager` impl wrapping a single i3 IPC command socket.
 /// Held inside `Arc<dyn WindowManager>` by the daemon's `AppState`.
@@ -122,7 +112,7 @@ impl I3Backend {
                                         .current
                                         .as_ref()
                                         .and_then(|n| n.name.clone());
-                                    snap_for_task.write().await.active_workspace = ws;
+                                    apply_workspace_focus(&snap_for_task, ws).await;
                                 }
                             }
                             Some(Ok(_)) => {}
@@ -182,24 +172,11 @@ impl WindowManager for I3Backend {
     }
 
     async fn focused_window(&self) -> WmResult<Option<WindowId>> {
-        Ok(self.snapshot.read().await.focused_id)
+        Ok(snapshot::read_focused_id(&self.snapshot).await)
     }
 
     async fn focused_context(&self) -> WmResult<Option<FocusedWindowContext>> {
-        let s = self.snapshot.read().await;
-        if s.focused_id.is_none()
-            && s.focused_class.is_none()
-            && s.focused_title.is_none()
-            && s.active_workspace.is_none()
-        {
-            return Ok(None);
-        }
-        Ok(Some(FocusedWindowContext {
-            id: s.focused_id,
-            class: s.focused_class.clone(),
-            title: s.focused_title.clone(),
-            workspace: s.active_workspace.clone(),
-        }))
+        Ok(snapshot::read_focused_context(&self.snapshot).await)
     }
 
     async fn list_windows(&self) -> WmResult<Vec<Window>> {
@@ -329,18 +306,18 @@ async fn seed_snapshot(cmd: &mut I3) -> Result<Snapshot> {
     })
 }
 
-/// Apply one i3 `Window` event to the cached focus snapshot.
-///
-/// Race rules (key on con_id, the unique container handle, rather than
-/// class — two windows of the same class would otherwise alias each
-/// other in title/close updates):
-/// - `Focus` overwrites id + class + title from the new container.
-/// - `Title` only takes effect when the event's con_id matches the
-///   currently-focused id — title events from background windows
-///   must not overwrite the foreground title.
-/// - `Close` clears id + class + title only when the closed container
-///   is the focused one. Workspace is left intact.
+/// Project an i3 `WindowData` event into the shared snapshot's
+/// `(id, class, title, kind)` tuple and dispatch to
+/// [`apply_window_event`]. The compositor-specific projection (reading
+/// `container.id`, `window_properties.class`, etc.) lives here; the
+/// "what changes when" rules live in `crate::snapshot`.
 async fn handle_window_event(w: &tokio_i3ipc::event::WindowData, snap: &Arc<RwLock<Snapshot>>) {
+    let kind = match w.change {
+        WindowChange::Focus => WindowChangeKind::Focus,
+        WindowChange::Title => WindowChangeKind::Title,
+        WindowChange::Close => WindowChangeKind::Close,
+        _ => return,
+    };
     let id = WindowId::new(w.container.id as u64);
     let class = w
         .container
@@ -348,33 +325,7 @@ async fn handle_window_event(w: &tokio_i3ipc::event::WindowData, snap: &Arc<RwLo
         .as_ref()
         .and_then(|p| p.class.clone());
     let title = w.container.name.clone();
-    match w.change {
-        WindowChange::Focus => {
-            let mut s = snap.write().await;
-            s.focused_id = id;
-            s.focused_class = class;
-            s.focused_title = title;
-        }
-        WindowChange::Title => {
-            let mut s = snap.write().await;
-            if s.focused_id == id && id.is_some() {
-                s.focused_title = title;
-                // Class can also drift on Title events when an app
-                // changes its WM_CLASS late; keep them in sync for
-                // the same id.
-                s.focused_class = class;
-            }
-        }
-        WindowChange::Close => {
-            let mut s = snap.write().await;
-            if s.focused_id == id && id.is_some() {
-                s.focused_id = None;
-                s.focused_class = None;
-                s.focused_title = None;
-            }
-        }
-        _ => {}
-    }
+    apply_window_event(snap, kind, id, class, title).await;
 }
 
 fn walk_focused(node: &reply::Node) -> Option<&reply::Node> {

--- a/crates/assistd-wm/src/i3.rs
+++ b/crates/assistd-wm/src/i3.rs
@@ -38,52 +38,52 @@ use crate::{
 
 /// `WindowManager` impl wrapping a single i3 IPC command socket.
 /// Held inside `Arc<dyn WindowManager>` by the daemon's `AppState`.
+///
+/// PR 5: the cmd connection is now `Option<I3>`. The supervisor task
+/// sets it to `None` while reconnecting after a socket drop or a
+/// timeout strike, and `Some` once the new connection is seeded. The
+/// trait-method helpers return [`WmError::Disconnected`] for the None
+/// state so callers can render the right hint without blocking.
 pub struct I3Backend {
-    cmd: Arc<Mutex<I3>>,
+    cmd: Arc<Mutex<Option<I3>>>,
     snapshot: Arc<RwLock<Snapshot>>,
+    /// Bumped by call-site failures (`run_command`, `get_tree`, …) so
+    /// the supervisor task reconnects without waiting for the next
+    /// event-stream error to fire.
+    reconnect: Arc<tokio::sync::Notify>,
 }
 
 /// Returned by [`I3Backend::start`] alongside the backend itself. The
 /// daemon awaits [`I3Handle::shutdown`] in its graceful-shutdown block
-/// so the event task drains before the process exits — matching how
-/// other long-lived subsystems (`embedder_task_handle`, `hotkey_handle`,
-/// etc.) are awaited in `daemon.rs`.
+/// so the supervisor task drains before the process exits — matching
+/// how other long-lived subsystems (`embedder_task_handle`,
+/// `hotkey_handle`, etc.) are awaited in `daemon.rs`.
 pub struct I3Handle {
     pub backend: Arc<I3Backend>,
-    event_task: JoinHandle<()>,
+    supervisor_task: JoinHandle<()>,
 }
 
 impl I3Handle {
     pub async fn shutdown(self) {
-        // The daemon flips `shutdown_tx` first; the event task selects
-        // on `shutdown.changed()` and exits. Awaiting here just drains.
-        let _ = self.event_task.await;
+        // The daemon flips `shutdown_tx` first; the supervisor task
+        // selects on `shutdown.changed()` and exits.
+        let _ = self.supervisor_task.await;
     }
 }
 
 impl I3Backend {
     /// Connect to the i3 IPC sockets, seed the focused-window snapshot,
-    /// and spawn the background event task.
+    /// and spawn the supervisor task that drives the event stream and
+    /// reconnects on socket drops.
     ///
-    /// Returns `Err` when the i3 socket isn't reachable (i3 not running,
-    /// `I3SOCK` unset, non-Linux dev box, …). The daemon catches that
-    /// and substitutes `NoWindowManager` so the rest of startup proceeds.
-    pub async fn start(mut shutdown: watch::Receiver<bool>) -> WmResult<I3Handle> {
-        // Two sockets: `listen()` consumes its connection by value, so a
-        // single socket can't multiplex command + event traffic.
-        let mut cmd = I3::connect()
-            .await
-            .map_err(|e| ipc_ctx(e, "connect to i3 IPC (cmd socket)"))?;
-        let mut events_conn = I3::connect()
-            .await
-            .map_err(|e| ipc_ctx(e, "connect to i3 IPC (events socket)"))?;
-        events_conn
-            .subscribe([Subscribe::Window, Subscribe::Workspace])
-            .await
-            .map_err(|e| ipc_ctx(e, "subscribe to i3 window+workspace events"))?;
-
-        // Seed snapshot before wrapping cmd in the Mutex — reuses the
-        // command socket since `get_tree()` needs `&mut`.
+    /// Returns `Err` when the i3 socket isn't reachable on first try
+    /// (i3 not running, `I3SOCK` unset, non-Linux dev box, …). The
+    /// daemon catches that and substitutes `NoWindowManager` so the
+    /// rest of startup proceeds. After the initial connect, transient
+    /// socket failures are handled in-process by the supervisor —
+    /// `i3-msg restart` no longer requires a daemon restart.
+    pub async fn start(shutdown: watch::Receiver<bool>) -> WmResult<I3Handle> {
+        let (mut cmd, events_conn) = connect_pair().await?;
         let initial = match seed_snapshot(&mut cmd).await {
             Ok(s) => s,
             Err(e) => {
@@ -92,60 +92,50 @@ impl I3Backend {
             }
         };
         let snapshot = Arc::new(RwLock::new(initial));
-
-        let snap_for_task = snapshot.clone();
-        let event_task = tokio::spawn(async move {
-            let mut stream = events_conn.listen();
-            loop {
-                tokio::select! {
-                    _ = shutdown.changed() => {
-                        if *shutdown.borrow() { break; }
-                    }
-                    evt = stream.next() => {
-                        match evt {
-                            Some(Ok(Event::Window(w))) => {
-                                handle_window_event(&w, &snap_for_task).await;
-                            }
-                            Some(Ok(Event::Workspace(d))) => {
-                                if matches!(d.change, WorkspaceChange::Focus) {
-                                    let ws = d
-                                        .current
-                                        .as_ref()
-                                        .and_then(|n| n.name.clone());
-                                    apply_workspace_focus(&snap_for_task, ws).await;
-                                }
-                            }
-                            Some(Ok(_)) => {}
-                            Some(Err(e)) => {
-                                tracing::warn!("i3 event stream error: {e}");
-                                break;
-                            }
-                            None => break, // socket closed
-                        }
-                    }
-                }
-            }
-            tracing::info!("i3 event task exited");
-        });
-
+        let reconnect = Arc::new(tokio::sync::Notify::new());
         let backend = Arc::new(Self {
-            cmd: Arc::new(Mutex::new(cmd)),
-            snapshot,
+            cmd: Arc::new(Mutex::new(Some(cmd))),
+            snapshot: snapshot.clone(),
+            reconnect: reconnect.clone(),
         });
+
+        let supervisor_task = tokio::spawn(supervisor_loop(
+            backend.clone(),
+            events_conn,
+            snapshot,
+            reconnect,
+            shutdown,
+        ));
+
         Ok(I3Handle {
             backend,
-            event_task,
+            supervisor_task,
         })
     }
 
     async fn run(&self, payload: &str) -> WmResult<()> {
-        let results = self
-            .cmd
-            .lock()
-            .await
-            .run_command(payload)
-            .await
-            .map_err(|e| ipc_ctx(e, "i3 RUN_COMMAND"))?;
+        let mut guard = self.cmd.lock().await;
+        let conn = guard.as_mut().ok_or(WmError::Disconnected)?;
+        let results = match tokio::time::timeout(
+            crate::WM_IPC_TIMEOUT,
+            conn.run_command(payload),
+        )
+        .await
+        {
+            Err(_) => {
+                // Wedged i3 — drop the conn so the supervisor reconnects
+                // instead of holding the broken socket forever.
+                *guard = None;
+                self.reconnect.notify_one();
+                return Err(WmError::Timeout(crate::WM_IPC_TIMEOUT));
+            }
+            Ok(Err(e)) => {
+                *guard = None;
+                self.reconnect.notify_one();
+                return Err(ipc_ctx(e, "i3 RUN_COMMAND"));
+            }
+            Ok(Ok(v)) => v,
+        };
         for r in results {
             if !r.success {
                 return Err(WmError::Rejected(format!(
@@ -180,26 +170,45 @@ impl WindowManager for I3Backend {
     }
 
     async fn list_windows(&self) -> WmResult<Vec<Window>> {
-        let tree = self
-            .cmd
-            .lock()
-            .await
-            .get_tree()
-            .await
-            .map_err(|e| ipc_ctx(e, "i3 GET_TREE"))?;
+        let mut guard = self.cmd.lock().await;
+        let conn = guard.as_mut().ok_or(WmError::Disconnected)?;
+        let tree = match tokio::time::timeout(crate::WM_IPC_TIMEOUT, conn.get_tree()).await {
+            Err(_) => {
+                *guard = None;
+                self.reconnect.notify_one();
+                return Err(WmError::Timeout(crate::WM_IPC_TIMEOUT));
+            }
+            Ok(Err(e)) => {
+                *guard = None;
+                self.reconnect.notify_one();
+                return Err(ipc_ctx(e, "i3 GET_TREE"));
+            }
+            Ok(Ok(t)) => t,
+        };
+        // Drop the lock before walking the tree so concurrent calls
+        // can proceed against the shared cmd socket.
+        drop(guard);
         let mut out = Vec::new();
         collect_windows(&tree, None, &mut out);
         Ok(out)
     }
 
     async fn list_workspaces(&self) -> WmResult<Vec<WorkspaceInfo>> {
-        let ws = self
-            .cmd
-            .lock()
-            .await
-            .get_workspaces()
-            .await
-            .map_err(|e| ipc_ctx(e, "i3 GET_WORKSPACES"))?;
+        let mut guard = self.cmd.lock().await;
+        let conn = guard.as_mut().ok_or(WmError::Disconnected)?;
+        let ws = match tokio::time::timeout(crate::WM_IPC_TIMEOUT, conn.get_workspaces()).await {
+            Err(_) => {
+                *guard = None;
+                self.reconnect.notify_one();
+                return Err(WmError::Timeout(crate::WM_IPC_TIMEOUT));
+            }
+            Ok(Err(e)) => {
+                *guard = None;
+                self.reconnect.notify_one();
+                return Err(ipc_ctx(e, "i3 GET_WORKSPACES"));
+            }
+            Ok(Ok(w)) => w,
+        };
         Ok(ws
             .into_iter()
             .map(|w| WorkspaceInfo {
@@ -304,6 +313,120 @@ async fn seed_snapshot(cmd: &mut I3) -> Result<Snapshot> {
         focused_title,
         active_workspace,
     })
+}
+
+/// Open the cmd + events socket pair and subscribe events. Pulled out
+/// of `start()` so the supervisor can reuse it on each reconnect.
+async fn connect_pair() -> WmResult<(I3, I3)> {
+    let cmd = I3::connect()
+        .await
+        .map_err(|e| ipc_ctx(e, "connect to i3 IPC (cmd socket)"))?;
+    let mut events_conn = I3::connect()
+        .await
+        .map_err(|e| ipc_ctx(e, "connect to i3 IPC (events socket)"))?;
+    events_conn
+        .subscribe([Subscribe::Window, Subscribe::Workspace])
+        .await
+        .map_err(|e| ipc_ctx(e, "subscribe to i3 window+workspace events"))?;
+    Ok((cmd, events_conn))
+}
+
+/// Drive one events connection until it errors or the supervisor
+/// signals a forced reconnect. Returns when the inner loop should
+/// fall through to the reconnect branch, or `false` if shutdown was
+/// observed (in which case the supervisor exits cleanly).
+async fn drive_events(
+    events_conn: I3,
+    snapshot: Arc<RwLock<Snapshot>>,
+    reconnect: Arc<tokio::sync::Notify>,
+    shutdown: &mut watch::Receiver<bool>,
+) -> bool {
+    let mut stream = events_conn.listen();
+    loop {
+        tokio::select! {
+            _ = shutdown.changed() => {
+                if *shutdown.borrow() { return false; }
+            }
+            _ = reconnect.notified() => {
+                return true;
+            }
+            evt = stream.next() => {
+                match evt {
+                    Some(Ok(Event::Window(w))) => handle_window_event(&w, &snapshot).await,
+                    Some(Ok(Event::Workspace(d))) => {
+                        if matches!(d.change, WorkspaceChange::Focus) {
+                            let ws = d.current.as_ref().and_then(|n| n.name.clone());
+                            apply_workspace_focus(&snapshot, ws).await;
+                        }
+                    }
+                    Some(Ok(_)) => {}
+                    Some(Err(e)) => {
+                        tracing::warn!("i3 event stream error: {e}");
+                        return true;
+                    }
+                    None => return true, // socket closed
+                }
+            }
+        }
+    }
+}
+
+/// Outer reconnect loop. Drives events through `drive_events`; on
+/// fall-through (socket error, forced-reconnect, or initial events-
+/// stream creation failure), drops `cmd` to `None`, sleeps with
+/// exponential backoff, and reconnects. Exits cleanly on shutdown.
+async fn supervisor_loop(
+    backend: Arc<I3Backend>,
+    initial_events: I3,
+    snapshot: Arc<RwLock<Snapshot>>,
+    reconnect: Arc<tokio::sync::Notify>,
+    mut shutdown: watch::Receiver<bool>,
+) {
+    // First pass: drive the events conn we got at startup. cmd is
+    // already in `Some(_)` state, no reconnect needed yet.
+    if !drive_events(initial_events, snapshot.clone(), reconnect.clone(), &mut shutdown).await {
+        tracing::info!("i3 supervisor exited (shutdown during initial events stream)");
+        return;
+    }
+
+    // Subsequent passes: clear cmd, reconnect, re-seed, drive events.
+    let mut attempt: u32 = 0;
+    loop {
+        *backend.cmd.lock().await = None;
+        tracing::warn!("i3 disconnected; reconnecting (attempt {})", attempt + 1);
+
+        let delay = crate::backoff::backoff_delay(attempt);
+        tokio::select! {
+            _ = shutdown.changed() => {
+                if *shutdown.borrow() {
+                    tracing::info!("i3 supervisor exited (shutdown during backoff)");
+                    return;
+                }
+            }
+            _ = tokio::time::sleep(delay) => {}
+        }
+
+        match connect_pair().await {
+            Ok((mut cmd, events_conn)) => {
+                if let Ok(s) = seed_snapshot(&mut cmd).await {
+                    *snapshot.write().await = s;
+                }
+                *backend.cmd.lock().await = Some(cmd);
+                attempt = 0;
+                tracing::info!("i3 backend reconnected");
+                if !drive_events(events_conn, snapshot.clone(), reconnect.clone(), &mut shutdown)
+                    .await
+                {
+                    tracing::info!("i3 supervisor exited (shutdown during events stream)");
+                    return;
+                }
+            }
+            Err(e) => {
+                tracing::warn!("i3 reconnect failed: {e}; will retry after backoff");
+                attempt = attempt.saturating_add(1);
+            }
+        }
+    }
 }
 
 /// Project an i3 `WindowData` event into the shared snapshot's

--- a/crates/assistd-wm/src/i3.rs
+++ b/crates/assistd-wm/src/i3.rs
@@ -27,7 +27,7 @@ use crate::snapshot::{
     self, Snapshot, WindowChangeKind, apply_window_event, apply_workspace_focus,
 };
 use crate::{
-    FocusedWindowContext, Layout, ResizeDir, WindowId, WindowManager, WmError, WmResult, Window,
+    FocusedWindowContext, Layout, ResizeDir, Window, WindowId, WindowManager, WmError, WmResult,
     WorkspaceId, WorkspaceInfo,
 };
 
@@ -116,26 +116,22 @@ impl I3Backend {
     async fn run(&self, payload: &str) -> WmResult<()> {
         let mut guard = self.cmd.lock().await;
         let conn = guard.as_mut().ok_or(WmError::Disconnected)?;
-        let results = match tokio::time::timeout(
-            crate::WM_IPC_TIMEOUT,
-            conn.run_command(payload),
-        )
-        .await
-        {
-            Err(_) => {
-                // Wedged i3 — drop the conn so the supervisor reconnects
-                // instead of holding the broken socket forever.
-                *guard = None;
-                self.reconnect.notify_one();
-                return Err(WmError::Timeout(crate::WM_IPC_TIMEOUT));
-            }
-            Ok(Err(e)) => {
-                *guard = None;
-                self.reconnect.notify_one();
-                return Err(ipc_ctx(e, "i3 RUN_COMMAND"));
-            }
-            Ok(Ok(v)) => v,
-        };
+        let results =
+            match tokio::time::timeout(crate::WM_IPC_TIMEOUT, conn.run_command(payload)).await {
+                Err(_) => {
+                    // Wedged i3 — drop the conn so the supervisor reconnects
+                    // instead of holding the broken socket forever.
+                    *guard = None;
+                    self.reconnect.notify_one();
+                    return Err(WmError::Timeout(crate::WM_IPC_TIMEOUT));
+                }
+                Ok(Err(e)) => {
+                    *guard = None;
+                    self.reconnect.notify_one();
+                    return Err(ipc_ctx(e, "i3 RUN_COMMAND"));
+                }
+                Ok(Ok(v)) => v,
+            };
         for r in results {
             if !r.success {
                 return Err(WmError::Rejected(format!(
@@ -226,7 +222,8 @@ impl WindowManager for I3Backend {
         direction: ResizeDir,
         pixels: u32,
     ) -> WmResult<()> {
-        self.run(&i3_resize_payload(window, direction, pixels)).await
+        self.run(&i3_resize_payload(window, direction, pixels))
+            .await
     }
 
     async fn set_layout(&self, layout: Layout) -> WmResult<()> {
@@ -384,7 +381,14 @@ async fn supervisor_loop(
 ) {
     // First pass: drive the events conn we got at startup. cmd is
     // already in `Some(_)` state, no reconnect needed yet.
-    if !drive_events(initial_events, snapshot.clone(), reconnect.clone(), &mut shutdown).await {
+    if !drive_events(
+        initial_events,
+        snapshot.clone(),
+        reconnect.clone(),
+        &mut shutdown,
+    )
+    .await
+    {
         tracing::info!("i3 supervisor exited (shutdown during initial events stream)");
         return;
     }
@@ -414,8 +418,13 @@ async fn supervisor_loop(
                 *backend.cmd.lock().await = Some(cmd);
                 attempt = 0;
                 tracing::info!("i3 backend reconnected");
-                if !drive_events(events_conn, snapshot.clone(), reconnect.clone(), &mut shutdown)
-                    .await
+                if !drive_events(
+                    events_conn,
+                    snapshot.clone(),
+                    reconnect.clone(),
+                    &mut shutdown,
+                )
+                .await
                 {
                     tracing::info!("i3 supervisor exited (shutdown during events stream)");
                     return;
@@ -482,7 +491,10 @@ mod tests {
         // No need for escape — con_id is a decimal integer literal,
         // never a free-form string.
         let p = i3_resize_payload(&id(1234567890), ResizeDir::Shrink, 5);
-        assert_eq!(p, r#"[con_id="1234567890"] resize shrink width 5 px or 0 ppt"#);
+        assert_eq!(
+            p,
+            r#"[con_id="1234567890"] resize shrink width 5 px or 0 ppt"#
+        );
     }
 
     #[test]

--- a/crates/assistd-wm/src/i3.rs
+++ b/crates/assistd-wm/src/i3.rs
@@ -24,8 +24,8 @@ use tokio_i3ipc::{
 use crate::criteria::{escape_for_criteria, format_workspace_target};
 use crate::error::ipc_ctx;
 use crate::{
-    FocusedWindowContext, WindowId, WindowManager, WmError, WmResult, Window, WorkspaceId,
-    WorkspaceInfo,
+    FocusedWindowContext, Layout, ResizeDir, WindowId, WindowManager, WmError, WmResult, Window,
+    WorkspaceId, WorkspaceInfo,
 };
 
 /// Cached focus state. Seeded from `get_tree()` + `get_workspaces()`
@@ -227,9 +227,36 @@ impl WindowManager for I3Backend {
             .collect())
     }
 
-    async fn run_raw(&self, payload: &str) -> WmResult<()> {
-        self.run(payload).await
+    async fn resize_width(
+        &self,
+        window: &WindowId,
+        direction: ResizeDir,
+        pixels: u32,
+    ) -> WmResult<()> {
+        self.run(&i3_resize_payload(window, direction, pixels)).await
     }
+
+    async fn set_layout(&self, layout: Layout) -> WmResult<()> {
+        self.run(&i3_layout_payload(layout)).await
+    }
+}
+
+/// Format the i3 RUN_COMMAND payload for `resize_width`. Factored out
+/// so unit tests can assert on the literal string without a live i3.
+fn i3_resize_payload(window: &WindowId, direction: ResizeDir, pixels: u32) -> String {
+    format!(
+        r#"[class="{}"] resize {} width {} px or 0 ppt"#,
+        escape_for_criteria(window),
+        direction.as_str(),
+        pixels,
+    )
+}
+
+/// Format the i3 RUN_COMMAND payload for `set_layout`. The bare
+/// `layout <name>` form acts on the focused container — the same shape
+/// `i3-msg layout …` produces.
+fn i3_layout_payload(layout: Layout) -> String {
+    format!("layout {}", layout.as_str())
 }
 
 /// Walk the i3 tree recursively, emitting one [`Window`] per leaf node
@@ -340,4 +367,38 @@ fn walk_focused(node: &reply::Node) -> Option<&reply::Node> {
         }
     }
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resize_payload_shape_and_escape() {
+        let p = i3_resize_payload(&"Firefox".to_string(), ResizeDir::Grow, 50);
+        assert_eq!(p, r#"[class="Firefox"] resize grow width 50 px or 0 ppt"#);
+    }
+
+    #[test]
+    fn resize_payload_escapes_quote_and_backslash() {
+        // Catches a regression where a class containing the criteria
+        // delimiters (`"`, `\`) would inject into the i3 command.
+        let p = i3_resize_payload(&r#"a"b\c"#.to_string(), ResizeDir::Shrink, 5);
+        assert_eq!(p, r#"[class="a\"b\\c"] resize shrink width 5 px or 0 ppt"#);
+    }
+
+    #[test]
+    fn layout_payload_emits_bare_form() {
+        // i3 / sway treat `layout <name>` as acting on the focused
+        // container — no criteria prefix.
+        for (l, expected) in [
+            (Layout::Default, "layout default"),
+            (Layout::Tabbed, "layout tabbed"),
+            (Layout::Stacking, "layout stacking"),
+            (Layout::SplitH, "layout splith"),
+            (Layout::SplitV, "layout splitv"),
+        ] {
+            assert_eq!(i3_layout_payload(l), expected);
+        }
+    }
 }

--- a/crates/assistd-wm/src/i3.rs
+++ b/crates/assistd-wm/src/i3.rs
@@ -33,9 +33,15 @@ use crate::{
 /// `Window::Title`, `Window::Close`, and `Workspace::Focus` event so
 /// the synchronous reads in [`I3Backend::focused_window`] and
 /// [`I3Backend::focused_context`] hit memory rather than IPC.
+///
+/// `focused_class` is the raw X11 class string from the i3 reply —
+/// stored as `String` rather than [`WindowId`] because this snapshot
+/// also feeds `focused_context()`'s human-readable
+/// [`FocusedWindowContext::class`] field. Conversion to [`WindowId`]
+/// happens at the trait method boundary.
 #[derive(Default, Clone)]
 struct Snapshot {
-    focused_class: Option<WindowId>,
+    focused_class: Option<String>,
     focused_title: Option<String>,
     active_workspace: Option<String>,
 }
@@ -165,7 +171,7 @@ impl I3Backend {
 #[async_trait]
 impl WindowManager for I3Backend {
     async fn focus(&self, window: &WindowId) -> WmResult<()> {
-        let cmd = format!(r#"[class="{}"] focus"#, escape_for_criteria(window));
+        let cmd = format!(r#"[class="{}"] focus"#, escape_for_criteria(window.as_str()));
         self.run(&cmd).await
     }
 
@@ -173,14 +179,20 @@ impl WindowManager for I3Backend {
         let target = format_workspace_target(workspace);
         let cmd = format!(
             r#"[class="{}"] move container to {}"#,
-            escape_for_criteria(window),
+            escape_for_criteria(window.as_str()),
             target,
         );
         self.run(&cmd).await
     }
 
     async fn focused_window(&self) -> WmResult<Option<WindowId>> {
-        Ok(self.snapshot.read().await.focused_class.clone())
+        Ok(self
+            .snapshot
+            .read()
+            .await
+            .focused_class
+            .clone()
+            .map(WindowId::from))
     }
 
     async fn focused_context(&self) -> WmResult<Option<FocusedWindowContext>> {
@@ -246,7 +258,7 @@ impl WindowManager for I3Backend {
 fn i3_resize_payload(window: &WindowId, direction: ResizeDir, pixels: u32) -> String {
     format!(
         r#"[class="{}"] resize {} width {} px or 0 ppt"#,
-        escape_for_criteria(window),
+        escape_for_criteria(window.as_str()),
         direction.as_str(),
         pixels,
     )
@@ -280,7 +292,7 @@ fn collect_windows(node: &reply::Node, current_ws: Option<&str>, out: &mut Vec<W
         && let Some(class) = props.class.clone()
     {
         out.push(Window {
-            id: class,
+            id: WindowId::from(class),
             title: props.title.clone(),
             workspace: next_ws.map(|s| s.to_string()),
         });
@@ -375,7 +387,7 @@ mod tests {
 
     #[test]
     fn resize_payload_shape_and_escape() {
-        let p = i3_resize_payload(&"Firefox".to_string(), ResizeDir::Grow, 50);
+        let p = i3_resize_payload(&WindowId::from("Firefox"), ResizeDir::Grow, 50);
         assert_eq!(p, r#"[class="Firefox"] resize grow width 50 px or 0 ppt"#);
     }
 
@@ -383,7 +395,7 @@ mod tests {
     fn resize_payload_escapes_quote_and_backslash() {
         // Catches a regression where a class containing the criteria
         // delimiters (`"`, `\`) would inject into the i3 command.
-        let p = i3_resize_payload(&r#"a"b\c"#.to_string(), ResizeDir::Shrink, 5);
+        let p = i3_resize_payload(&WindowId::from(r#"a"b\c"#), ResizeDir::Shrink, 5);
         assert_eq!(p, r#"[class="a\"b\\c"] resize shrink width 5 px or 0 ppt"#);
     }
 

--- a/crates/assistd-wm/src/i3.rs
+++ b/crates/assistd-wm/src/i3.rs
@@ -21,7 +21,7 @@ use tokio_i3ipc::{
     reply,
 };
 
-use crate::criteria::{escape_for_criteria, format_workspace_target};
+use crate::criteria::format_workspace_target;
 use crate::error::ipc_ctx;
 use crate::{
     FocusedWindowContext, Layout, ResizeDir, WindowId, WindowManager, WmError, WmResult, Window,
@@ -34,13 +34,13 @@ use crate::{
 /// the synchronous reads in [`I3Backend::focused_window`] and
 /// [`I3Backend::focused_context`] hit memory rather than IPC.
 ///
-/// `focused_class` is the raw X11 class string from the i3 reply —
-/// stored as `String` rather than [`WindowId`] because this snapshot
-/// also feeds `focused_context()`'s human-readable
-/// [`FocusedWindowContext::class`] field. Conversion to [`WindowId`]
-/// happens at the trait method boundary.
+/// PR 3b stores both the compositor con_id (the [`WindowId`] returned
+/// to callers) and the raw X11 class string (used for the system-prompt
+/// context block). The id is what changes on every `Focus` event; the
+/// class is what the model sees when it asks "what app is in front".
 #[derive(Default, Clone)]
 struct Snapshot {
+    focused_id: Option<WindowId>,
     focused_class: Option<String>,
     focused_title: Option<String>,
     active_workspace: Option<String>,
@@ -171,36 +171,31 @@ impl I3Backend {
 #[async_trait]
 impl WindowManager for I3Backend {
     async fn focus(&self, window: &WindowId) -> WmResult<()> {
-        let cmd = format!(r#"[class="{}"] focus"#, escape_for_criteria(window.as_str()));
+        let cmd = format!(r#"[con_id="{}"] focus"#, window.get());
         self.run(&cmd).await
     }
 
     async fn move_to_workspace(&self, window: &WindowId, workspace: &WorkspaceId) -> WmResult<()> {
         let target = format_workspace_target(workspace);
-        let cmd = format!(
-            r#"[class="{}"] move container to {}"#,
-            escape_for_criteria(window.as_str()),
-            target,
-        );
+        let cmd = format!(r#"[con_id="{}"] move container to {target}"#, window.get(),);
         self.run(&cmd).await
     }
 
     async fn focused_window(&self) -> WmResult<Option<WindowId>> {
-        Ok(self
-            .snapshot
-            .read()
-            .await
-            .focused_class
-            .clone()
-            .map(WindowId::from))
+        Ok(self.snapshot.read().await.focused_id)
     }
 
     async fn focused_context(&self) -> WmResult<Option<FocusedWindowContext>> {
         let s = self.snapshot.read().await;
-        if s.focused_class.is_none() && s.focused_title.is_none() && s.active_workspace.is_none() {
+        if s.focused_id.is_none()
+            && s.focused_class.is_none()
+            && s.focused_title.is_none()
+            && s.active_workspace.is_none()
+        {
             return Ok(None);
         }
         Ok(Some(FocusedWindowContext {
+            id: s.focused_id,
             class: s.focused_class.clone(),
             title: s.focused_title.clone(),
             workspace: s.active_workspace.clone(),
@@ -257,8 +252,8 @@ impl WindowManager for I3Backend {
 /// so unit tests can assert on the literal string without a live i3.
 fn i3_resize_payload(window: &WindowId, direction: ResizeDir, pixels: u32) -> String {
     format!(
-        r#"[class="{}"] resize {} width {} px or 0 ppt"#,
-        escape_for_criteria(window.as_str()),
+        r#"[con_id="{}"] resize {} width {} px or 0 ppt"#,
+        window.get(),
         direction.as_str(),
         pixels,
     )
@@ -272,14 +267,14 @@ fn i3_layout_payload(layout: Layout) -> String {
 }
 
 /// Walk the i3 tree recursively, emitting one [`Window`] per leaf node
-/// that has both an X11 window id and a class. Tracks the most recent
-/// `NodeType::Workspace` ancestor in `current_ws` so each window can be
-/// tagged with the workspace it lives on.
+/// that has an X11 window backing (i.e. real, mapped clients — not
+/// containers). Tracks the most recent `NodeType::Workspace` ancestor
+/// in `current_ws` so each window can be tagged with the workspace it
+/// lives on.
 ///
-/// Children of a non-workspace node inherit the parent's workspace
-/// context; children of a workspace node use that workspace's name.
-/// Floating nodes are walked alongside tiling nodes — both are real
-/// windows the user can focus.
+/// PR 3b: the [`Window::id`] is the i3 con_id (`reply::Node.id`),
+/// which is unique. The X11 class moves into [`Window::app`] for human
+/// display (`wm list`'s second column).
 fn collect_windows(node: &reply::Node, current_ws: Option<&str>, out: &mut Vec<Window>) {
     let next_ws = if matches!(node.node_type, reply::NodeType::Workspace) {
         node.name.as_deref()
@@ -288,12 +283,16 @@ fn collect_windows(node: &reply::Node, current_ws: Option<&str>, out: &mut Vec<W
     };
 
     if node.window.is_some()
-        && let Some(props) = node.window_properties.as_ref()
-        && let Some(class) = props.class.clone()
+        && let Some(id) = WindowId::new(node.id as u64)
     {
+        let (app, title) = match node.window_properties.as_ref() {
+            Some(props) => (props.class.clone(), props.title.clone()),
+            None => (None, None),
+        };
         out.push(Window {
-            id: WindowId::from(class),
-            title: props.title.clone(),
+            id,
+            app,
+            title,
             workspace: next_ws.map(|s| s.to_string()),
         });
     }
@@ -306,6 +305,7 @@ fn collect_windows(node: &reply::Node, current_ws: Option<&str>, out: &mut Vec<W
 async fn seed_snapshot(cmd: &mut I3) -> Result<Snapshot> {
     let tree = cmd.get_tree().await.context("i3 GET_TREE")?;
     let focused = walk_focused(&tree);
+    let focused_id = focused.and_then(|n| WindowId::new(n.id as u64));
     let focused_class = focused
         .and_then(|n| n.window_properties.as_ref())
         .and_then(|p| p.class.clone());
@@ -322,6 +322,7 @@ async fn seed_snapshot(cmd: &mut I3) -> Result<Snapshot> {
         }
     };
     Ok(Snapshot {
+        focused_id,
         focused_class,
         focused_title,
         active_workspace,
@@ -330,14 +331,17 @@ async fn seed_snapshot(cmd: &mut I3) -> Result<Snapshot> {
 
 /// Apply one i3 `Window` event to the cached focus snapshot.
 ///
-/// Race rules:
-/// - `Focus` overwrites both class and title from the new container.
-/// - `Title` only takes effect when the event's class matches the
-///   currently-focused class — title events from background windows
+/// Race rules (key on con_id, the unique container handle, rather than
+/// class — two windows of the same class would otherwise alias each
+/// other in title/close updates):
+/// - `Focus` overwrites id + class + title from the new container.
+/// - `Title` only takes effect when the event's con_id matches the
+///   currently-focused id — title events from background windows
 ///   must not overwrite the foreground title.
-/// - `Close` clears class + title only when the closed container is
-///   the focused one. Workspace is left intact.
+/// - `Close` clears id + class + title only when the closed container
+///   is the focused one. Workspace is left intact.
 async fn handle_window_event(w: &tokio_i3ipc::event::WindowData, snap: &Arc<RwLock<Snapshot>>) {
+    let id = WindowId::new(w.container.id as u64);
     let class = w
         .container
         .window_properties
@@ -347,20 +351,24 @@ async fn handle_window_event(w: &tokio_i3ipc::event::WindowData, snap: &Arc<RwLo
     match w.change {
         WindowChange::Focus => {
             let mut s = snap.write().await;
+            s.focused_id = id;
             s.focused_class = class;
             s.focused_title = title;
         }
         WindowChange::Title => {
             let mut s = snap.write().await;
-            // Only honor title updates for the currently-focused class.
-            // (i3 emits Title events for background windows too.)
-            if s.focused_class == class && class.is_some() {
+            if s.focused_id == id && id.is_some() {
                 s.focused_title = title;
+                // Class can also drift on Title events when an app
+                // changes its WM_CLASS late; keep them in sync for
+                // the same id.
+                s.focused_class = class;
             }
         }
         WindowChange::Close => {
             let mut s = snap.write().await;
-            if s.focused_class == class && class.is_some() {
+            if s.focused_id == id && id.is_some() {
+                s.focused_id = None;
                 s.focused_class = None;
                 s.focused_title = None;
             }
@@ -385,18 +393,22 @@ fn walk_focused(node: &reply::Node) -> Option<&reply::Node> {
 mod tests {
     use super::*;
 
-    #[test]
-    fn resize_payload_shape_and_escape() {
-        let p = i3_resize_payload(&WindowId::from("Firefox"), ResizeDir::Grow, 50);
-        assert_eq!(p, r#"[class="Firefox"] resize grow width 50 px or 0 ppt"#);
+    fn id(n: u64) -> WindowId {
+        WindowId::new(n).expect("test ids are non-zero")
     }
 
     #[test]
-    fn resize_payload_escapes_quote_and_backslash() {
-        // Catches a regression where a class containing the criteria
-        // delimiters (`"`, `\`) would inject into the i3 command.
-        let p = i3_resize_payload(&WindowId::from(r#"a"b\c"#), ResizeDir::Shrink, 5);
-        assert_eq!(p, r#"[class="a\"b\\c"] resize shrink width 5 px or 0 ppt"#);
+    fn resize_payload_uses_con_id_criteria() {
+        let p = i3_resize_payload(&id(42), ResizeDir::Grow, 50);
+        assert_eq!(p, r#"[con_id="42"] resize grow width 50 px or 0 ppt"#);
+    }
+
+    #[test]
+    fn resize_payload_renders_id_in_decimal() {
+        // No need for escape — con_id is a decimal integer literal,
+        // never a free-form string.
+        let p = i3_resize_payload(&id(1234567890), ResizeDir::Shrink, 5);
+        assert_eq!(p, r#"[con_id="1234567890"] resize shrink width 5 px or 0 ppt"#);
     }
 
     #[test]

--- a/crates/assistd-wm/src/i3.rs
+++ b/crates/assistd-wm/src/i3.rs
@@ -22,7 +22,11 @@ use tokio_i3ipc::{
 };
 
 use crate::criteria::{escape_for_criteria, format_workspace_target};
-use crate::{FocusedWindowContext, Window, WindowId, WindowManager, WorkspaceId, WorkspaceInfo};
+use crate::error::ipc_ctx;
+use crate::{
+    FocusedWindowContext, WindowId, WindowManager, WmError, WmResult, Window, WorkspaceId,
+    WorkspaceInfo,
+};
 
 /// Cached focus state. Seeded from `get_tree()` + `get_workspaces()`
 /// at startup, then updated by the event task on each `Window::Focus`,
@@ -68,19 +72,19 @@ impl I3Backend {
     /// Returns `Err` when the i3 socket isn't reachable (i3 not running,
     /// `I3SOCK` unset, non-Linux dev box, …). The daemon catches that
     /// and substitutes `NoWindowManager` so the rest of startup proceeds.
-    pub async fn start(mut shutdown: watch::Receiver<bool>) -> Result<I3Handle> {
+    pub async fn start(mut shutdown: watch::Receiver<bool>) -> WmResult<I3Handle> {
         // Two sockets: `listen()` consumes its connection by value, so a
         // single socket can't multiplex command + event traffic.
         let mut cmd = I3::connect()
             .await
-            .context("connect to i3 IPC (cmd socket)")?;
+            .map_err(|e| ipc_ctx(e, "connect to i3 IPC (cmd socket)"))?;
         let mut events_conn = I3::connect()
             .await
-            .context("connect to i3 IPC (events socket)")?;
+            .map_err(|e| ipc_ctx(e, "connect to i3 IPC (events socket)"))?;
         events_conn
             .subscribe([Subscribe::Window, Subscribe::Workspace])
             .await
-            .context("subscribe to i3 window+workspace events")?;
+            .map_err(|e| ipc_ctx(e, "subscribe to i3 window+workspace events"))?;
 
         // Seed snapshot before wrapping cmd in the Mutex — reuses the
         // command socket since `get_tree()` needs `&mut`.
@@ -138,20 +142,20 @@ impl I3Backend {
         })
     }
 
-    async fn run(&self, payload: &str) -> Result<()> {
+    async fn run(&self, payload: &str) -> WmResult<()> {
         let results = self
             .cmd
             .lock()
             .await
             .run_command(payload)
             .await
-            .with_context(|| format!("i3 RUN_COMMAND failed: {payload}"))?;
+            .map_err(|e| ipc_ctx(e, "i3 RUN_COMMAND"))?;
         for r in results {
             if !r.success {
-                anyhow::bail!(
-                    "i3 rejected command `{payload}`: {}",
-                    r.error.unwrap_or_default()
-                );
+                return Err(WmError::Rejected(format!(
+                    "{payload}: {}",
+                    r.error.unwrap_or_else(|| "unknown error".into())
+                )));
             }
         }
         Ok(())
@@ -160,12 +164,12 @@ impl I3Backend {
 
 #[async_trait]
 impl WindowManager for I3Backend {
-    async fn focus(&self, window: &WindowId) -> Result<()> {
+    async fn focus(&self, window: &WindowId) -> WmResult<()> {
         let cmd = format!(r#"[class="{}"] focus"#, escape_for_criteria(window));
         self.run(&cmd).await
     }
 
-    async fn move_to_workspace(&self, window: &WindowId, workspace: &WorkspaceId) -> Result<()> {
+    async fn move_to_workspace(&self, window: &WindowId, workspace: &WorkspaceId) -> WmResult<()> {
         let target = format_workspace_target(workspace);
         let cmd = format!(
             r#"[class="{}"] move container to {}"#,
@@ -175,11 +179,11 @@ impl WindowManager for I3Backend {
         self.run(&cmd).await
     }
 
-    async fn focused_window(&self) -> Result<Option<WindowId>> {
+    async fn focused_window(&self) -> WmResult<Option<WindowId>> {
         Ok(self.snapshot.read().await.focused_class.clone())
     }
 
-    async fn focused_context(&self) -> Result<Option<FocusedWindowContext>> {
+    async fn focused_context(&self) -> WmResult<Option<FocusedWindowContext>> {
         let s = self.snapshot.read().await;
         if s.focused_class.is_none() && s.focused_title.is_none() && s.active_workspace.is_none() {
             return Ok(None);
@@ -191,27 +195,27 @@ impl WindowManager for I3Backend {
         }))
     }
 
-    async fn list_windows(&self) -> Result<Vec<Window>> {
+    async fn list_windows(&self) -> WmResult<Vec<Window>> {
         let tree = self
             .cmd
             .lock()
             .await
             .get_tree()
             .await
-            .context("i3 GET_TREE")?;
+            .map_err(|e| ipc_ctx(e, "i3 GET_TREE"))?;
         let mut out = Vec::new();
         collect_windows(&tree, None, &mut out);
         Ok(out)
     }
 
-    async fn list_workspaces(&self) -> Result<Vec<WorkspaceInfo>> {
+    async fn list_workspaces(&self) -> WmResult<Vec<WorkspaceInfo>> {
         let ws = self
             .cmd
             .lock()
             .await
             .get_workspaces()
             .await
-            .context("i3 GET_WORKSPACES")?;
+            .map_err(|e| ipc_ctx(e, "i3 GET_WORKSPACES"))?;
         Ok(ws
             .into_iter()
             .map(|w| WorkspaceInfo {
@@ -223,7 +227,7 @@ impl WindowManager for I3Backend {
             .collect())
     }
 
-    async fn run_raw(&self, payload: &str) -> Result<()> {
+    async fn run_raw(&self, payload: &str) -> WmResult<()> {
         self.run(payload).await
     }
 }

--- a/crates/assistd-wm/src/lib.rs
+++ b/crates/assistd-wm/src/lib.rs
@@ -19,7 +19,7 @@
 
 use async_trait::async_trait;
 
-pub mod criteria;
+pub(crate) mod criteria;
 pub mod error;
 pub mod i3;
 pub mod sway;
@@ -119,6 +119,99 @@ pub struct OutputInfo {
     pub focused_workspace: Option<String>,
 }
 
+/// Direction for a width-resize operation. Decoded from the
+/// `wm resize <class> <grow|shrink> <px>` user argument.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResizeDir {
+    Grow,
+    Shrink,
+}
+
+impl ResizeDir {
+    /// i3/sway-syntax keyword used inside the `resize` command payload.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ResizeDir::Grow => "grow",
+            ResizeDir::Shrink => "shrink",
+        }
+    }
+}
+
+impl std::fmt::Display for ResizeDir {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl std::str::FromStr for ResizeDir {
+    type Err = ParseResizeDirError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "grow" => Ok(ResizeDir::Grow),
+            "shrink" => Ok(ResizeDir::Shrink),
+            _ => Err(ParseResizeDirError),
+        }
+    }
+}
+
+/// Returned by [`ResizeDir::from_str`] when the input is neither
+/// `"grow"` nor `"shrink"`. Carries no data — the caller already has
+/// the offending input and renders its own message.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ParseResizeDirError;
+
+/// Layout to apply to the focused container. Decoded from the
+/// `wm layout <name>` user argument.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Layout {
+    Default,
+    Tabbed,
+    Stacking,
+    SplitH,
+    SplitV,
+}
+
+impl Layout {
+    /// i3/sway-syntax keyword used inside the `layout` command payload.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Layout::Default => "default",
+            Layout::Tabbed => "tabbed",
+            Layout::Stacking => "stacking",
+            Layout::SplitH => "splith",
+            Layout::SplitV => "splitv",
+        }
+    }
+}
+
+impl std::fmt::Display for Layout {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl std::str::FromStr for Layout {
+    type Err = ParseLayoutError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "default" => Ok(Layout::Default),
+            "tabbed" => Ok(Layout::Tabbed),
+            "stacking" => Ok(Layout::Stacking),
+            "splith" => Ok(Layout::SplitH),
+            "splitv" => Ok(Layout::SplitV),
+            _ => Err(ParseLayoutError),
+        }
+    }
+}
+
+/// Returned by [`Layout::from_str`] when the input is not a known
+/// layout name. Carries no data; the caller already has the offending
+/// input and renders its own message.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ParseLayoutError;
+
 /// Snapshot of what the user is currently looking at. Returned by
 /// [`WindowManager::focused_context`]. Each field is independently
 /// optional because compositors deliver focus / title / workspace
@@ -200,12 +293,20 @@ pub trait WindowManager: Send + Sync + 'static {
         Ok(None)
     }
 
-    /// Send a raw, backend-specific command payload. Used for operations
-    /// that have no typed return value and where adding a per-operation
-    /// trait method would be a thin wrapper around a string format
-    /// (resize, layout, …). Callers are responsible for the syntax —
-    /// keep this behind subcommands that document the expected dialect.
-    async fn run_raw(&self, payload: &str) -> WmResult<()>;
+    /// Resize the named window's width by `pixels`. Backends format the
+    /// compositor-specific payload internally so consumers don't reach
+    /// into IPC syntax.
+    async fn resize_width(
+        &self,
+        window: &WindowId,
+        direction: ResizeDir,
+        pixels: u32,
+    ) -> WmResult<()>;
+
+    /// Set the layout of the currently-focused container. Acts on the
+    /// focus state — no window argument — because that's how
+    /// `i3-msg layout …` and `swaymsg layout …` behave.
+    async fn set_layout(&self, layout: Layout) -> WmResult<()>;
 
     /// Enumerate the compositor's outputs (monitors). Sway exposes a
     /// detailed reply via `GET_OUTPUTS`; i3's reply is much sparser, so
@@ -255,7 +356,15 @@ impl WindowManager for NoWindowManager {
     async fn list_workspaces(&self) -> WmResult<Vec<WorkspaceInfo>> {
         Err(WmError::Disconnected)
     }
-    async fn run_raw(&self, _payload: &str) -> WmResult<()> {
+    async fn resize_width(
+        &self,
+        _window: &WindowId,
+        _direction: ResizeDir,
+        _pixels: u32,
+    ) -> WmResult<()> {
+        Err(WmError::Disconnected)
+    }
+    async fn set_layout(&self, _layout: Layout) -> WmResult<()> {
         Err(WmError::Disconnected)
     }
     async fn list_outputs(&self) -> WmResult<Vec<OutputInfo>> {
@@ -305,8 +414,41 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn no_window_manager_refuses_run_raw() {
-        assert!(NoWindowManager.run_raw("focus").await.is_err());
+    async fn no_window_manager_refuses_resize() {
+        let err = NoWindowManager
+            .resize_width(&"win".into(), ResizeDir::Grow, 10)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, WmError::Disconnected));
+    }
+
+    #[tokio::test]
+    async fn no_window_manager_refuses_layout() {
+        let err = NoWindowManager.set_layout(Layout::Tabbed).await.unwrap_err();
+        assert!(matches!(err, WmError::Disconnected));
+    }
+
+    #[test]
+    fn resize_dir_roundtrips() {
+        assert_eq!("grow".parse::<ResizeDir>().unwrap(), ResizeDir::Grow);
+        assert_eq!("shrink".parse::<ResizeDir>().unwrap(), ResizeDir::Shrink);
+        assert_eq!(ResizeDir::Grow.to_string(), "grow");
+        assert!("sideways".parse::<ResizeDir>().is_err());
+    }
+
+    #[test]
+    fn layout_roundtrips() {
+        for (s, l) in [
+            ("default", Layout::Default),
+            ("tabbed", Layout::Tabbed),
+            ("stacking", Layout::Stacking),
+            ("splith", Layout::SplitH),
+            ("splitv", Layout::SplitV),
+        ] {
+            assert_eq!(s.parse::<Layout>().unwrap(), l);
+            assert_eq!(l.to_string(), s);
+        }
+        assert!("spinning".parse::<Layout>().is_err());
     }
 
     #[tokio::test]
@@ -338,7 +480,15 @@ mod tests {
             async fn list_workspaces(&self) -> WmResult<Vec<WorkspaceInfo>> {
                 Ok(Vec::new())
             }
-            async fn run_raw(&self, _payload: &str) -> WmResult<()> {
+            async fn resize_width(
+                &self,
+                _w: &WindowId,
+                _d: ResizeDir,
+                _p: u32,
+            ) -> WmResult<()> {
+                Ok(())
+            }
+            async fn set_layout(&self, _l: Layout) -> WmResult<()> {
                 Ok(())
             }
         }

--- a/crates/assistd-wm/src/lib.rs
+++ b/crates/assistd-wm/src/lib.rs
@@ -22,6 +22,7 @@ use async_trait::async_trait;
 pub(crate) mod criteria;
 pub mod error;
 pub mod i3;
+pub(crate) mod snapshot;
 pub mod sway;
 pub use error::{WmError, WmResult};
 pub use i3::{I3Backend, I3Handle};

--- a/crates/assistd-wm/src/lib.rs
+++ b/crates/assistd-wm/src/lib.rs
@@ -17,12 +17,13 @@
 //! `[compositor].type` in `config.toml` (or runtime detection when
 //! `type = "auto"` — see `assistd_config::compositor::detect_from_env`).
 
-use anyhow::Result;
 use async_trait::async_trait;
 
 pub mod criteria;
+pub mod error;
 pub mod i3;
 pub mod sway;
+pub use error::{WmError, WmResult};
 pub use i3::{I3Backend, I3Handle};
 pub use sway::{SwayBackend, SwayHandle};
 
@@ -172,20 +173,21 @@ pub fn is_terminal_class(class: &str) -> bool {
 #[async_trait]
 pub trait WindowManager: Send + Sync + 'static {
     /// Focus the window with the given id.
-    async fn focus(&self, window: &WindowId) -> Result<()>;
+    async fn focus(&self, window: &WindowId) -> WmResult<()>;
 
     /// Move the named window to the given workspace.
-    async fn move_to_workspace(&self, window: &WindowId, workspace: &WorkspaceId) -> Result<()>;
+    async fn move_to_workspace(&self, window: &WindowId, workspace: &WorkspaceId)
+    -> WmResult<()>;
 
     /// Return the id of the currently focused window, or `None` when no
     /// window holds focus (e.g. an empty workspace).
-    async fn focused_window(&self) -> Result<Option<WindowId>>;
+    async fn focused_window(&self) -> WmResult<Option<WindowId>>;
 
     /// Enumerate every mapped window the compositor knows about.
-    async fn list_windows(&self) -> Result<Vec<Window>>;
+    async fn list_windows(&self) -> WmResult<Vec<Window>>;
 
     /// Enumerate every workspace the compositor knows about.
-    async fn list_workspaces(&self) -> Result<Vec<WorkspaceInfo>>;
+    async fn list_workspaces(&self) -> WmResult<Vec<WorkspaceInfo>>;
 
     /// Return a snapshot of the currently focused window's class,
     /// title, and the active workspace. Used by the daemon to inject
@@ -194,7 +196,7 @@ pub trait WindowManager: Send + Sync + 'static {
     /// Returns `Ok(None)` when nothing is focused or the backend has
     /// no opinion. The default impl returns `Ok(None)` so backends
     /// without event-snapshot support compile unchanged.
-    async fn focused_context(&self) -> Result<Option<FocusedWindowContext>> {
+    async fn focused_context(&self) -> WmResult<Option<FocusedWindowContext>> {
         Ok(None)
     }
 
@@ -203,25 +205,25 @@ pub trait WindowManager: Send + Sync + 'static {
     /// trait method would be a thin wrapper around a string format
     /// (resize, layout, …). Callers are responsible for the syntax —
     /// keep this behind subcommands that document the expected dialect.
-    async fn run_raw(&self, payload: &str) -> Result<()>;
+    async fn run_raw(&self, payload: &str) -> WmResult<()>;
 
     /// Enumerate the compositor's outputs (monitors). Sway exposes a
     /// detailed reply via `GET_OUTPUTS`; i3's reply is much sparser, so
-    /// the default implementation returns `Err` and i3-class backends
-    /// inherit it. Callers that surface this through a tool (`wm
-    /// outputs`) must translate the error into a "not supported"
-    /// message rather than an empty list, so users see the difference
-    /// between an unsupported backend and a connected machine with zero
-    /// monitors.
-    async fn list_outputs(&self) -> Result<Vec<OutputInfo>> {
-        anyhow::bail!("backend does not support output enumeration")
+    /// the default implementation returns [`WmError::Unsupported`] and
+    /// i3-class backends inherit it. Callers that surface this through
+    /// a tool (`wm outputs`) must translate the error into a "not
+    /// supported" message rather than an empty list, so users see the
+    /// difference between an unsupported backend and a connected
+    /// machine with zero monitors.
+    async fn list_outputs(&self) -> WmResult<Vec<OutputInfo>> {
+        Err(WmError::Unsupported("output enumeration"))
     }
 
     /// Report whether the backend is actually connected to a compositor.
     /// The default `true` covers concrete backends; [`NoWindowManager`]
     /// overrides to `false` so callers can short-circuit with a single
     /// "compositor not connected" message instead of waiting for the
-    /// generic `bail!` from each operation.
+    /// generic [`WmError::Disconnected`] from each operation.
     fn is_connected(&self) -> bool {
         true
     }
@@ -234,26 +236,30 @@ pub struct NoWindowManager;
 
 #[async_trait]
 impl WindowManager for NoWindowManager {
-    async fn focus(&self, _window: &WindowId) -> Result<()> {
-        anyhow::bail!("no window manager backend is configured")
+    async fn focus(&self, _window: &WindowId) -> WmResult<()> {
+        Err(WmError::Disconnected)
     }
-    async fn move_to_workspace(&self, _window: &WindowId, _workspace: &WorkspaceId) -> Result<()> {
-        anyhow::bail!("no window manager backend is configured")
+    async fn move_to_workspace(
+        &self,
+        _window: &WindowId,
+        _workspace: &WorkspaceId,
+    ) -> WmResult<()> {
+        Err(WmError::Disconnected)
     }
-    async fn focused_window(&self) -> Result<Option<WindowId>> {
+    async fn focused_window(&self) -> WmResult<Option<WindowId>> {
         Ok(None)
     }
-    async fn list_windows(&self) -> Result<Vec<Window>> {
-        anyhow::bail!("no window manager backend is configured")
+    async fn list_windows(&self) -> WmResult<Vec<Window>> {
+        Err(WmError::Disconnected)
     }
-    async fn list_workspaces(&self) -> Result<Vec<WorkspaceInfo>> {
-        anyhow::bail!("no window manager backend is configured")
+    async fn list_workspaces(&self) -> WmResult<Vec<WorkspaceInfo>> {
+        Err(WmError::Disconnected)
     }
-    async fn run_raw(&self, _payload: &str) -> Result<()> {
-        anyhow::bail!("no window manager backend is configured")
+    async fn run_raw(&self, _payload: &str) -> WmResult<()> {
+        Err(WmError::Disconnected)
     }
-    async fn list_outputs(&self) -> Result<Vec<OutputInfo>> {
-        anyhow::bail!("no window manager backend is configured")
+    async fn list_outputs(&self) -> WmResult<Vec<OutputInfo>> {
+        Err(WmError::Disconnected)
     }
     fn is_connected(&self) -> bool {
         false
@@ -317,28 +323,28 @@ mod tests {
 
         #[async_trait]
         impl WindowManager for MinimalWm {
-            async fn focus(&self, _w: &WindowId) -> Result<()> {
+            async fn focus(&self, _w: &WindowId) -> WmResult<()> {
                 Ok(())
             }
-            async fn move_to_workspace(&self, _w: &WindowId, _ws: &WorkspaceId) -> Result<()> {
+            async fn move_to_workspace(&self, _w: &WindowId, _ws: &WorkspaceId) -> WmResult<()> {
                 Ok(())
             }
-            async fn focused_window(&self) -> Result<Option<WindowId>> {
+            async fn focused_window(&self) -> WmResult<Option<WindowId>> {
                 Ok(None)
             }
-            async fn list_windows(&self) -> Result<Vec<Window>> {
+            async fn list_windows(&self) -> WmResult<Vec<Window>> {
                 Ok(Vec::new())
             }
-            async fn list_workspaces(&self) -> Result<Vec<WorkspaceInfo>> {
+            async fn list_workspaces(&self) -> WmResult<Vec<WorkspaceInfo>> {
                 Ok(Vec::new())
             }
-            async fn run_raw(&self, _payload: &str) -> Result<()> {
+            async fn run_raw(&self, _payload: &str) -> WmResult<()> {
                 Ok(())
             }
         }
 
         let err = MinimalWm.list_outputs().await.unwrap_err();
-        assert!(err.to_string().contains("does not support"), "{err}");
+        assert!(matches!(err, WmError::Unsupported(op) if op == "output enumeration"));
     }
 
     #[test]

--- a/crates/assistd-wm/src/lib.rs
+++ b/crates/assistd-wm/src/lib.rs
@@ -431,8 +431,7 @@ pub trait WindowManager: Send + Sync + 'static {
     async fn focus(&self, window: &WindowId) -> WmResult<()>;
 
     /// Move the named window to the given workspace.
-    async fn move_to_workspace(&self, window: &WindowId, workspace: &WorkspaceId)
-    -> WmResult<()>;
+    async fn move_to_workspace(&self, window: &WindowId, workspace: &WorkspaceId) -> WmResult<()>;
 
     /// Return the id of the currently focused window, or `None` when no
     /// window holds focus (e.g. an empty workspace).
@@ -590,7 +589,10 @@ mod tests {
 
     #[tokio::test]
     async fn no_window_manager_refuses_layout() {
-        let err = NoWindowManager.set_layout(Layout::Tabbed).await.unwrap_err();
+        let err = NoWindowManager
+            .set_layout(Layout::Tabbed)
+            .await
+            .unwrap_err();
         assert!(matches!(err, WmError::Disconnected));
     }
 
@@ -604,7 +606,10 @@ mod tests {
 
     #[test]
     fn window_id_parses_decimal_only() {
-        assert_eq!("42".parse::<WindowId>().unwrap(), WindowId::new(42).unwrap());
+        assert_eq!(
+            "42".parse::<WindowId>().unwrap(),
+            WindowId::new(42).unwrap()
+        );
         // 0 has no NonZeroU64 representation.
         assert!("0".parse::<WindowId>().is_err());
         // Non-numeric input: rejected.
@@ -664,12 +669,7 @@ mod tests {
             async fn list_workspaces(&self) -> WmResult<Vec<WorkspaceInfo>> {
                 Ok(Vec::new())
             }
-            async fn resize_width(
-                &self,
-                _w: &WindowId,
-                _d: ResizeDir,
-                _p: u32,
-            ) -> WmResult<()> {
+            async fn resize_width(&self, _w: &WindowId, _d: ResizeDir, _p: u32) -> WmResult<()> {
                 Ok(())
             }
             async fn set_layout(&self, _l: Layout) -> WmResult<()> {

--- a/crates/assistd-wm/src/lib.rs
+++ b/crates/assistd-wm/src/lib.rs
@@ -47,64 +47,67 @@ impl WmHandle {
     }
 }
 
-/// Identifier for a window or client in the compositor's namespace.
+/// Opaque identifier for a window in the compositor's namespace.
 ///
-/// PR 3a: opaque newtype around `String` — same payload as the prior
-/// `pub type WindowId = String` alias, but the wrapper prevents
-/// argument swaps in `move_to_workspace(window, workspace)` and lets
-/// PR 3b retarget the inner repr (compositor con_id, `NonZeroU64`)
-/// without churning every call site again.
+/// Wraps the compositor's container id — i3 emits this as
+/// `reply::Node.id: usize`, Sway as `Node.id: i64` — so two windows of
+/// the same X11 class (e.g. two Firefox windows) can be addressed
+/// independently. The criteria string for both compositors is
+/// `[con_id="N"]`.
 ///
-/// For now, the inner string is the X11 class on the i3 backend or the
-/// `app_id`/class fallback on Sway. PR 3b moves this to the
-/// compositor's unique container id so two windows of the same class
-/// can be addressed independently.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct WindowId(String);
+/// `NonZeroU64` is chosen so `Option<WindowId>` is the same size as a
+/// bare `u64` and so a zero id (which neither compositor emits, but
+/// which would be ambiguous if it ever appeared) is unrepresentable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct WindowId(pub std::num::NonZeroU64);
 
 impl WindowId {
-    /// Borrow the inner string. Use this where backend code needs
-    /// `&str` for criteria escaping or `format!`-style interpolation.
-    pub fn as_str(&self) -> &str {
-        &self.0
+    /// Construct a [`WindowId`] from a raw `u64`. Returns `None` for 0
+    /// — the compositor never emits zero, so the wrapper takes that as
+    /// a structural error signal rather than treating it as valid.
+    pub fn new(raw: u64) -> Option<Self> {
+        std::num::NonZeroU64::new(raw).map(WindowId)
+    }
+
+    /// Unwrap to the raw `u64`. Useful for IPC payload formatting
+    /// (`format!("{}", id.get())` produces `"42"`).
+    pub fn get(self) -> u64 {
+        self.0.get()
     }
 }
 
 impl std::fmt::Display for WindowId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&self.0)
+        write!(f, "{}", self.0.get())
     }
 }
 
-impl AsRef<str> for WindowId {
-    fn as_ref(&self) -> &str {
-        &self.0
+/// Returned by [`WindowId::from_str`] when the input is not a positive
+/// decimal integer. The caller already has the offending input and
+/// renders its own message.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ParseWindowIdError;
+
+impl std::fmt::Display for ParseWindowIdError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("expected positive decimal con_id")
     }
 }
 
-impl From<String> for WindowId {
-    fn from(s: String) -> Self {
-        WindowId(s)
-    }
-}
-
-impl From<&str> for WindowId {
-    fn from(s: &str) -> Self {
-        WindowId(s.to_string())
-    }
-}
-
-impl From<WindowId> for String {
-    fn from(w: WindowId) -> String {
-        w.0
-    }
-}
+impl std::error::Error for ParseWindowIdError {}
 
 impl std::str::FromStr for WindowId {
-    type Err = std::convert::Infallible;
+    type Err = ParseWindowIdError;
 
+    /// Parse a decimal con_id. Hex / leading-`0x` is rejected — Sway's
+    /// id space is large enough that decimal is the only consistent
+    /// rendering, and non-numeric ids would just be confusing for the
+    /// LLM that's piping `wm list` output back into `wm focus`.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(WindowId(s.to_string()))
+        s.parse::<u64>()
+            .ok()
+            .and_then(WindowId::new)
+            .ok_or(ParseWindowIdError)
     }
 }
 
@@ -183,14 +186,21 @@ impl From<u32> for WorkspaceId {
 }
 
 /// One row of [`WindowManager::list_windows`]. The trait's wider methods
-/// (`focus`, `move_to_workspace`) take a [`WindowId`] alone; this struct
-/// is the richer view returned to surfaces (the `wm list` command) that
-/// need title and workspace context to format human-readable output.
+/// (`focus`, `move_to_workspace`) take a [`WindowId`] (con_id) alone;
+/// this struct is the richer view returned to surfaces (the `wm list`
+/// command) that need a human-readable label and workspace context.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Window {
-    /// Identifier usable with [`WindowManager::focus`] /
-    /// [`WindowManager::move_to_workspace`]. For i3 this is the X11 class.
+    /// Compositor-unique id, usable with [`WindowManager::focus`] /
+    /// [`WindowManager::move_to_workspace`]. Emitted as the leading
+    /// `<id>` column in `wm list` so the LLM can pipe it back.
     pub id: WindowId,
+    /// Human-readable application label — X11 `WM_CLASS` on i3, or
+    /// `app_id` (Wayland-native) / `class` (XWayland) on Sway. `None`
+    /// when the window has neither set, which is rare. Surfaced as the
+    /// second column of `wm list` so the LLM can disambiguate ids by
+    /// app name.
+    pub app: Option<String>,
     /// `_NET_WM_NAME` / `WM_NAME`. Missing on some transient or just-
     /// mapped windows.
     pub title: Option<String>,
@@ -345,7 +355,14 @@ pub struct ParseLayoutError;
 /// — so callers can read it cheaply on every LLM query.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct FocusedWindowContext {
-    /// X11 `WM_CLASS` of the focused window (or compositor-equivalent).
+    /// Compositor con_id of the focused window. Surfaced for callers
+    /// that want to wire `wm focus $(wm active)` flows; the system-
+    /// prompt block does not render it (the model picks windows by
+    /// human description, so a numeric id is just token waste).
+    pub id: Option<WindowId>,
+    /// X11 `WM_CLASS` (or `app_id` on Wayland-native sway) of the
+    /// focused window. Used for the "Current desktop context" block
+    /// the daemon injects into the LLM's per-turn system prompt.
     pub class: Option<String>,
     /// `_NET_WM_NAME` / `WM_NAME` of the focused window.
     pub title: Option<String>,
@@ -512,16 +529,20 @@ mod tests {
         assert!(NoWindowManager.focused_window().await.unwrap().is_none());
     }
 
+    fn id1() -> WindowId {
+        WindowId::new(1).expect("1 is non-zero")
+    }
+
     #[tokio::test]
     async fn no_window_manager_refuses_focus() {
-        assert!(NoWindowManager.focus(&"win1".into()).await.is_err());
+        assert!(NoWindowManager.focus(&id1()).await.is_err());
     }
 
     #[tokio::test]
     async fn no_window_manager_refuses_move() {
         assert!(
             NoWindowManager
-                .move_to_workspace(&"win1".into(), &"3".into())
+                .move_to_workspace(&id1(), &WorkspaceId::Num(3))
                 .await
                 .is_err()
         );
@@ -540,7 +561,7 @@ mod tests {
     #[tokio::test]
     async fn no_window_manager_refuses_resize() {
         let err = NoWindowManager
-            .resize_width(&"win".into(), ResizeDir::Grow, 10)
+            .resize_width(&id1(), ResizeDir::Grow, 10)
             .await
             .unwrap_err();
         assert!(matches!(err, WmError::Disconnected));
@@ -558,6 +579,24 @@ mod tests {
         assert_eq!("shrink".parse::<ResizeDir>().unwrap(), ResizeDir::Shrink);
         assert_eq!(ResizeDir::Grow.to_string(), "grow");
         assert!("sideways".parse::<ResizeDir>().is_err());
+    }
+
+    #[test]
+    fn window_id_parses_decimal_only() {
+        assert_eq!("42".parse::<WindowId>().unwrap(), WindowId::new(42).unwrap());
+        // 0 has no NonZeroU64 representation.
+        assert!("0".parse::<WindowId>().is_err());
+        // Non-numeric input: rejected.
+        assert!("Firefox".parse::<WindowId>().is_err());
+        // Negative: rejected (u64 doesn't accept "-1").
+        assert!("-1".parse::<WindowId>().is_err());
+        // Hex / leading-0x: rejected.
+        assert!("0x2a".parse::<WindowId>().is_err());
+    }
+
+    #[test]
+    fn window_id_display_is_decimal() {
+        assert_eq!(WindowId::new(42).unwrap().to_string(), "42");
     }
 
     #[test]

--- a/crates/assistd-wm/src/lib.rs
+++ b/crates/assistd-wm/src/lib.rs
@@ -22,8 +22,10 @@ use async_trait::async_trait;
 pub(crate) mod backoff;
 pub(crate) mod criteria;
 pub mod error;
+#[cfg(feature = "i3")]
 pub mod i3;
 pub(crate) mod snapshot;
+#[cfg(feature = "sway")]
 pub mod sway;
 
 /// Per-call IPC timeout — `run_command`, `get_tree`, `get_workspaces`,
@@ -32,24 +34,35 @@ pub mod sway;
 /// wedges with it.
 pub(crate) const WM_IPC_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 pub use error::{WmError, WmResult};
+#[cfg(feature = "i3")]
 pub use i3::{I3Backend, I3Handle};
+#[cfg(feature = "sway")]
 pub use sway::{SwayBackend, SwayHandle};
 
 /// Aggregated shutdown handle for the active WM backend, so the daemon
 /// can hold a single `Option<WmHandle>` regardless of which backend
-/// was started. Each variant wraps the per-backend handle's own event
-/// task; [`WmHandle::shutdown`] dispatches.
+/// was started. Each variant wraps the per-backend supervisor task;
+/// [`WmHandle::shutdown`] dispatches.
+///
+/// The variants are feature-gated to match the backend modules — a
+/// build with `--no-default-features --features i3` only sees
+/// `WmHandle::I3` and the daemon's match becomes exhaustive against
+/// the smaller enum.
 pub enum WmHandle {
+    #[cfg(feature = "i3")]
     I3(I3Handle),
+    #[cfg(feature = "sway")]
     Sway(SwayHandle),
 }
 
 impl WmHandle {
-    /// Drains the per-backend event task. The daemon should flip its
-    /// shutdown watch first; this just awaits the task's exit.
+    /// Drains the per-backend supervisor task. The daemon should flip
+    /// its shutdown watch first; this just awaits the task's exit.
     pub async fn shutdown(self) {
         match self {
+            #[cfg(feature = "i3")]
             Self::I3(h) => h.shutdown().await,
+            #[cfg(feature = "sway")]
             Self::Sway(h) => h.shutdown().await,
         }
     }

--- a/crates/assistd-wm/src/lib.rs
+++ b/crates/assistd-wm/src/lib.rs
@@ -19,11 +19,18 @@
 
 use async_trait::async_trait;
 
+pub(crate) mod backoff;
 pub(crate) mod criteria;
 pub mod error;
 pub mod i3;
 pub(crate) mod snapshot;
 pub mod sway;
+
+/// Per-call IPC timeout — `run_command`, `get_tree`, `get_workspaces`,
+/// `get_outputs`. A wedged compositor must release within one user
+/// turn or the daemon's "every-turn-injects-window-context" path
+/// wedges with it.
+pub(crate) const WM_IPC_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 pub use error::{WmError, WmResult};
 pub use i3::{I3Backend, I3Handle};
 pub use sway::{SwayBackend, SwayHandle};

--- a/crates/assistd-wm/src/lib.rs
+++ b/crates/assistd-wm/src/lib.rs
@@ -48,15 +48,139 @@ impl WmHandle {
 }
 
 /// Identifier for a window or client in the compositor's namespace.
-/// Represented as a string because i3, Sway, and Hyprland each use
-/// different underlying id types — the i3 backend treats this as the
-/// X11 window class (e.g. `"Firefox"`).
-pub type WindowId = String;
+///
+/// PR 3a: opaque newtype around `String` — same payload as the prior
+/// `pub type WindowId = String` alias, but the wrapper prevents
+/// argument swaps in `move_to_workspace(window, workspace)` and lets
+/// PR 3b retarget the inner repr (compositor con_id, `NonZeroU64`)
+/// without churning every call site again.
+///
+/// For now, the inner string is the X11 class on the i3 backend or the
+/// `app_id`/class fallback on Sway. PR 3b moves this to the
+/// compositor's unique container id so two windows of the same class
+/// can be addressed independently.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct WindowId(String);
 
-/// Workspace identifier. Same reasoning as [`WindowId`]. The i3 backend
-/// emits `workspace number N` when this parses as `u32`, otherwise
-/// `workspace "<name>"`.
-pub type WorkspaceId = String;
+impl WindowId {
+    /// Borrow the inner string. Use this where backend code needs
+    /// `&str` for criteria escaping or `format!`-style interpolation.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for WindowId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl AsRef<str> for WindowId {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<String> for WindowId {
+    fn from(s: String) -> Self {
+        WindowId(s)
+    }
+}
+
+impl From<&str> for WindowId {
+    fn from(s: &str) -> Self {
+        WindowId(s.to_string())
+    }
+}
+
+impl From<WindowId> for String {
+    fn from(w: WindowId) -> String {
+        w.0
+    }
+}
+
+impl std::str::FromStr for WindowId {
+    type Err = std::convert::Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(WindowId(s.to_string()))
+    }
+}
+
+/// Workspace identifier — either a number (i3/sway's `workspace number
+/// N` form, robust to renames) or a free-form name (`workspace
+/// "<name>"`).
+///
+/// Modeling this as an enum kills the parse-round-trip the previous
+/// type alias forced on `format_workspace_target`: the parser ran on
+/// every focus/move dispatch even though the caller already knew which
+/// form they meant.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum WorkspaceId {
+    /// Numeric workspace, addressed by `workspace number N`.
+    Num(u32),
+    /// Named workspace, addressed by `workspace "<name>"`.
+    Name(String),
+}
+
+impl WorkspaceId {
+    /// Construct a numeric workspace id.
+    pub fn num(n: u32) -> Self {
+        WorkspaceId::Num(n)
+    }
+
+    /// Construct a named workspace id. Use this for non-numeric
+    /// workspace names like `"scratch"` or `"1:web"` — note that
+    /// `"1:web"` is a *named* workspace because it does not parse as
+    /// `u32` even though it visually starts with a digit.
+    pub fn name(s: impl Into<String>) -> Self {
+        WorkspaceId::Name(s.into())
+    }
+}
+
+impl std::fmt::Display for WorkspaceId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            WorkspaceId::Num(n) => write!(f, "{n}"),
+            WorkspaceId::Name(s) => f.write_str(s),
+        }
+    }
+}
+
+impl std::str::FromStr for WorkspaceId {
+    type Err = std::convert::Infallible;
+
+    /// Parse-or-name: a string that round-trips through `u32::from_str`
+    /// becomes [`WorkspaceId::Num`]; everything else is
+    /// [`WorkspaceId::Name`]. Mirrors the previous alias-based
+    /// `format_workspace_target` behaviour so call sites don't change.
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if let Ok(n) = s.parse::<u32>() {
+            Ok(WorkspaceId::Num(n))
+        } else {
+            Ok(WorkspaceId::Name(s.to_string()))
+        }
+    }
+}
+
+impl From<&str> for WorkspaceId {
+    fn from(s: &str) -> Self {
+        s.parse().expect("WorkspaceId parser is infallible")
+    }
+}
+
+impl From<String> for WorkspaceId {
+    fn from(s: String) -> Self {
+        s.as_str().into()
+    }
+}
+
+impl From<u32> for WorkspaceId {
+    fn from(n: u32) -> Self {
+        WorkspaceId::Num(n)
+    }
+}
 
 /// One row of [`WindowManager::list_windows`]. The trait's wider methods
 /// (`focus`, `move_to_workspace`) take a [`WindowId`] alone; this struct

--- a/crates/assistd-wm/src/snapshot.rs
+++ b/crates/assistd-wm/src/snapshot.rs
@@ -1,0 +1,280 @@
+//! Shared focus-snapshot state and event-apply logic for the i3 and
+//! Sway backends.
+//!
+//! Both compositors deliver the same kinds of `Window` events (Focus,
+//! Title, Close) and the same `Workspace::Focus` event. The race rules
+//! for keeping the snapshot consistent under those events are
+//! identical (key on the unique con_id, drop title updates from
+//! background windows, etc.). Originally those rules lived in two
+//! near-identical `handle_window_event` copies — one per backend.
+//!
+//! Each backend now extracts the container's `(id, class, title)` from
+//! its native `WindowEvent` payload (the only piece that's compositor-
+//! specific, since the reply types differ between `tokio-i3ipc` and
+//! `swayipc-async`) and hands off to [`apply_window_event`] /
+//! [`apply_workspace_focus`] here. The "what changes when" lives in
+//! one place; the "how do I parse the IPC frame" stays in the
+//! backend-specific module.
+//!
+//! No sealed `Compositor` trait yet — that was the more aggressive
+//! goal in the M9 plan; it requires an async-trait + associated-stream
+//! shape that risks GAT pitfalls and would force every backend to
+//! own-and-pin its event stream. The simpler share-the-rules form
+//! removes the bulk of the duplication without the lifetime gymnastics.
+//! Revisit if PR 5 (reconnection supervisor) ends up wanting the same
+//! generic shape.
+
+use std::sync::Arc;
+
+use tokio::sync::RwLock;
+
+use crate::{FocusedWindowContext, WindowId};
+
+/// Cached focus state. Shared between the i3 and Sway backends.
+///
+/// Stores the compositor con_id (the [`WindowId`] returned to callers)
+/// alongside the raw `app_id` / X11 class string and window title used
+/// to render [`FocusedWindowContext::class`] / `::title` for the
+/// system-prompt context block.
+#[derive(Default, Clone)]
+pub(crate) struct Snapshot {
+    pub focused_id: Option<WindowId>,
+    pub focused_class: Option<String>,
+    pub focused_title: Option<String>,
+    pub active_workspace: Option<String>,
+}
+
+/// The subset of `Window`-event change kinds the snapshot reacts to.
+/// Backends translate their native enum (`tokio_i3ipc::event::WindowChange`
+/// / `swayipc_async::WindowChange`) into this shared shape.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum WindowChangeKind {
+    Focus,
+    Title,
+    Close,
+}
+
+/// Apply a `Window` event to the cached focus snapshot.
+///
+/// Race rules (key on con_id rather than class — two windows of the
+/// same app would otherwise alias each other in title/close updates):
+/// - `Focus` overwrites id + class + title from the new container.
+/// - `Title` only takes effect when the event's con_id matches the
+///   currently-focused id. Title events from background windows must
+///   not overwrite the foreground title; class also drifts to match
+///   the latest container metadata for the same id.
+/// - `Close` clears id + class + title only when the closed container
+///   is the focused one. Workspace is left intact.
+pub(crate) async fn apply_window_event(
+    snap: &Arc<RwLock<Snapshot>>,
+    kind: WindowChangeKind,
+    id: Option<WindowId>,
+    class: Option<String>,
+    title: Option<String>,
+) {
+    match kind {
+        WindowChangeKind::Focus => {
+            let mut s = snap.write().await;
+            s.focused_id = id;
+            s.focused_class = class;
+            s.focused_title = title;
+        }
+        WindowChangeKind::Title => {
+            let mut s = snap.write().await;
+            if s.focused_id == id && id.is_some() {
+                s.focused_title = title;
+                s.focused_class = class;
+            }
+        }
+        WindowChangeKind::Close => {
+            let mut s = snap.write().await;
+            if s.focused_id == id && id.is_some() {
+                s.focused_id = None;
+                s.focused_class = None;
+                s.focused_title = None;
+            }
+        }
+    }
+}
+
+/// Apply a `Workspace::Focus` event to the snapshot. Used by both
+/// backends to keep `active_workspace` aligned with what the
+/// compositor reports as the currently-focused workspace.
+pub(crate) async fn apply_workspace_focus(snap: &Arc<RwLock<Snapshot>>, workspace: Option<String>) {
+    snap.write().await.active_workspace = workspace;
+}
+
+/// Read the currently-focused window's id from the snapshot. Cheap
+/// (single RwLock read), so callers don't need to cache the result.
+pub(crate) async fn read_focused_id(snap: &Arc<RwLock<Snapshot>>) -> Option<WindowId> {
+    snap.read().await.focused_id
+}
+
+/// Build a [`FocusedWindowContext`] from the snapshot for the daemon's
+/// per-turn system-prompt injection. Returns `None` only when every
+/// field is empty — a partial snapshot still produces a context block.
+pub(crate) async fn read_focused_context(
+    snap: &Arc<RwLock<Snapshot>>,
+) -> Option<FocusedWindowContext> {
+    let s = snap.read().await;
+    if s.focused_id.is_none()
+        && s.focused_class.is_none()
+        && s.focused_title.is_none()
+        && s.active_workspace.is_none()
+    {
+        return None;
+    }
+    Some(FocusedWindowContext {
+        id: s.focused_id,
+        class: s.focused_class.clone(),
+        title: s.focused_title.clone(),
+        workspace: s.active_workspace.clone(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn id(n: u64) -> WindowId {
+        WindowId::new(n).expect("test ids are non-zero")
+    }
+
+    fn snap() -> Arc<RwLock<Snapshot>> {
+        Arc::new(RwLock::new(Snapshot::default()))
+    }
+
+    #[tokio::test]
+    async fn focus_event_overwrites_all_fields() {
+        let s = snap();
+        apply_window_event(
+            &s,
+            WindowChangeKind::Focus,
+            Some(id(42)),
+            Some("Firefox".into()),
+            Some("GitHub".into()),
+        )
+        .await;
+        let r = s.read().await;
+        assert_eq!(r.focused_id, Some(id(42)));
+        assert_eq!(r.focused_class.as_deref(), Some("Firefox"));
+        assert_eq!(r.focused_title.as_deref(), Some("GitHub"));
+    }
+
+    #[tokio::test]
+    async fn title_event_for_focused_id_updates_title() {
+        let s = snap();
+        apply_window_event(
+            &s,
+            WindowChangeKind::Focus,
+            Some(id(42)),
+            Some("Firefox".into()),
+            Some("Old".into()),
+        )
+        .await;
+        apply_window_event(
+            &s,
+            WindowChangeKind::Title,
+            Some(id(42)),
+            Some("Firefox".into()),
+            Some("New".into()),
+        )
+        .await;
+        assert_eq!(s.read().await.focused_title.as_deref(), Some("New"));
+    }
+
+    #[tokio::test]
+    async fn title_event_for_other_id_is_ignored() {
+        // The crucial regression check: a background window's Title
+        // event must NOT overwrite the foreground title. Pre-PR-3b
+        // this used to be keyed on class, which aliased two windows
+        // of the same app.
+        let s = snap();
+        apply_window_event(
+            &s,
+            WindowChangeKind::Focus,
+            Some(id(42)),
+            Some("Firefox".into()),
+            Some("foreground".into()),
+        )
+        .await;
+        apply_window_event(
+            &s,
+            WindowChangeKind::Title,
+            Some(id(99)), // different con_id
+            Some("Firefox".into()),
+            Some("background drift".into()),
+        )
+        .await;
+        assert_eq!(s.read().await.focused_title.as_deref(), Some("foreground"));
+    }
+
+    #[tokio::test]
+    async fn close_event_for_focused_id_clears_focus() {
+        let s = snap();
+        apply_window_event(
+            &s,
+            WindowChangeKind::Focus,
+            Some(id(42)),
+            Some("Firefox".into()),
+            Some("GitHub".into()),
+        )
+        .await;
+        apply_window_event(
+            &s,
+            WindowChangeKind::Close,
+            Some(id(42)),
+            Some("Firefox".into()),
+            Some("GitHub".into()),
+        )
+        .await;
+        let r = s.read().await;
+        assert!(r.focused_id.is_none());
+        assert!(r.focused_class.is_none());
+        assert!(r.focused_title.is_none());
+    }
+
+    #[tokio::test]
+    async fn close_event_for_other_id_is_ignored() {
+        let s = snap();
+        apply_window_event(
+            &s,
+            WindowChangeKind::Focus,
+            Some(id(42)),
+            Some("Firefox".into()),
+            Some("GitHub".into()),
+        )
+        .await;
+        apply_window_event(
+            &s,
+            WindowChangeKind::Close,
+            Some(id(99)),
+            Some("Other".into()),
+            Some("Other".into()),
+        )
+        .await;
+        assert_eq!(s.read().await.focused_id, Some(id(42)));
+    }
+
+    #[tokio::test]
+    async fn workspace_focus_updates_active_workspace() {
+        let s = snap();
+        apply_workspace_focus(&s, Some("3".into())).await;
+        assert_eq!(s.read().await.active_workspace.as_deref(), Some("3"));
+    }
+
+    #[tokio::test]
+    async fn read_focused_context_returns_none_for_empty() {
+        let s = snap();
+        assert!(read_focused_context(&s).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn read_focused_context_returns_some_for_partial() {
+        let s = snap();
+        apply_workspace_focus(&s, Some("3".into())).await;
+        let ctx = read_focused_context(&s).await.unwrap();
+        assert!(ctx.id.is_none());
+        assert_eq!(ctx.workspace.as_deref(), Some("3"));
+    }
+}

--- a/crates/assistd-wm/src/sway.rs
+++ b/crates/assistd-wm/src/sway.rs
@@ -25,7 +25,7 @@
 
 use std::sync::Arc;
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use async_trait::async_trait;
 use futures_util::StreamExt;
 use swayipc_async::{Connection, Event, EventType, Node, NodeType, WindowChange, WorkspaceChange};
@@ -33,8 +33,10 @@ use tokio::sync::{Mutex, RwLock, watch};
 use tokio::task::JoinHandle;
 
 use crate::criteria::{escape_for_criteria, format_workspace_target};
+use crate::error::ipc_ctx;
 use crate::{
-    FocusedWindowContext, OutputInfo, Window, WindowId, WindowManager, WorkspaceId, WorkspaceInfo,
+    FocusedWindowContext, OutputInfo, WindowId, WindowManager, WmError, WmResult, Window,
+    WorkspaceId, WorkspaceInfo,
 };
 
 /// Cached focus state. Seeded from `get_tree()` + `get_workspaces()` at
@@ -83,16 +85,16 @@ impl SwayBackend {
     /// running, `$SWAYSOCK` unset, X11/i3 session, …). The daemon
     /// catches that and substitutes `NoWindowManager` so the rest of
     /// startup proceeds.
-    pub async fn start(mut shutdown: watch::Receiver<bool>) -> Result<SwayHandle> {
+    pub async fn start(mut shutdown: watch::Receiver<bool>) -> WmResult<SwayHandle> {
         // Two connections: `subscribe()` consumes its connection by
         // value, so a single socket can't multiplex command + event
         // traffic. Same constraint as i3.
         let mut cmd = Connection::new()
             .await
-            .map_err(|e| anyhow::anyhow!("connect to sway IPC (cmd socket): {e}"))?;
+            .map_err(|e| ipc_ctx(e, "connect to sway IPC (cmd socket)"))?;
         let events_conn = Connection::new()
             .await
-            .map_err(|e| anyhow::anyhow!("connect to sway IPC (events socket): {e}"))?;
+            .map_err(|e| ipc_ctx(e, "connect to sway IPC (events socket)"))?;
 
         // Seed snapshot before wrapping cmd in the Mutex — get_tree()
         // and get_workspaces() need `&mut Connection`.
@@ -108,7 +110,7 @@ impl SwayBackend {
         let mut stream = events_conn
             .subscribe([EventType::Window, EventType::Workspace])
             .await
-            .map_err(|e| anyhow::anyhow!("subscribe to sway window+workspace events: {e}"))?;
+            .map_err(|e| ipc_ctx(e, "subscribe to sway window+workspace events"))?;
 
         let snap_for_task = snapshot.clone();
         let event_task = tokio::spawn(async move {
@@ -154,16 +156,16 @@ impl SwayBackend {
         })
     }
 
-    async fn run(&self, payload: &str) -> Result<()> {
+    async fn run(&self, payload: &str) -> WmResult<()> {
         let outcomes = self
             .cmd
             .lock()
             .await
             .run_command(payload)
             .await
-            .map_err(|e| anyhow::anyhow!("sway RUN_COMMAND failed: {payload}: {e}"))?;
+            .map_err(|e| ipc_ctx(e, "sway RUN_COMMAND"))?;
         for r in outcomes {
-            r.with_context(|| format!("sway rejected `{payload}`"))?;
+            r.map_err(|e| WmError::Rejected(format!("{payload}: {e}")))?;
         }
         Ok(())
     }
@@ -171,23 +173,23 @@ impl SwayBackend {
 
 #[async_trait]
 impl WindowManager for SwayBackend {
-    async fn focus(&self, window: &WindowId) -> Result<()> {
+    async fn focus(&self, window: &WindowId) -> WmResult<()> {
         let cmd = composite_criteria_command(window, "focus");
         self.run(&cmd).await
     }
 
-    async fn move_to_workspace(&self, window: &WindowId, workspace: &WorkspaceId) -> Result<()> {
+    async fn move_to_workspace(&self, window: &WindowId, workspace: &WorkspaceId) -> WmResult<()> {
         let target = format_workspace_target(workspace);
         let action = format!("move container to {target}");
         let cmd = composite_criteria_command(window, &action);
         self.run(&cmd).await
     }
 
-    async fn focused_window(&self) -> Result<Option<WindowId>> {
+    async fn focused_window(&self) -> WmResult<Option<WindowId>> {
         Ok(self.snapshot.read().await.focused_class.clone())
     }
 
-    async fn focused_context(&self) -> Result<Option<FocusedWindowContext>> {
+    async fn focused_context(&self) -> WmResult<Option<FocusedWindowContext>> {
         let s = self.snapshot.read().await;
         if s.focused_class.is_none() && s.focused_title.is_none() && s.active_workspace.is_none() {
             return Ok(None);
@@ -199,27 +201,27 @@ impl WindowManager for SwayBackend {
         }))
     }
 
-    async fn list_windows(&self) -> Result<Vec<Window>> {
+    async fn list_windows(&self) -> WmResult<Vec<Window>> {
         let tree = self
             .cmd
             .lock()
             .await
             .get_tree()
             .await
-            .map_err(|e| anyhow::anyhow!("sway GET_TREE: {e}"))?;
+            .map_err(|e| ipc_ctx(e, "sway GET_TREE"))?;
         let mut out = Vec::new();
         collect_windows(&tree, None, &mut out);
         Ok(out)
     }
 
-    async fn list_workspaces(&self) -> Result<Vec<WorkspaceInfo>> {
+    async fn list_workspaces(&self) -> WmResult<Vec<WorkspaceInfo>> {
         let ws = self
             .cmd
             .lock()
             .await
             .get_workspaces()
             .await
-            .map_err(|e| anyhow::anyhow!("sway GET_WORKSPACES: {e}"))?;
+            .map_err(|e| ipc_ctx(e, "sway GET_WORKSPACES"))?;
         Ok(ws
             .into_iter()
             .map(|w| WorkspaceInfo {
@@ -231,18 +233,18 @@ impl WindowManager for SwayBackend {
             .collect())
     }
 
-    async fn run_raw(&self, payload: &str) -> Result<()> {
+    async fn run_raw(&self, payload: &str) -> WmResult<()> {
         self.run(payload).await
     }
 
-    async fn list_outputs(&self) -> Result<Vec<OutputInfo>> {
+    async fn list_outputs(&self) -> WmResult<Vec<OutputInfo>> {
         let outputs = self
             .cmd
             .lock()
             .await
             .get_outputs()
             .await
-            .map_err(|e| anyhow::anyhow!("sway GET_OUTPUTS: {e}"))?;
+            .map_err(|e| ipc_ctx(e, "sway GET_OUTPUTS"))?;
         Ok(outputs
             .into_iter()
             .map(|o| OutputInfo {

--- a/crates/assistd-wm/src/sway.rs
+++ b/crates/assistd-wm/src/sway.rs
@@ -32,7 +32,7 @@ use swayipc_async::{Connection, Event, EventType, Node, NodeType, WindowChange, 
 use tokio::sync::{Mutex, RwLock, watch};
 use tokio::task::JoinHandle;
 
-use crate::criteria::{escape_for_criteria, format_workspace_target};
+use crate::criteria::format_workspace_target;
 use crate::error::ipc_ctx;
 use crate::{
     FocusedWindowContext, Layout, OutputInfo, ResizeDir, WindowId, WindowManager, WmError,
@@ -44,17 +44,28 @@ use crate::{
 /// `Window::Close`, and `Workspace::Focus` event so synchronous reads
 /// don't round-trip the IPC socket.
 ///
-/// The field is named `focused_class` to match the i3 backend, but on
-/// Sway it stores `app_id` for Wayland-native windows and falls back to
-/// the X11 class only for XWayland views — see the module-level doc.
-/// Stored as raw `String` (rather than [`WindowId`]) so it doubles as
-/// the source of [`FocusedWindowContext::class`] for the prompt-injection
-/// path; conversion to [`WindowId`] happens at the trait method boundary.
+/// PR 3b stores both the compositor con_id (the [`WindowId`] returned
+/// to callers) and the raw `app_id` / class string used for the system-
+/// prompt context block. On Sway, `focused_class` prefers `app_id`
+/// (Wayland-native) and falls back to the X11 `class` for XWayland —
+/// see the module-level doc.
 #[derive(Default, Clone)]
 struct Snapshot {
+    focused_id: Option<WindowId>,
     focused_class: Option<String>,
     focused_title: Option<String>,
     active_workspace: Option<String>,
+}
+
+/// Cast a sway `Node.id` (`i64`) to a [`WindowId`]. Sway never emits
+/// non-positive ids in practice, but the bounds check keeps the
+/// conversion total — non-positive ids are silently dropped (the
+/// caller treats them as "no id available").
+fn sway_id(raw: i64) -> Option<WindowId> {
+    if raw <= 0 {
+        return None;
+    }
+    WindowId::new(raw as u64)
 }
 
 /// `WindowManager` impl wrapping a single Sway IPC command socket.
@@ -177,33 +188,31 @@ impl SwayBackend {
 #[async_trait]
 impl WindowManager for SwayBackend {
     async fn focus(&self, window: &WindowId) -> WmResult<()> {
-        let cmd = composite_criteria_command(window, "focus");
+        let cmd = format!(r#"[con_id="{}"] focus"#, window.get());
         self.run(&cmd).await
     }
 
     async fn move_to_workspace(&self, window: &WindowId, workspace: &WorkspaceId) -> WmResult<()> {
         let target = format_workspace_target(workspace);
-        let action = format!("move container to {target}");
-        let cmd = composite_criteria_command(window, &action);
+        let cmd = format!(r#"[con_id="{}"] move container to {target}"#, window.get());
         self.run(&cmd).await
     }
 
     async fn focused_window(&self) -> WmResult<Option<WindowId>> {
-        Ok(self
-            .snapshot
-            .read()
-            .await
-            .focused_class
-            .clone()
-            .map(WindowId::from))
+        Ok(self.snapshot.read().await.focused_id)
     }
 
     async fn focused_context(&self) -> WmResult<Option<FocusedWindowContext>> {
         let s = self.snapshot.read().await;
-        if s.focused_class.is_none() && s.focused_title.is_none() && s.active_workspace.is_none() {
+        if s.focused_id.is_none()
+            && s.focused_class.is_none()
+            && s.focused_title.is_none()
+            && s.active_workspace.is_none()
+        {
             return Ok(None);
         }
         Ok(Some(FocusedWindowContext {
+            id: s.focused_id,
             class: s.focused_class.clone(),
             title: s.focused_title.clone(),
             workspace: s.active_workspace.clone(),
@@ -284,22 +293,16 @@ impl WindowManager for SwayBackend {
     }
 }
 
-/// Emit a Sway command that runs `action` against either `[app_id="X"]`
-/// or `[class="X"]` — Wayland-native windows expose `app_id`, XWayland
-/// views expose `class`. Sway processes the two clauses sequentially;
-/// each clause that matches 0 windows is a silent success, so the
-/// composite is safe even when only one form applies.
-fn composite_criteria_command(window: &WindowId, action: &str) -> String {
-    let escaped = escape_for_criteria(window.as_str());
-    format!(r#"[app_id="{escaped}"] {action}; [class="{escaped}"] {action}"#)
-}
-
-/// Format the Sway RUN_COMMAND payload for `resize_width`. Uses the
-/// same `app_id|class` composite as `focus` / `move_to_workspace` so a
-/// caller-provided id matches whichever form Sway has registered.
+/// Format the Sway RUN_COMMAND payload for `resize_width`. PR 3b
+/// drops the `app_id|class` composite — Sway accepts `[con_id=N]`
+/// criteria for any window regardless of XWayland-vs-Wayland origin.
 fn sway_resize_payload(window: &WindowId, direction: ResizeDir, pixels: u32) -> String {
-    let action = format!("resize {} width {} px or 0 ppt", direction.as_str(), pixels);
-    composite_criteria_command(window, &action)
+    format!(
+        r#"[con_id="{}"] resize {} width {} px or 0 ppt"#,
+        window.get(),
+        direction.as_str(),
+        pixels,
+    )
 }
 
 /// Format the Sway RUN_COMMAND payload for `set_layout`. Acts on the
@@ -323,24 +326,28 @@ fn collect_windows(node: &Node, current_ws: Option<&str>, out: &mut Vec<Window>)
         current_ws
     };
 
-    if matches!(node.node_type, NodeType::Con | NodeType::FloatingCon) {
+    if matches!(node.node_type, NodeType::Con | NodeType::FloatingCon)
+        && let Some(id) = sway_id(node.id)
+    {
+        // Prefer Wayland-native app_id; fall back to the X11 class for
+        // XWayland views. A leaf with neither falls through with
+        // app: None — the LLM can still target it by con_id.
         let class = node
             .window_properties
             .as_ref()
             .and_then(|p| p.class.clone());
-        let id = node.app_id.clone().or(class);
-        if let Some(id) = id {
-            let title = node.name.clone().or_else(|| {
-                node.window_properties
-                    .as_ref()
-                    .and_then(|p| p.title.clone())
-            });
-            out.push(Window {
-                id: WindowId::from(id),
-                title,
-                workspace: next_ws.map(|s| s.to_string()),
-            });
-        }
+        let app = node.app_id.clone().or(class);
+        let title = node.name.clone().or_else(|| {
+            node.window_properties
+                .as_ref()
+                .and_then(|p| p.title.clone())
+        });
+        out.push(Window {
+            id,
+            app,
+            title,
+            workspace: next_ws.map(|s| s.to_string()),
+        });
     }
 
     for child in node.nodes.iter().chain(node.floating_nodes.iter()) {
@@ -354,6 +361,7 @@ async fn seed_snapshot(cmd: &mut Connection) -> Result<Snapshot> {
         .await
         .map_err(|e| anyhow::anyhow!("sway GET_TREE: {e}"))?;
     let focused = walk_focused(&tree);
+    let focused_id = focused.and_then(|n| sway_id(n.id));
     let focused_class = focused.and_then(|n| {
         n.app_id
             .clone()
@@ -376,6 +384,7 @@ async fn seed_snapshot(cmd: &mut Connection) -> Result<Snapshot> {
         }
     };
     Ok(Snapshot {
+        focused_id,
         focused_class,
         focused_title,
         active_workspace,
@@ -384,16 +393,17 @@ async fn seed_snapshot(cmd: &mut Connection) -> Result<Snapshot> {
 
 /// Apply one Sway `Window` event to the cached focus snapshot.
 ///
-/// Race rules (mirror i3 backend):
-/// - `Focus` overwrites both class/app_id and title from the new
-///   container.
-/// - `Title` only takes effect when the event's id matches the
+/// Race rules (mirror i3 backend; key on the unique con_id rather than
+/// the class/app_id, so two windows of the same app don't alias):
+/// - `Focus` overwrites id + class/app_id + title from the new container.
+/// - `Title` only takes effect when the event's con_id matches the
 ///   currently-focused id — title events from background windows must
 ///   not overwrite the foreground title.
 /// - `Close` clears focus state only when the closed container is the
 ///   focused one. Workspace is left intact.
 async fn handle_window_event(w: &swayipc_async::WindowEvent, snap: &Arc<RwLock<Snapshot>>) {
-    let id = w.container.app_id.clone().or_else(|| {
+    let id = sway_id(w.container.id);
+    let class = w.container.app_id.clone().or_else(|| {
         w.container
             .window_properties
             .as_ref()
@@ -408,19 +418,21 @@ async fn handle_window_event(w: &swayipc_async::WindowEvent, snap: &Arc<RwLock<S
     match w.change {
         WindowChange::Focus => {
             let mut s = snap.write().await;
-            s.focused_class = id;
+            s.focused_id = id;
+            s.focused_class = class;
             s.focused_title = title;
         }
         WindowChange::Title => {
             let mut s = snap.write().await;
-            // Only honor title updates for the currently-focused id.
-            if s.focused_class == id && id.is_some() {
+            if s.focused_id == id && id.is_some() {
                 s.focused_title = title;
+                s.focused_class = class;
             }
         }
         WindowChange::Close => {
             let mut s = snap.write().await;
-            if s.focused_class == id && id.is_some() {
+            if s.focused_id == id && id.is_some() {
+                s.focused_id = None;
                 s.focused_class = None;
                 s.focused_title = None;
             }
@@ -445,49 +457,31 @@ fn walk_focused(node: &Node) -> Option<&Node> {
 mod tests {
     use super::*;
 
-    #[test]
-    fn composite_criteria_command_emits_app_id_and_class_clauses() {
-        let s = composite_criteria_command(&WindowId::from("firefox"), "focus");
-        assert_eq!(s, r#"[app_id="firefox"] focus; [class="firefox"] focus"#);
+    fn id(n: u64) -> WindowId {
+        WindowId::new(n).expect("test ids are non-zero")
     }
 
     #[test]
-    fn composite_criteria_command_escapes_special_chars() {
-        let s = composite_criteria_command(&WindowId::from(r#"a"b\c"#), "focus");
-        assert_eq!(s, r#"[app_id="a\"b\\c"] focus; [class="a\"b\\c"] focus"#);
+    fn resize_payload_uses_con_id_criteria() {
+        // PR 3b: Sway's `[con_id=N]` is a single-clause match — no
+        // more `app_id|class` composite, since con_id covers Wayland-
+        // native and XWayland views uniformly.
+        let p = sway_resize_payload(&id(42), ResizeDir::Grow, 50);
+        assert_eq!(p, r#"[con_id="42"] resize grow width 50 px or 0 ppt"#);
     }
 
     #[test]
-    fn composite_criteria_command_uses_full_action() {
-        let s = composite_criteria_command(
-            &WindowId::from("kitty"),
-            "move container to workspace number 3",
-        );
-        assert_eq!(
-            s,
-            r#"[app_id="kitty"] move container to workspace number 3; [class="kitty"] move container to workspace number 3"#
-        );
+    fn resize_payload_renders_id_in_decimal() {
+        let p = sway_resize_payload(&id(1234567890), ResizeDir::Shrink, 5);
+        assert_eq!(p, r#"[con_id="1234567890"] resize shrink width 5 px or 0 ppt"#);
     }
 
     #[test]
-    fn resize_payload_shape_and_escape() {
-        // Sway mirrors the focus dispatch's `app_id|class` composite so
-        // the resize lands regardless of which identifier the
-        // user-supplied id matches.
-        let p = sway_resize_payload(&WindowId::from("firefox"), ResizeDir::Grow, 50);
-        assert_eq!(
-            p,
-            r#"[app_id="firefox"] resize grow width 50 px or 0 ppt; [class="firefox"] resize grow width 50 px or 0 ppt"#
-        );
-    }
-
-    #[test]
-    fn resize_payload_escapes_quote_and_backslash() {
-        let p = sway_resize_payload(&WindowId::from(r#"a"b\c"#), ResizeDir::Shrink, 5);
-        assert_eq!(
-            p,
-            r#"[app_id="a\"b\\c"] resize shrink width 5 px or 0 ppt; [class="a\"b\\c"] resize shrink width 5 px or 0 ppt"#
-        );
+    fn sway_id_rejects_non_positive() {
+        assert!(sway_id(0).is_none());
+        assert!(sway_id(-1).is_none());
+        assert!(sway_id(-12345).is_none());
+        assert_eq!(sway_id(42), WindowId::new(42));
     }
 
     #[test]

--- a/crates/assistd-wm/src/sway.rs
+++ b/crates/assistd-wm/src/sway.rs
@@ -47,9 +47,12 @@ use crate::{
 /// The field is named `focused_class` to match the i3 backend, but on
 /// Sway it stores `app_id` for Wayland-native windows and falls back to
 /// the X11 class only for XWayland views — see the module-level doc.
+/// Stored as raw `String` (rather than [`WindowId`]) so it doubles as
+/// the source of [`FocusedWindowContext::class`] for the prompt-injection
+/// path; conversion to [`WindowId`] happens at the trait method boundary.
 #[derive(Default, Clone)]
 struct Snapshot {
-    focused_class: Option<WindowId>,
+    focused_class: Option<String>,
     focused_title: Option<String>,
     active_workspace: Option<String>,
 }
@@ -186,7 +189,13 @@ impl WindowManager for SwayBackend {
     }
 
     async fn focused_window(&self) -> WmResult<Option<WindowId>> {
-        Ok(self.snapshot.read().await.focused_class.clone())
+        Ok(self
+            .snapshot
+            .read()
+            .await
+            .focused_class
+            .clone()
+            .map(WindowId::from))
     }
 
     async fn focused_context(&self) -> WmResult<Option<FocusedWindowContext>> {
@@ -281,7 +290,7 @@ impl WindowManager for SwayBackend {
 /// each clause that matches 0 windows is a silent success, so the
 /// composite is safe even when only one form applies.
 fn composite_criteria_command(window: &WindowId, action: &str) -> String {
-    let escaped = escape_for_criteria(window);
+    let escaped = escape_for_criteria(window.as_str());
     format!(r#"[app_id="{escaped}"] {action}; [class="{escaped}"] {action}"#)
 }
 
@@ -327,7 +336,7 @@ fn collect_windows(node: &Node, current_ws: Option<&str>, out: &mut Vec<Window>)
                     .and_then(|p| p.title.clone())
             });
             out.push(Window {
-                id,
+                id: WindowId::from(id),
                 title,
                 workspace: next_ws.map(|s| s.to_string()),
             });
@@ -438,20 +447,20 @@ mod tests {
 
     #[test]
     fn composite_criteria_command_emits_app_id_and_class_clauses() {
-        let s = composite_criteria_command(&"firefox".to_string(), "focus");
+        let s = composite_criteria_command(&WindowId::from("firefox"), "focus");
         assert_eq!(s, r#"[app_id="firefox"] focus; [class="firefox"] focus"#);
     }
 
     #[test]
     fn composite_criteria_command_escapes_special_chars() {
-        let s = composite_criteria_command(&r#"a"b\c"#.to_string(), "focus");
+        let s = composite_criteria_command(&WindowId::from(r#"a"b\c"#), "focus");
         assert_eq!(s, r#"[app_id="a\"b\\c"] focus; [class="a\"b\\c"] focus"#);
     }
 
     #[test]
     fn composite_criteria_command_uses_full_action() {
         let s = composite_criteria_command(
-            &"kitty".to_string(),
+            &WindowId::from("kitty"),
             "move container to workspace number 3",
         );
         assert_eq!(
@@ -465,7 +474,7 @@ mod tests {
         // Sway mirrors the focus dispatch's `app_id|class` composite so
         // the resize lands regardless of which identifier the
         // user-supplied id matches.
-        let p = sway_resize_payload(&"firefox".to_string(), ResizeDir::Grow, 50);
+        let p = sway_resize_payload(&WindowId::from("firefox"), ResizeDir::Grow, 50);
         assert_eq!(
             p,
             r#"[app_id="firefox"] resize grow width 50 px or 0 ppt; [class="firefox"] resize grow width 50 px or 0 ppt"#
@@ -474,7 +483,7 @@ mod tests {
 
     #[test]
     fn resize_payload_escapes_quote_and_backslash() {
-        let p = sway_resize_payload(&r#"a"b\c"#.to_string(), ResizeDir::Shrink, 5);
+        let p = sway_resize_payload(&WindowId::from(r#"a"b\c"#), ResizeDir::Shrink, 5);
         assert_eq!(
             p,
             r#"[app_id="a\"b\\c"] resize shrink width 5 px or 0 ppt; [class="a\"b\\c"] resize shrink width 5 px or 0 ppt"#

--- a/crates/assistd-wm/src/sway.rs
+++ b/crates/assistd-wm/src/sway.rs
@@ -35,8 +35,8 @@ use tokio::task::JoinHandle;
 use crate::criteria::{escape_for_criteria, format_workspace_target};
 use crate::error::ipc_ctx;
 use crate::{
-    FocusedWindowContext, OutputInfo, WindowId, WindowManager, WmError, WmResult, Window,
-    WorkspaceId, WorkspaceInfo,
+    FocusedWindowContext, Layout, OutputInfo, ResizeDir, WindowId, WindowManager, WmError,
+    WmResult, Window, WorkspaceId, WorkspaceInfo,
 };
 
 /// Cached focus state. Seeded from `get_tree()` + `get_workspaces()` at
@@ -233,8 +233,18 @@ impl WindowManager for SwayBackend {
             .collect())
     }
 
-    async fn run_raw(&self, payload: &str) -> WmResult<()> {
-        self.run(payload).await
+    async fn resize_width(
+        &self,
+        window: &WindowId,
+        direction: ResizeDir,
+        pixels: u32,
+    ) -> WmResult<()> {
+        self.run(&sway_resize_payload(window, direction, pixels))
+            .await
+    }
+
+    async fn set_layout(&self, layout: Layout) -> WmResult<()> {
+        self.run(&sway_layout_payload(layout)).await
     }
 
     async fn list_outputs(&self) -> WmResult<Vec<OutputInfo>> {
@@ -273,6 +283,21 @@ impl WindowManager for SwayBackend {
 fn composite_criteria_command(window: &WindowId, action: &str) -> String {
     let escaped = escape_for_criteria(window);
     format!(r#"[app_id="{escaped}"] {action}; [class="{escaped}"] {action}"#)
+}
+
+/// Format the Sway RUN_COMMAND payload for `resize_width`. Uses the
+/// same `app_id|class` composite as `focus` / `move_to_workspace` so a
+/// caller-provided id matches whichever form Sway has registered.
+fn sway_resize_payload(window: &WindowId, direction: ResizeDir, pixels: u32) -> String {
+    let action = format!("resize {} width {} px or 0 ppt", direction.as_str(), pixels);
+    composite_criteria_command(window, &action)
+}
+
+/// Format the Sway RUN_COMMAND payload for `set_layout`. Acts on the
+/// focused container — same form i3 uses, since Sway speaks the i3
+/// IPC dialect for `layout`.
+fn sway_layout_payload(layout: Layout) -> String {
+    format!("layout {}", layout.as_str())
 }
 
 /// Walk Sway's tree recursively, emitting one [`Window`] per leaf view.
@@ -433,5 +458,39 @@ mod tests {
             s,
             r#"[app_id="kitty"] move container to workspace number 3; [class="kitty"] move container to workspace number 3"#
         );
+    }
+
+    #[test]
+    fn resize_payload_shape_and_escape() {
+        // Sway mirrors the focus dispatch's `app_id|class` composite so
+        // the resize lands regardless of which identifier the
+        // user-supplied id matches.
+        let p = sway_resize_payload(&"firefox".to_string(), ResizeDir::Grow, 50);
+        assert_eq!(
+            p,
+            r#"[app_id="firefox"] resize grow width 50 px or 0 ppt; [class="firefox"] resize grow width 50 px or 0 ppt"#
+        );
+    }
+
+    #[test]
+    fn resize_payload_escapes_quote_and_backslash() {
+        let p = sway_resize_payload(&r#"a"b\c"#.to_string(), ResizeDir::Shrink, 5);
+        assert_eq!(
+            p,
+            r#"[app_id="a\"b\\c"] resize shrink width 5 px or 0 ppt; [class="a\"b\\c"] resize shrink width 5 px or 0 ppt"#
+        );
+    }
+
+    #[test]
+    fn layout_payload_emits_bare_form() {
+        // No criteria prefix — Sway speaks the i3 dialect for layout
+        // and acts on the focused container.
+        for (l, expected) in [
+            (Layout::Default, "layout default"),
+            (Layout::Tabbed, "layout tabbed"),
+            (Layout::SplitH, "layout splith"),
+        ] {
+            assert_eq!(sway_layout_payload(l), expected);
+        }
     }
 }

--- a/crates/assistd-wm/src/sway.rs
+++ b/crates/assistd-wm/src/sway.rs
@@ -28,7 +28,9 @@ use std::sync::Arc;
 use anyhow::Result;
 use async_trait::async_trait;
 use futures_util::StreamExt;
-use swayipc_async::{Connection, Event, EventType, Node, NodeType, WindowChange, WorkspaceChange};
+use swayipc_async::{
+    Connection, Event, EventStream, EventType, Node, NodeType, WindowChange, WorkspaceChange,
+};
 use tokio::sync::{Mutex, RwLock, watch};
 use tokio::task::JoinHandle;
 
@@ -62,9 +64,15 @@ fn sway_id(raw: i64) -> Option<WindowId> {
 
 /// `WindowManager` impl wrapping a single Sway IPC command socket.
 /// Held inside `Arc<dyn WindowManager>` by the daemon's `AppState`.
+///
+/// PR 5: cmd is `Option<Connection>`. The supervisor task sets it to
+/// `None` while reconnecting after a socket drop or a timeout strike,
+/// and `Some` once the new connection is seeded. Trait-method helpers
+/// short-circuit with [`WmError::Disconnected`] for the None state.
 pub struct SwayBackend {
-    cmd: Arc<Mutex<Connection>>,
+    cmd: Arc<Mutex<Option<Connection>>>,
     snapshot: Arc<RwLock<Snapshot>>,
+    reconnect: Arc<tokio::sync::Notify>,
 }
 
 /// Returned by [`SwayBackend::start`] alongside the backend itself. The
@@ -72,38 +80,27 @@ pub struct SwayBackend {
 /// block — same pattern as `I3Handle`.
 pub struct SwayHandle {
     pub backend: Arc<SwayBackend>,
-    event_task: JoinHandle<()>,
+    supervisor_task: JoinHandle<()>,
 }
 
 impl SwayHandle {
     pub async fn shutdown(self) {
-        // The daemon flips `shutdown_tx` first; the event task selects
-        // on `shutdown.changed()` and exits. Awaiting here just drains.
-        let _ = self.event_task.await;
+        // The daemon flips `shutdown_tx` first; the supervisor task
+        // selects on `shutdown.changed()` and exits.
+        let _ = self.supervisor_task.await;
     }
 }
 
 impl SwayBackend {
     /// Connect to Sway's IPC sockets, seed the focused-window snapshot,
-    /// and spawn the background event task.
+    /// and spawn the supervisor task that drives the event stream and
+    /// reconnects on socket drops.
     ///
-    /// Returns `Err` when the Sway socket isn't reachable (Sway not
-    /// running, `$SWAYSOCK` unset, X11/i3 session, …). The daemon
-    /// catches that and substitutes `NoWindowManager` so the rest of
-    /// startup proceeds.
-    pub async fn start(mut shutdown: watch::Receiver<bool>) -> WmResult<SwayHandle> {
-        // Two connections: `subscribe()` consumes its connection by
-        // value, so a single socket can't multiplex command + event
-        // traffic. Same constraint as i3.
-        let mut cmd = Connection::new()
-            .await
-            .map_err(|e| ipc_ctx(e, "connect to sway IPC (cmd socket)"))?;
-        let events_conn = Connection::new()
-            .await
-            .map_err(|e| ipc_ctx(e, "connect to sway IPC (events socket)"))?;
-
-        // Seed snapshot before wrapping cmd in the Mutex — get_tree()
-        // and get_workspaces() need `&mut Connection`.
+    /// Returns `Err` only on the initial connect failure. After
+    /// startup, transient socket errors (e.g. `swaymsg reload`) are
+    /// handled in-process by the supervisor.
+    pub async fn start(shutdown: watch::Receiver<bool>) -> WmResult<SwayHandle> {
+        let (mut cmd, stream) = connect_pair().await?;
         let initial = match seed_snapshot(&mut cmd).await {
             Ok(s) => s,
             Err(e) => {
@@ -112,64 +109,48 @@ impl SwayBackend {
             }
         };
         let snapshot = Arc::new(RwLock::new(initial));
-
-        let mut stream = events_conn
-            .subscribe([EventType::Window, EventType::Workspace])
-            .await
-            .map_err(|e| ipc_ctx(e, "subscribe to sway window+workspace events"))?;
-
-        let snap_for_task = snapshot.clone();
-        let event_task = tokio::spawn(async move {
-            loop {
-                tokio::select! {
-                    _ = shutdown.changed() => {
-                        if *shutdown.borrow() { break; }
-                    }
-                    evt = stream.next() => {
-                        match evt {
-                            Some(Ok(Event::Window(w))) => {
-                                handle_window_event(&w, &snap_for_task).await;
-                            }
-                            Some(Ok(Event::Workspace(d))) => {
-                                if matches!(d.change, WorkspaceChange::Focus) {
-                                    let ws = d
-                                        .current
-                                        .as_ref()
-                                        .and_then(|n| n.name.clone());
-                                    apply_workspace_focus(&snap_for_task, ws).await;
-                                }
-                            }
-                            Some(Ok(_)) => {}
-                            Some(Err(e)) => {
-                                tracing::warn!("sway event stream error: {e}");
-                                break;
-                            }
-                            None => break, // socket closed
-                        }
-                    }
-                }
-            }
-            tracing::info!("sway event task exited");
-        });
-
+        let reconnect = Arc::new(tokio::sync::Notify::new());
         let backend = Arc::new(Self {
-            cmd: Arc::new(Mutex::new(cmd)),
-            snapshot,
+            cmd: Arc::new(Mutex::new(Some(cmd))),
+            snapshot: snapshot.clone(),
+            reconnect: reconnect.clone(),
         });
+
+        let supervisor_task = tokio::spawn(supervisor_loop(
+            backend.clone(),
+            stream,
+            snapshot,
+            reconnect,
+            shutdown,
+        ));
+
         Ok(SwayHandle {
             backend,
-            event_task,
+            supervisor_task,
         })
     }
 
     async fn run(&self, payload: &str) -> WmResult<()> {
-        let outcomes = self
-            .cmd
-            .lock()
-            .await
-            .run_command(payload)
-            .await
-            .map_err(|e| ipc_ctx(e, "sway RUN_COMMAND"))?;
+        let mut guard = self.cmd.lock().await;
+        let conn = guard.as_mut().ok_or(WmError::Disconnected)?;
+        let outcomes = match tokio::time::timeout(
+            crate::WM_IPC_TIMEOUT,
+            conn.run_command(payload),
+        )
+        .await
+        {
+            Err(_) => {
+                *guard = None;
+                self.reconnect.notify_one();
+                return Err(WmError::Timeout(crate::WM_IPC_TIMEOUT));
+            }
+            Ok(Err(e)) => {
+                *guard = None;
+                self.reconnect.notify_one();
+                return Err(ipc_ctx(e, "sway RUN_COMMAND"));
+            }
+            Ok(Ok(v)) => v,
+        };
         for r in outcomes {
             r.map_err(|e| WmError::Rejected(format!("{payload}: {e}")))?;
         }
@@ -199,26 +180,43 @@ impl WindowManager for SwayBackend {
     }
 
     async fn list_windows(&self) -> WmResult<Vec<Window>> {
-        let tree = self
-            .cmd
-            .lock()
-            .await
-            .get_tree()
-            .await
-            .map_err(|e| ipc_ctx(e, "sway GET_TREE"))?;
+        let mut guard = self.cmd.lock().await;
+        let conn = guard.as_mut().ok_or(WmError::Disconnected)?;
+        let tree = match tokio::time::timeout(crate::WM_IPC_TIMEOUT, conn.get_tree()).await {
+            Err(_) => {
+                *guard = None;
+                self.reconnect.notify_one();
+                return Err(WmError::Timeout(crate::WM_IPC_TIMEOUT));
+            }
+            Ok(Err(e)) => {
+                *guard = None;
+                self.reconnect.notify_one();
+                return Err(ipc_ctx(e, "sway GET_TREE"));
+            }
+            Ok(Ok(t)) => t,
+        };
+        drop(guard);
         let mut out = Vec::new();
         collect_windows(&tree, None, &mut out);
         Ok(out)
     }
 
     async fn list_workspaces(&self) -> WmResult<Vec<WorkspaceInfo>> {
-        let ws = self
-            .cmd
-            .lock()
-            .await
-            .get_workspaces()
-            .await
-            .map_err(|e| ipc_ctx(e, "sway GET_WORKSPACES"))?;
+        let mut guard = self.cmd.lock().await;
+        let conn = guard.as_mut().ok_or(WmError::Disconnected)?;
+        let ws = match tokio::time::timeout(crate::WM_IPC_TIMEOUT, conn.get_workspaces()).await {
+            Err(_) => {
+                *guard = None;
+                self.reconnect.notify_one();
+                return Err(WmError::Timeout(crate::WM_IPC_TIMEOUT));
+            }
+            Ok(Err(e)) => {
+                *guard = None;
+                self.reconnect.notify_one();
+                return Err(ipc_ctx(e, "sway GET_WORKSPACES"));
+            }
+            Ok(Ok(w)) => w,
+        };
         Ok(ws
             .into_iter()
             .map(|w| WorkspaceInfo {
@@ -245,13 +243,21 @@ impl WindowManager for SwayBackend {
     }
 
     async fn list_outputs(&self) -> WmResult<Vec<OutputInfo>> {
-        let outputs = self
-            .cmd
-            .lock()
-            .await
-            .get_outputs()
-            .await
-            .map_err(|e| ipc_ctx(e, "sway GET_OUTPUTS"))?;
+        let mut guard = self.cmd.lock().await;
+        let conn = guard.as_mut().ok_or(WmError::Disconnected)?;
+        let outputs = match tokio::time::timeout(crate::WM_IPC_TIMEOUT, conn.get_outputs()).await {
+            Err(_) => {
+                *guard = None;
+                self.reconnect.notify_one();
+                return Err(WmError::Timeout(crate::WM_IPC_TIMEOUT));
+            }
+            Ok(Err(e)) => {
+                *guard = None;
+                self.reconnect.notify_one();
+                return Err(ipc_ctx(e, "sway GET_OUTPUTS"));
+            }
+            Ok(Ok(v)) => v,
+        };
         Ok(outputs
             .into_iter()
             .map(|o| OutputInfo {
@@ -269,6 +275,120 @@ impl WindowManager for SwayBackend {
                 focused_workspace: o.current_workspace,
             })
             .collect())
+    }
+}
+
+/// Open the cmd + events socket pair and subscribe events. Pulled out
+/// of `start()` so the supervisor can reuse it on each reconnect.
+async fn connect_pair() -> WmResult<(Connection, EventStream)> {
+    let cmd = Connection::new()
+        .await
+        .map_err(|e| ipc_ctx(e, "connect to sway IPC (cmd socket)"))?;
+    let events_conn = Connection::new()
+        .await
+        .map_err(|e| ipc_ctx(e, "connect to sway IPC (events socket)"))?;
+    let stream = events_conn
+        .subscribe([EventType::Window, EventType::Workspace])
+        .await
+        .map_err(|e| ipc_ctx(e, "subscribe to sway window+workspace events"))?;
+    Ok((cmd, stream))
+}
+
+/// Drive one events stream until it errors or the supervisor signals
+/// a forced reconnect. Returns `false` if shutdown was observed
+/// (caller exits cleanly), `true` if the inner loop fell through and
+/// the caller should reconnect.
+async fn drive_events(
+    mut stream: EventStream,
+    snapshot: Arc<RwLock<Snapshot>>,
+    reconnect: Arc<tokio::sync::Notify>,
+    shutdown: &mut watch::Receiver<bool>,
+) -> bool {
+    loop {
+        tokio::select! {
+            _ = shutdown.changed() => {
+                if *shutdown.borrow() { return false; }
+            }
+            _ = reconnect.notified() => {
+                return true;
+            }
+            evt = stream.next() => {
+                match evt {
+                    Some(Ok(Event::Window(w))) => handle_window_event(&w, &snapshot).await,
+                    Some(Ok(Event::Workspace(d))) => {
+                        if matches!(d.change, WorkspaceChange::Focus) {
+                            let ws = d.current.as_ref().and_then(|n| n.name.clone());
+                            apply_workspace_focus(&snapshot, ws).await;
+                        }
+                    }
+                    Some(Ok(_)) => {}
+                    Some(Err(e)) => {
+                        tracing::warn!("sway event stream error: {e}");
+                        return true;
+                    }
+                    None => return true, // socket closed
+                }
+            }
+        }
+    }
+}
+
+/// Outer reconnect loop. Mirrors the i3 supervisor: drive events
+/// through `drive_events`; on fall-through, drop cmd, sleep with
+/// exponential backoff, reconnect, re-seed, repeat.
+async fn supervisor_loop(
+    backend: Arc<SwayBackend>,
+    initial_stream: EventStream,
+    snapshot: Arc<RwLock<Snapshot>>,
+    reconnect: Arc<tokio::sync::Notify>,
+    mut shutdown: watch::Receiver<bool>,
+) {
+    if !drive_events(
+        initial_stream,
+        snapshot.clone(),
+        reconnect.clone(),
+        &mut shutdown,
+    )
+    .await
+    {
+        tracing::info!("sway supervisor exited (shutdown during initial events stream)");
+        return;
+    }
+
+    let mut attempt: u32 = 0;
+    loop {
+        *backend.cmd.lock().await = None;
+        tracing::warn!("sway disconnected; reconnecting (attempt {})", attempt + 1);
+
+        let delay = crate::backoff::backoff_delay(attempt);
+        tokio::select! {
+            _ = shutdown.changed() => {
+                if *shutdown.borrow() {
+                    tracing::info!("sway supervisor exited (shutdown during backoff)");
+                    return;
+                }
+            }
+            _ = tokio::time::sleep(delay) => {}
+        }
+
+        match connect_pair().await {
+            Ok((mut cmd, stream)) => {
+                if let Ok(s) = seed_snapshot(&mut cmd).await {
+                    *snapshot.write().await = s;
+                }
+                *backend.cmd.lock().await = Some(cmd);
+                attempt = 0;
+                tracing::info!("sway backend reconnected");
+                if !drive_events(stream, snapshot.clone(), reconnect.clone(), &mut shutdown).await {
+                    tracing::info!("sway supervisor exited (shutdown during events stream)");
+                    return;
+                }
+            }
+            Err(e) => {
+                tracing::warn!("sway reconnect failed: {e}; will retry after backoff");
+                attempt = attempt.saturating_add(1);
+            }
+        }
     }
 }
 

--- a/crates/assistd-wm/src/sway.rs
+++ b/crates/assistd-wm/src/sway.rs
@@ -34,28 +34,20 @@ use tokio::task::JoinHandle;
 
 use crate::criteria::format_workspace_target;
 use crate::error::ipc_ctx;
+use crate::snapshot::{
+    self, Snapshot, WindowChangeKind, apply_window_event, apply_workspace_focus,
+};
 use crate::{
     FocusedWindowContext, Layout, OutputInfo, ResizeDir, WindowId, WindowManager, WmError,
     WmResult, Window, WorkspaceId, WorkspaceInfo,
 };
 
-/// Cached focus state. Seeded from `get_tree()` + `get_workspaces()` at
-/// startup, then updated on each Sway `Window::Focus`, `Window::Title`,
-/// `Window::Close`, and `Workspace::Focus` event so synchronous reads
-/// don't round-trip the IPC socket.
-///
-/// PR 3b stores both the compositor con_id (the [`WindowId`] returned
-/// to callers) and the raw `app_id` / class string used for the system-
-/// prompt context block. On Sway, `focused_class` prefers `app_id`
-/// (Wayland-native) and falls back to the X11 `class` for XWayland —
-/// see the module-level doc.
-#[derive(Default, Clone)]
-struct Snapshot {
-    focused_id: Option<WindowId>,
-    focused_class: Option<String>,
-    focused_title: Option<String>,
-    active_workspace: Option<String>,
-}
+// PR 4: the Snapshot struct + apply-event race rules now live in
+// `crate::snapshot` so the i3 and Sway backends share them. Sway's
+// `focused_class` semantics (prefer `app_id` for Wayland-native
+// windows, fall back to the X11 class for XWayland views) live in
+// `handle_window_event` below, where we project the native event into
+// the shared `(id, class, title)` tuple.
 
 /// Cast a sway `Node.id` (`i64`) to a [`WindowId`]. Sway never emits
 /// non-positive ids in practice, but the bounds check keeps the
@@ -144,7 +136,7 @@ impl SwayBackend {
                                         .current
                                         .as_ref()
                                         .and_then(|n| n.name.clone());
-                                    snap_for_task.write().await.active_workspace = ws;
+                                    apply_workspace_focus(&snap_for_task, ws).await;
                                 }
                             }
                             Some(Ok(_)) => {}
@@ -199,24 +191,11 @@ impl WindowManager for SwayBackend {
     }
 
     async fn focused_window(&self) -> WmResult<Option<WindowId>> {
-        Ok(self.snapshot.read().await.focused_id)
+        Ok(snapshot::read_focused_id(&self.snapshot).await)
     }
 
     async fn focused_context(&self) -> WmResult<Option<FocusedWindowContext>> {
-        let s = self.snapshot.read().await;
-        if s.focused_id.is_none()
-            && s.focused_class.is_none()
-            && s.focused_title.is_none()
-            && s.active_workspace.is_none()
-        {
-            return Ok(None);
-        }
-        Ok(Some(FocusedWindowContext {
-            id: s.focused_id,
-            class: s.focused_class.clone(),
-            title: s.focused_title.clone(),
-            workspace: s.active_workspace.clone(),
-        }))
+        Ok(snapshot::read_focused_context(&self.snapshot).await)
     }
 
     async fn list_windows(&self) -> WmResult<Vec<Window>> {
@@ -391,17 +370,18 @@ async fn seed_snapshot(cmd: &mut Connection) -> Result<Snapshot> {
     })
 }
 
-/// Apply one Sway `Window` event to the cached focus snapshot.
-///
-/// Race rules (mirror i3 backend; key on the unique con_id rather than
-/// the class/app_id, so two windows of the same app don't alias):
-/// - `Focus` overwrites id + class/app_id + title from the new container.
-/// - `Title` only takes effect when the event's con_id matches the
-///   currently-focused id — title events from background windows must
-///   not overwrite the foreground title.
-/// - `Close` clears focus state only when the closed container is the
-///   focused one. Workspace is left intact.
+/// Project a Sway `WindowEvent` into the shared snapshot's
+/// `(id, class, title, kind)` tuple and dispatch to
+/// [`apply_window_event`]. The Sway-specific bits — `app_id` lookup,
+/// XWayland fallback, name-vs-window_properties.title preference —
+/// live here; the race rules live in `crate::snapshot`.
 async fn handle_window_event(w: &swayipc_async::WindowEvent, snap: &Arc<RwLock<Snapshot>>) {
+    let kind = match w.change {
+        WindowChange::Focus => WindowChangeKind::Focus,
+        WindowChange::Title => WindowChangeKind::Title,
+        WindowChange::Close => WindowChangeKind::Close,
+        _ => return,
+    };
     let id = sway_id(w.container.id);
     let class = w.container.app_id.clone().or_else(|| {
         w.container
@@ -415,30 +395,7 @@ async fn handle_window_event(w: &swayipc_async::WindowEvent, snap: &Arc<RwLock<S
             .as_ref()
             .and_then(|p| p.title.clone())
     });
-    match w.change {
-        WindowChange::Focus => {
-            let mut s = snap.write().await;
-            s.focused_id = id;
-            s.focused_class = class;
-            s.focused_title = title;
-        }
-        WindowChange::Title => {
-            let mut s = snap.write().await;
-            if s.focused_id == id && id.is_some() {
-                s.focused_title = title;
-                s.focused_class = class;
-            }
-        }
-        WindowChange::Close => {
-            let mut s = snap.write().await;
-            if s.focused_id == id && id.is_some() {
-                s.focused_id = None;
-                s.focused_class = None;
-                s.focused_title = None;
-            }
-        }
-        _ => {}
-    }
+    apply_window_event(snap, kind, id, class, title).await;
 }
 
 fn walk_focused(node: &Node) -> Option<&Node> {

--- a/crates/assistd-wm/src/sway.rs
+++ b/crates/assistd-wm/src/sway.rs
@@ -40,8 +40,8 @@ use crate::snapshot::{
     self, Snapshot, WindowChangeKind, apply_window_event, apply_workspace_focus,
 };
 use crate::{
-    FocusedWindowContext, Layout, OutputInfo, ResizeDir, WindowId, WindowManager, WmError,
-    WmResult, Window, WorkspaceId, WorkspaceInfo,
+    FocusedWindowContext, Layout, OutputInfo, ResizeDir, Window, WindowId, WindowManager, WmError,
+    WmResult, WorkspaceId, WorkspaceInfo,
 };
 
 // PR 4: the Snapshot struct + apply-event race rules now live in
@@ -133,24 +133,20 @@ impl SwayBackend {
     async fn run(&self, payload: &str) -> WmResult<()> {
         let mut guard = self.cmd.lock().await;
         let conn = guard.as_mut().ok_or(WmError::Disconnected)?;
-        let outcomes = match tokio::time::timeout(
-            crate::WM_IPC_TIMEOUT,
-            conn.run_command(payload),
-        )
-        .await
-        {
-            Err(_) => {
-                *guard = None;
-                self.reconnect.notify_one();
-                return Err(WmError::Timeout(crate::WM_IPC_TIMEOUT));
-            }
-            Ok(Err(e)) => {
-                *guard = None;
-                self.reconnect.notify_one();
-                return Err(ipc_ctx(e, "sway RUN_COMMAND"));
-            }
-            Ok(Ok(v)) => v,
-        };
+        let outcomes =
+            match tokio::time::timeout(crate::WM_IPC_TIMEOUT, conn.run_command(payload)).await {
+                Err(_) => {
+                    *guard = None;
+                    self.reconnect.notify_one();
+                    return Err(WmError::Timeout(crate::WM_IPC_TIMEOUT));
+                }
+                Ok(Err(e)) => {
+                    *guard = None;
+                    self.reconnect.notify_one();
+                    return Err(ipc_ctx(e, "sway RUN_COMMAND"));
+                }
+                Ok(Ok(v)) => v,
+            };
         for r in outcomes {
             r.map_err(|e| WmError::Rejected(format!("{payload}: {e}")))?;
         }
@@ -550,7 +546,10 @@ mod tests {
     #[test]
     fn resize_payload_renders_id_in_decimal() {
         let p = sway_resize_payload(&id(1234567890), ResizeDir::Shrink, 5);
-        assert_eq!(p, r#"[con_id="1234567890"] resize shrink width 5 px or 0 ppt"#);
+        assert_eq!(
+            p,
+            r#"[con_id="1234567890"] resize shrink width 5 px or 0 ppt"#
+        );
     }
 
     #[test]

--- a/crates/assistd-wm/tests/common/mod.rs
+++ b/crates/assistd-wm/tests/common/mod.rs
@@ -11,7 +11,7 @@
 
 use std::sync::Arc;
 
-use assistd_wm::WindowManager;
+use assistd_wm::{WindowId, WindowManager};
 
 /// `focused_window()` should return Some(class) for a session with at
 /// least one mapped, focused window — which is the common case on a
@@ -40,8 +40,14 @@ pub async fn assert_focused_context_agrees(wm: &Arc<dyn WindowManager>) {
         .await
         .expect("focused_context query failed")
         .expect("expected Some(FocusedWindowContext) for a focused session");
+    // `focused` is now `Option<WindowId>` (newtype around the class
+    // string in PR 3a); `ctx.class` is the raw `Option<String>` for
+    // human display. Compare via &str to keep the contract intact while
+    // the inner repr stabilizes (PR 3b will switch WindowId to a
+    // NonZeroU64 con_id and the contract here changes shape with it).
     assert_eq!(
-        ctx.class, focused,
+        ctx.class.as_deref(),
+        focused.as_ref().map(WindowId::as_str),
         "focused_context().class should agree with focused_window()"
     );
 }

--- a/crates/assistd-wm/tests/common/mod.rs
+++ b/crates/assistd-wm/tests/common/mod.rs
@@ -11,7 +11,7 @@
 
 use std::sync::Arc;
 
-use assistd_wm::{WindowId, WindowManager};
+use assistd_wm::WindowManager;
 
 /// `focused_window()` should return Some(class) for a session with at
 /// least one mapped, focused window — which is the common case on a
@@ -40,15 +40,12 @@ pub async fn assert_focused_context_agrees(wm: &Arc<dyn WindowManager>) {
         .await
         .expect("focused_context query failed")
         .expect("expected Some(FocusedWindowContext) for a focused session");
-    // `focused` is now `Option<WindowId>` (newtype around the class
-    // string in PR 3a); `ctx.class` is the raw `Option<String>` for
-    // human display. Compare via &str to keep the contract intact while
-    // the inner repr stabilizes (PR 3b will switch WindowId to a
-    // NonZeroU64 con_id and the contract here changes shape with it).
+    // PR 3b: focused_window() returns the compositor con_id; the
+    // focused_context().id field carries the same id, surfaced from the
+    // same snapshot read. Both are `Option<WindowId>` (NonZeroU64).
     assert_eq!(
-        ctx.class.as_deref(),
-        focused.as_ref().map(WindowId::as_str),
-        "focused_context().class should agree with focused_window()"
+        ctx.id, focused,
+        "focused_context().id should agree with focused_window()"
     );
 }
 


### PR DESCRIPTION
Refinements to window management:
- Id based window controls instead of name based control
- deduped logic in sway.rs and i3.rs
- general improvements