### PR TITLE
Handle MCP tool results in the agent loop

### DIFF
--- a/crates/assistd-core/src/agent.rs
+++ b/crates/assistd-core/src/agent.rs
@@ -878,6 +878,189 @@ mod tests {
         assert_eq!(pushed[1][0].content, "(no memories)");
     }
 
+    /// Fake `Tool` shaped like `McpToolAdapter`: returns the exact
+    /// envelope the live adapter produces (`type` / `output` /
+    /// `exit_code` / `duration_ms` / `truncated`) so the agent loop
+    /// dispatch path is exercised end-to-end without bringing
+    /// `assistd-mcp` in as a dev-dep. Carries a fixed scripted result
+    /// so the test can assert what flowed back to the model.
+    struct FakeMcpTool {
+        name: String,
+        result: Value,
+    }
+
+    #[async_trait]
+    impl assistd_tools::Tool for FakeMcpTool {
+        fn name(&self) -> &str {
+            &self.name
+        }
+        fn description(&self) -> &str {
+            "fake mcp tool"
+        }
+        fn parameters_schema(&self) -> Value {
+            serde_json::json!({"type": "object"})
+        }
+        async fn invoke(&self, _args: Value) -> anyhow::Result<Value> {
+            Ok(self.result.clone())
+        }
+    }
+
+    /// Acceptance: a turn that mixes an MCP-shaped tool call and a
+    /// native `run` call drives both through `dispatch_tool_call`,
+    /// emits a `ToolCall`/`ToolResult` pair for each, and pushes both
+    /// results back to the backend in order. This is the wire-level
+    /// proof that the agent loop is tool-source-agnostic — MCP tools
+    /// and native tools share the same dispatch/result/feedback path.
+    #[tokio::test]
+    async fn agent_loop_mixes_native_and_mcp_calls() {
+        use assistd_tools::commands::EchoCommand;
+        let mut reg = CommandRegistry::new();
+        reg.register(EchoCommand);
+        let mut tools = ToolRegistry::new();
+        tools.register(RunTool::new(
+            Arc::new(reg),
+            &ToolsOutputConfig::default(),
+            std::env::temp_dir().join(format!("assistd-agent-test-mix-{}", std::process::id())),
+        ));
+        // Same envelope shape `McpToolAdapter::tool_result_to_json`
+        // produces for a `ToolResult::Text("calendar entries")`.
+        tools.register(FakeMcpTool {
+            name: "mcp__google_calendar__list_events".into(),
+            result: serde_json::json!({
+                "type": "text",
+                "output": "10:00 standup\n14:00 review",
+                "exit_code": 0,
+                "duration_ms": 12,
+                "truncated": false,
+            }),
+        });
+        let tools = Arc::new(tools);
+
+        let backend = MockBackend::with(vec![
+            // Step 1: model calls the MCP tool.
+            StepOutcome::ToolCalls(vec![ToolCall {
+                id: "c-mcp".into(),
+                name: "mcp__google_calendar__list_events".into(),
+                arguments: serde_json::json!({"date": "tomorrow"}),
+            }]),
+            // Step 2: model follows up with a native `run` call —
+            // proving the loop accepts a different tool on the next
+            // step without state leaking from the prior MCP call.
+            StepOutcome::ToolCalls(vec![call("c-run", "echo hello")]),
+            StepOutcome::Final,
+        ]);
+
+        let (tx, mut rx) = mpsc::channel(32);
+        run_agent_turn(
+            backend.clone(),
+            tools,
+            10,
+            "what's on my calendar tomorrow?".into(),
+            Vec::new(),
+            tx,
+            CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+        let events = collect(&mut rx).await;
+
+        let names: Vec<String> = events
+            .iter()
+            .filter_map(|e| match e {
+                LlmEvent::ToolCall { name, .. } => Some(name.clone()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            names,
+            vec!["mcp__google_calendar__list_events", "run"],
+            "tool calls didn't fire in the scripted order"
+        );
+
+        let pushed = backend.pushed_results.lock().unwrap();
+        assert_eq!(pushed.len(), 2, "two push_tool_results round-trips");
+        assert!(
+            pushed[0][0].content.contains("standup"),
+            "MCP body must reach next step: {:?}",
+            pushed[0][0].content
+        );
+        assert!(
+            pushed[1][0].content.contains("hello"),
+            "native echo body must reach next step: {:?}",
+            pushed[1][0].content
+        );
+    }
+
+    /// Acceptance: when the MCP adapter returns its error envelope
+    /// (`exit_code: -1`, convention-compliant `output` line), the
+    /// agent loop threads it back to the model unchanged so the
+    /// recovery hint survives. Without this, a brittle catch-all
+    /// elsewhere in the dispatch path would clobber the line and the
+    /// model would lose the actionable next step.
+    #[tokio::test]
+    async fn agent_loop_propagates_mcp_error_envelope_to_next_step() {
+        let mut tools = ToolRegistry::new();
+        tools.register(FakeMcpTool {
+            name: "mcp__google_calendar__list_events".into(),
+            // Mirrors `error_envelope` in `assistd-mcp/src/lib.rs` —
+            // the line carries `Check:` which the model needs to see
+            // intact.
+            result: serde_json::json!({
+                "type": "error",
+                "output": "[error] mcp__google_calendar__list_events: \
+                           MCP server returned error code -32602: Invalid params. \
+                           Check: the arguments and try again\n",
+                "exit_code": -1,
+                "duration_ms": 7,
+                "truncated": false,
+            }),
+        });
+        let tools = Arc::new(tools);
+
+        let backend = MockBackend::with(vec![
+            StepOutcome::ToolCalls(vec![ToolCall {
+                id: "c-mcp".into(),
+                name: "mcp__google_calendar__list_events".into(),
+                arguments: serde_json::json!({}),
+            }]),
+            StepOutcome::Final,
+        ]);
+        let (tx, mut rx) = mpsc::channel(16);
+        run_agent_turn(
+            backend.clone(),
+            tools,
+            10,
+            "what's on my calendar?".into(),
+            Vec::new(),
+            tx,
+            CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+        drop(collect(&mut rx).await);
+
+        let pushed = backend.pushed_results.lock().unwrap();
+        assert_eq!(pushed.len(), 1);
+        let payload = &pushed[0][0];
+        assert!(
+            payload
+                .content
+                .starts_with("[error] mcp__google_calendar__list_events: "),
+            "convention prefix lost: {:?}",
+            payload.content
+        );
+        assert!(
+            payload.content.contains("Check:"),
+            "recovery hint stripped before reaching the model: {:?}",
+            payload.content
+        );
+        assert!(
+            payload.content.contains("-32602"),
+            "rpc code lost: {:?}",
+            payload.content
+        );
+    }
+
     #[tokio::test]
     async fn cancellation_during_slow_step_preempts_loop() {
         // Fire a cancellation while the LLM step is still pending,

--- a/crates/assistd-mcp/src/error.rs
+++ b/crates/assistd-mcp/src/error.rs
@@ -7,6 +7,15 @@ use thiserror::Error;
 /// processed our request and returned a structured error" from "the
 /// transport itself broke." `TransportClosed` and `RequestTimeout` are
 /// the two terminal failure modes the supervisor watches for.
+///
+/// # Translating to the agent-facing error convention
+///
+/// Native tool errors follow `[error] <cmd>: <what>. <Hint>: <recovery>` so
+/// the LLM gets a one-step recovery path on every failure (the convention
+/// is documented in `assistd-tools/src/command.rs`). MCP tool failures must
+/// honor the same shape so the model treats them like any other tool error.
+/// [`mcp_error_line`] does that translation per variant — call it from any
+/// site that surfaces an `McpError` to the model.
 #[derive(Debug, Error)]
 pub enum McpError {
     #[error("failed to spawn MCP server `{path}`: {source}")]
@@ -51,5 +60,150 @@ pub enum McpError {
 impl McpError {
     pub fn http(e: impl std::fmt::Display) -> Self {
         Self::Http(e.to_string())
+    }
+}
+
+/// Translate an [`McpError`] into the daemon's `[error] <cmd>: <what>.
+/// <Hint>: <recovery>\n` line shape so the model sees an MCP failure with
+/// the same recovery affordances as a native tool failure.
+///
+/// `tool_name` is the registry-facing identifier (typically
+/// `mcp__<server>__<tool>`) — the LLM is already addressing the tool by
+/// that name, so echoing it back keeps the message anchored.
+///
+/// The `<Hint>` keyword is one of `Use:` / `Try:` / `Check:` / `Available:`
+/// per the convention in `assistd-tools/src/command.rs:11-32`. The recovery
+/// clause is a concrete next step the model can take — retry, switch tools,
+/// or check daemon-side state — chosen to match each variant's failure mode.
+pub fn mcp_error_line(tool_name: &str, e: &McpError) -> String {
+    match e {
+        McpError::Spawn { path, source } => format!(
+            "[error] {tool_name}: failed to spawn MCP server `{path}`: {source}. \
+             Check: the server command/args in config.toml\n"
+        ),
+        McpError::TransportClosed => format!(
+            "[error] {tool_name}: MCP transport closed. \
+             Try: another tool while the server reconnects\n"
+        ),
+        McpError::RequestTimeout(d) => format!(
+            "[error] {tool_name}: MCP request timed out after {d:?}. \
+             Try: the call again or a smaller request\n"
+        ),
+        McpError::RpcError {
+            code,
+            message,
+            data: _,
+        } => format!(
+            "[error] {tool_name}: MCP server returned error code {code}: {message}. \
+             Check: the arguments and try again\n"
+        ),
+        McpError::Protocol(m) => format!(
+            "[error] {tool_name}: MCP protocol error: {m}. \
+             Check: daemon logs for malformed responses\n"
+        ),
+        McpError::ServerDown => format!(
+            "[error] {tool_name}: MCP server is currently unavailable. \
+             Try: another tool while the server reconnects\n"
+        ),
+        McpError::TooManyInFlight => format!(
+            "[error] {tool_name}: too many in-flight MCP requests. \
+             Try: the call again after pending requests drain\n"
+        ),
+        McpError::Io(e) => format!(
+            "[error] {tool_name}: MCP I/O error: {e}. \
+             Check: daemon logs for transport details\n"
+        ),
+        McpError::Json(e) => format!(
+            "[error] {tool_name}: MCP JSON error: {e}. \
+             Check: daemon logs for transport details\n"
+        ),
+        McpError::Http(m) => format!(
+            "[error] {tool_name}: MCP HTTP error: {m}. \
+             Check: daemon logs for transport details\n"
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn contains_hint(s: &str) -> bool {
+        s.contains("Use:") || s.contains("Try:") || s.contains("Check:") || s.contains("Available:")
+    }
+
+    /// Every `McpError` variant must produce a convention-compliant line:
+    /// starts with `[error] <tool>: `, includes one of the four hint words,
+    /// and ends with a newline. Mirrors the gating test in
+    /// `assistd-tools/src/command.rs::every_registered_command_emits_…`.
+    #[test]
+    fn every_variant_emits_convention_compliant_line() {
+        let cases: Vec<(&str, McpError)> = vec![
+            (
+                "spawn",
+                McpError::Spawn {
+                    path: "/usr/bin/fake".into(),
+                    source: std::io::Error::new(std::io::ErrorKind::NotFound, "missing"),
+                },
+            ),
+            ("transport_closed", McpError::TransportClosed),
+            (
+                "timeout",
+                McpError::RequestTimeout(std::time::Duration::from_secs(30)),
+            ),
+            (
+                "rpc",
+                McpError::RpcError {
+                    code: -32602,
+                    message: "Invalid params".into(),
+                    data: None,
+                },
+            ),
+            ("protocol", McpError::Protocol("bad frame".into())),
+            ("server_down", McpError::ServerDown),
+            ("too_many", McpError::TooManyInFlight),
+            ("io", McpError::Io(std::io::Error::other("pipe broke"))),
+            ("http", McpError::Http("503".into())),
+        ];
+        for (label, e) in cases {
+            let line = mcp_error_line("mcp__web__search", &e);
+            assert!(
+                line.starts_with("[error] mcp__web__search: "),
+                "{label}: missing `[error] <tool>: ` prefix — got {line:?}"
+            );
+            assert!(
+                contains_hint(&line),
+                "{label}: missing recovery hint (Use/Try/Check/Available) — got {line:?}"
+            );
+            assert!(line.ends_with('\n'), "{label}: missing trailing newline");
+        }
+    }
+
+    #[test]
+    fn rpc_error_line_carries_code_and_message() {
+        let e = McpError::RpcError {
+            code: -32602,
+            message: "Invalid params: missing `query`".into(),
+            data: None,
+        };
+        let line = mcp_error_line("mcp__web__search", &e);
+        assert!(line.contains("-32602"), "{line}");
+        assert!(line.contains("Invalid params"), "{line}");
+        assert!(line.contains("Check:"), "{line}");
+    }
+
+    #[test]
+    fn timeout_line_carries_duration() {
+        let e = McpError::RequestTimeout(std::time::Duration::from_secs(30));
+        let line = mcp_error_line("mcp__web__search", &e);
+        assert!(line.contains("30s"), "duration must be visible: {line}");
+        assert!(line.contains("Try:"), "{line}");
+    }
+
+    #[test]
+    fn server_down_line_suggests_retry() {
+        let line = mcp_error_line("mcp__web__search", &McpError::ServerDown);
+        assert!(line.contains("Try:"), "{line}");
+        assert!(line.contains("reconnect"), "{line}");
     }
 }

--- a/crates/assistd-mcp/src/health_route.rs
+++ b/crates/assistd-mcp/src/health_route.rs
@@ -17,6 +17,7 @@ use async_trait::async_trait;
 use serde_json::{Value, json};
 use tokio::sync::watch;
 
+use crate::error::{McpError, mcp_error_line};
 use crate::handle::HealthState;
 use crate::{McpToolAdapter, Tool};
 
@@ -64,19 +65,21 @@ impl Tool for HealthRoutedTool {
                 // `assistd_tools::PresentResult` so the agent loop's
                 // dispatch site (`agent.rs::dispatch_tool_call`) reads
                 // `output`/`exit_code`/`duration_ms`/`truncated` straight
-                // into the tool_role message body. The model gets a
-                // typed error it can react to without the daemon
-                // surfacing this as a transport failure.
+                // into the tool_role message body. Routing through
+                // `mcp_error_line(ServerDown)` keeps the line shape
+                // consistent with every other MCP failure the model
+                // sees, so the recovery hint (`Try: another tool while
+                // the server reconnects`) is the same regardless of
+                // whether the failure was caught at the wrapper or at
+                // the transport. `duration_ms` stays 0 — the wrapper
+                // short-circuits before any RPC, so 0 is honest.
                 Ok(json!({
                     "type": "error",
-                    "output": format!(
-                        "[error] {}: MCP server '{}' unavailable; tool cannot be called.",
-                        self.inner.name(),
-                        self.server_name,
-                    ),
+                    "output": mcp_error_line(self.inner.name(), &McpError::ServerDown),
                     "exit_code": -1,
                     "duration_ms": 0,
                     "truncated": false,
+                    "server_name": self.server_name,
                 }))
             }
         }
@@ -133,9 +136,18 @@ mod tests {
         assert_eq!(result["type"], "error");
         assert_eq!(result["exit_code"], -1);
         assert_eq!(result["truncated"], false);
+        // Server name carried out-of-band on a separate field so the
+        // message body itself can stay convention-compliant without
+        // having to embed the supervisor's identifier mid-sentence.
+        assert_eq!(result["server_name"], "web");
         let output = result["output"].as_str().unwrap();
-        assert!(output.contains("mcp__web__search"));
-        assert!(output.contains("'web'"));
+        // Convention-compliant line: `[error] <tool>: <what>. <Hint>: <recovery>\n`
+        assert!(output.starts_with("[error] mcp__web__search: "), "{output}");
+        assert!(
+            output.contains("Try:") || output.contains("Check:"),
+            "missing recovery hint: {output}"
+        );
+        assert!(output.ends_with('\n'));
     }
 
     #[tokio::test]

--- a/crates/assistd-mcp/src/lib.rs
+++ b/crates/assistd-mcp/src/lib.rs
@@ -52,6 +52,7 @@
 //! local `see` / `screenshot` commands.
 
 use std::sync::Arc;
+use std::time::Instant;
 
 use anyhow::Result;
 use assistd_tools::Tool;
@@ -66,7 +67,7 @@ pub mod jsonrpc;
 pub mod sse;
 pub mod stdio;
 
-pub use error::McpError;
+pub use error::{McpError, mcp_error_line};
 pub use handle::{HealthState, McpServerHandle, SwitchingClient, TransportConfig};
 pub use health_route::HealthRoutedTool;
 pub use sse::{SseConfig, SseLifeline, SseMcpClient};
@@ -146,10 +147,47 @@ impl Tool for McpToolAdapter {
         self.schema.input_schema.clone()
     }
 
+    /// Always resolves to `Ok(json)` — failure is rendered into the
+    /// envelope itself (with `exit_code: -1` and a convention-compliant
+    /// `[error] …. <Hint>: <recovery>` line in `output`) instead of
+    /// bubbling a Rust `Err` to the agent loop. That keeps the model on a
+    /// single recovery path: read the error line, pick a different tool or
+    /// retry. Bubbling the error would be caught by `dispatch_tool_call`'s
+    /// generic catch-all, which collapses every variant into the same
+    /// "tool invocation failed" message and loses the recovery hint.
     async fn invoke(&self, args: Value) -> Result<Value> {
-        let result = self.client.invoke(&self.schema.name, args).await?;
-        Ok(tool_result_to_json(result))
+        let start = Instant::now();
+        let outcome = self.client.invoke(&self.schema.name, args).await;
+        let duration_ms = start.elapsed().as_millis();
+        match outcome {
+            Ok(r) => Ok(tool_result_to_json(r, duration_ms)),
+            Err(e) => Ok(error_envelope(&self.registry_name, &e, duration_ms)),
+        }
     }
+}
+
+/// Build the failure-shaped JSON envelope. Mirrors the success shape so
+/// the agent loop's `dispatch_tool_call` reads `output`/`exit_code`/
+/// `duration_ms` straight into the tool-result message body without a
+/// branch. The error line itself comes from [`mcp_error_line`] when the
+/// underlying error is an [`McpError`]; for unexpected error types we
+/// fall back to a generic Convention-compliant line so the body still
+/// carries a `<Hint>: <recovery>` clause.
+fn error_envelope(tool_name: &str, e: &anyhow::Error, duration_ms: u128) -> Value {
+    let line = match e.downcast_ref::<McpError>() {
+        Some(mcp_err) => mcp_error_line(tool_name, mcp_err),
+        None => format!(
+            "[error] {tool_name}: tool invocation failed: {e}. \
+             Try: a different command\n"
+        ),
+    };
+    json!({
+        "type": "error",
+        "output": line,
+        "exit_code": -1,
+        "duration_ms": duration_ms,
+        "truncated": false,
+    })
 }
 
 /// Render an [`McpClient`] [`ToolResult`] into the JSON shape the agent
@@ -161,21 +199,25 @@ impl Tool for McpToolAdapter {
 ///   "type": "text" | "image" | "json",
 ///   "output": "...",                    // model-visible body
 ///   "exit_code": 0,
-///   "duration_ms": 0,
+///   "duration_ms": <real-elapsed-ms>,
 ///   "truncated": false,
 ///   "attachments": [...]                // present only for Image
 /// }
 /// ```
 ///
+/// `duration_ms` is supplied by the caller so it reflects the actual MCP
+/// RPC round-trip time — the TUI surfaces this in the `[exit:N | Xms]`
+/// footer alongside the colored bar.
+///
 /// `attachments[].data` is the base64-encoded image bytes (NOT
 /// `bytes_base64`); this matches `assistd_core::agent::parse_attachment`.
-fn tool_result_to_json(r: ToolResult) -> Value {
+fn tool_result_to_json(r: ToolResult, duration_ms: u128) -> Value {
     match r {
         ToolResult::Text(s) => json!({
             "type": "text",
             "output": s,
             "exit_code": 0,
-            "duration_ms": 0,
+            "duration_ms": duration_ms,
             "truncated": false,
         }),
         ToolResult::Json(v) => json!({
@@ -183,7 +225,7 @@ fn tool_result_to_json(r: ToolResult) -> Value {
             "output": v.to_string(),
             "value": v,
             "exit_code": 0,
-            "duration_ms": 0,
+            "duration_ms": duration_ms,
             "truncated": false,
         }),
         ToolResult::Image { mime, bytes } => {
@@ -193,7 +235,7 @@ fn tool_result_to_json(r: ToolResult) -> Value {
                 "type": "image",
                 "output": format!("(image: {mime}, {len} bytes)"),
                 "exit_code": 0,
-                "duration_ms": 0,
+                "duration_ms": duration_ms,
                 "truncated": false,
                 "attachments": [
                     {"type": "image", "mime": mime, "data": data_b64}
@@ -297,6 +339,31 @@ mod tests {
         }
     }
 
+    /// Fake server that always fails its `invoke` with a caller-supplied
+    /// `McpError`, after an optional sleep. Used to exercise the
+    /// adapter's error-envelope path and duration tracking.
+    struct ErrFakeClient {
+        err: std::sync::Mutex<Option<McpError>>,
+        sleep: std::time::Duration,
+    }
+
+    #[async_trait]
+    impl McpClient for ErrFakeClient {
+        async fn list_tools(&self) -> Result<Vec<ToolSchema>> {
+            Ok(vec![ToolSchema {
+                name: "search".into(),
+                description: "search".into(),
+                input_schema: json!({"type": "object"}),
+            }])
+        }
+
+        async fn invoke(&self, _name: &str, _arguments: Value) -> Result<ToolResult> {
+            tokio::time::sleep(self.sleep).await;
+            let e = self.err.lock().unwrap().take().expect("err pre-armed");
+            Err(e.into())
+        }
+    }
+
     fn one_tool_client() -> Arc<dyn McpClient> {
         Arc::new(FakeMcpClient {
             schemas: vec![ToolSchema {
@@ -304,6 +371,13 @@ mod tests {
                 description: "search the web".into(),
                 input_schema: json!({"type": "object", "properties": {}}),
             }],
+        })
+    }
+
+    fn err_client_with(err: McpError, sleep: std::time::Duration) -> Arc<dyn McpClient> {
+        Arc::new(ErrFakeClient {
+            err: std::sync::Mutex::new(Some(err)),
+            sleep,
         })
     }
 
@@ -339,10 +413,13 @@ mod tests {
 
     #[test]
     fn image_tool_result_lifts_into_attachments_array() {
-        let v = tool_result_to_json(ToolResult::Image {
-            mime: "image/png".into(),
-            bytes: vec![0xDE, 0xAD, 0xBE, 0xEF],
-        });
+        let v = tool_result_to_json(
+            ToolResult::Image {
+                mime: "image/png".into(),
+                bytes: vec![0xDE, 0xAD, 0xBE, 0xEF],
+            },
+            0,
+        );
         assert_eq!(v["type"], "image");
         assert_eq!(v["exit_code"], 0);
         assert_eq!(v["truncated"], false);
@@ -362,7 +439,7 @@ mod tests {
 
     #[test]
     fn text_tool_result_uses_dispatch_envelope() {
-        let v = tool_result_to_json(ToolResult::Text("hello".into()));
+        let v = tool_result_to_json(ToolResult::Text("hello".into()), 0);
         assert_eq!(v["type"], "text");
         assert_eq!(v["output"], "hello");
         assert_eq!(v["exit_code"], 0);
@@ -371,14 +448,89 @@ mod tests {
 
     #[test]
     fn json_tool_result_carries_value_and_string_output() {
-        let v = tool_result_to_json(ToolResult::Json(json!({"answer": 42})));
+        let v = tool_result_to_json(ToolResult::Json(json!({"answer": 42})), 0);
         assert_eq!(v["type"], "json");
         assert_eq!(v["value"], json!({"answer": 42}));
         assert!(v["output"].as_str().unwrap().contains("answer"));
     }
 
     #[test]
+    fn tool_result_carries_duration_ms_through_envelope() {
+        let v = tool_result_to_json(ToolResult::Text("hi".into()), 42);
+        assert_eq!(v["duration_ms"], 42);
+    }
+
+    #[test]
     fn version_is_not_empty() {
         assert!(!version().is_empty());
+    }
+
+    /// Acceptance: when the upstream client fails with `RpcError`, the
+    /// adapter must surface the failure as a tool-result envelope (not
+    /// a Rust `Err`), with `exit_code: -1` and a convention-compliant
+    /// `[error] <tool>: …. Check: …` line. This is what lets the agent
+    /// loop's `dispatch_tool_call` thread the body straight into the
+    /// model's tool-role message without losing the recovery hint.
+    #[tokio::test]
+    async fn adapter_returns_error_envelope_on_rpc_error() {
+        let client = err_client_with(
+            McpError::RpcError {
+                code: -32602,
+                message: "missing field 'query'".into(),
+                data: None,
+            },
+            std::time::Duration::ZERO,
+        );
+        let tools = adapt_client_as_tools(client, "mcp__web").await.unwrap();
+        let tool = tools.into_iter().next().unwrap();
+        let out = tool.invoke(json!({})).await.unwrap();
+        assert_eq!(out["type"], "error");
+        assert_eq!(out["exit_code"], -1);
+        assert_eq!(out["truncated"], false);
+        let body = out["output"].as_str().unwrap();
+        assert!(
+            body.starts_with("[error] mcp__web__search: "),
+            "missing convention prefix: {body}"
+        );
+        assert!(body.contains("-32602"), "missing rpc code: {body}");
+        assert!(body.contains("missing field"), "missing message: {body}");
+        assert!(body.contains("Check:"), "missing recovery hint: {body}");
+    }
+
+    /// Acceptance: timeouts get a `Try:` recovery hint that suggests
+    /// retrying or shrinking the request — distinct from `RpcError`'s
+    /// `Check:` (which says "the input is wrong"). The model needs the
+    /// distinction to pick the right next step.
+    #[tokio::test]
+    async fn adapter_returns_error_envelope_on_timeout() {
+        let client = err_client_with(
+            McpError::RequestTimeout(std::time::Duration::from_secs(30)),
+            std::time::Duration::ZERO,
+        );
+        let tools = adapt_client_as_tools(client, "mcp__web").await.unwrap();
+        let tool = tools.into_iter().next().unwrap();
+        let out = tool.invoke(json!({})).await.unwrap();
+        assert_eq!(out["type"], "error");
+        assert_eq!(out["exit_code"], -1);
+        let body = out["output"].as_str().unwrap();
+        assert!(body.contains("timed out"), "{body}");
+        assert!(body.contains("30s"), "{body}");
+        assert!(body.contains("Try:"), "{body}");
+    }
+
+    /// Acceptance: `duration_ms` reflects the real RPC round-trip, not
+    /// a hardcoded 0. The TUI's `[exit:N | Xms]` footer surfaces this
+    /// to the user, so a stuck call should look stuck.
+    #[tokio::test]
+    async fn adapter_records_real_duration_ms() {
+        let client = err_client_with(McpError::ServerDown, std::time::Duration::from_millis(20));
+        let tools = adapt_client_as_tools(client, "mcp__web").await.unwrap();
+        let tool = tools.into_iter().next().unwrap();
+        let out = tool.invoke(json!({})).await.unwrap();
+        let dur = out["duration_ms"].as_u64().expect("duration_ms u64");
+        assert!(
+            dur >= 15,
+            "duration must include the upstream sleep: got {dur}ms"
+        );
     }
 }

--- a/crates/assistd-mcp/tests/integration_stdio.rs
+++ b/crates/assistd-mcp/tests/integration_stdio.rs
@@ -165,9 +165,19 @@ async fn server_crash_short_circuits_subsequent_calls() {
         .expect("invoke returns Ok with a typed error JSON");
     assert_eq!(post["type"], "error");
     assert_eq!(post["exit_code"], -1);
+    // Server name carried out-of-band on `server_name` so the message
+    // body itself can stay convention-compliant without embedding the
+    // supervisor's identifier mid-sentence.
+    assert_eq!(post["server_name"], "fake");
     let output = post["output"].as_str().unwrap();
-    assert!(output.contains("mcp__fake__echo"));
-    assert!(output.contains("'fake'"));
+    assert!(
+        output.starts_with("[error] mcp__fake__echo: "),
+        "convention prefix missing: {output}"
+    );
+    assert!(
+        output.contains("Try:") || output.contains("Check:"),
+        "recovery hint missing: {output}"
+    );
 
     handle.shutdown().await;
 }


### PR DESCRIPTION
refined MCP tool integration so MCP calls behave like native ones in the agent loop.