### PR TITLE
Add graceful error recovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,6 +194,7 @@ dependencies = [
  "assistd-wm",
  "async-trait",
  "base64",
+ "libc",
  "serde",
  "serde_json",
  "shlex",

--- a/crates/assistd-core/Cargo.toml
+++ b/crates/assistd-core/Cargo.toml
@@ -19,6 +19,7 @@ assistd-wm    = { workspace = true }
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 base64 = { workspace = true }
+libc = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 shlex = { workspace = true }

--- a/crates/assistd-core/src/agent.rs
+++ b/crates/assistd-core/src/agent.rs
@@ -1303,7 +1303,7 @@ mod tests {
         ) -> Result<(), assistd_llm::HealthWaitError> {
             self.wait_calls
                 .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            self.wait_result.lock().unwrap().clone().unwrap_or(Ok(()))
+            (*self.wait_result.lock().unwrap()).unwrap_or(Ok(()))
         }
     }
 

--- a/crates/assistd-core/src/agent.rs
+++ b/crates/assistd-core/src/agent.rs
@@ -12,15 +12,25 @@
 //! conversation state. `AppState::handle_query` owns that lock.
 
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use anyhow::Result;
-use assistd_llm::{LlmBackend, LlmError, LlmEvent, StepOutcome, ToolCall, ToolResultPayload};
+use assistd_llm::{
+    HealthWaitError, LlmBackend, LlmError, LlmEvent, LlmHealthProbe, StepOutcome, ToolCall,
+    ToolResultPayload,
+};
 use assistd_tools::{Attachment, ToolRegistry};
 use serde_json::Value;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, instrument, warn};
+
+/// Wall-clock budget for waiting on an LLM restart before falling
+/// through to a terminal error. The supervisor's worst-case backoff
+/// sum is 1+2+4+8+16+32 = 63s; 75s gives headroom for spawn + health
+/// probe latency. Longer than this and we treat the restart as
+/// hopeless and surface to the user.
+const REPLAY_WAIT_BUDGET: Duration = Duration::from_secs(75);
 
 /// Run one agent turn end-to-end.
 ///
@@ -49,6 +59,13 @@ use tracing::{debug, info, instrument, warn};
 /// Pass [`CancellationToken::new`] (a fresh, never-cancelled token) if
 /// the caller doesn't need explicit cancellation — the
 /// `tx.is_closed()` path keeps existing behaviour for that case.
+///
+/// `health` is the optional restart probe used to recover from
+/// llama-server crashes mid-turn. When `Some`, the loop reacts to
+/// [`LlmError::ServerRestarting`] by emitting a `Status` event,
+/// waiting for `ReadyState::Ready`, and re-running the same step
+/// once. Pass `None` for tests / mock backends that never crash.
+#[allow(clippy::too_many_arguments)]
 #[instrument(skip_all, name = "agent_turn")]
 pub async fn run_agent_turn(
     backend: Arc<dyn LlmBackend>,
@@ -58,6 +75,7 @@ pub async fn run_agent_turn(
     user_attachments: Vec<Attachment>,
     tx: mpsc::Sender<LlmEvent>,
     cancel: CancellationToken,
+    health: Option<Arc<dyn LlmHealthProbe>>,
 ) -> Result<()> {
     backend
         .push_user(user_text, user_attachments)
@@ -76,18 +94,124 @@ pub async fn run_agent_turn(
             return Ok(());
         }
 
-        let outcome = tokio::select! {
-            biased;
-            () = cancel.cancelled() => {
-                debug!(
-                    target: "assistd::agent",
-                    iteration,
-                    "cancellation fired during LLM step; stopping"
-                );
-                return Ok(());
-            }
-            r = backend.step(schemas.clone(), tx.clone()) => match r {
-                Ok(o) => o,
+        // Per-iteration replay budget: at most one restart-driven
+        // retry. The supervisor's own consecutive-failure cap (5) is
+        // the daemon-level circuit breaker; this keeps the user-visible
+        // latency bounded if the supervisor recovers but the model
+        // still crashes on the same prompt.
+        let mut restart_attempted = false;
+
+        let outcome = loop {
+            let step_result = tokio::select! {
+                biased;
+                () = cancel.cancelled() => {
+                    debug!(
+                        target: "assistd::agent",
+                        iteration,
+                        "cancellation fired during LLM step; stopping"
+                    );
+                    return Ok(());
+                }
+                r = backend.step(schemas.clone(), tx.clone()) => r,
+            };
+
+            match step_result {
+                Ok(o) => break o,
+                Err(LlmError::ServerRestarting(reason))
+                    if !restart_attempted && health.is_some() =>
+                {
+                    restart_attempted = true;
+                    crate::recovery_event!(
+                        crate::RecoverySeverity::Warning,
+                        crate::Component::Llm,
+                        "crash_detected",
+                        iteration = iteration,
+                        reason = %reason,
+                        "llama-server died mid-step; waiting for supervisor restart and replaying"
+                    );
+                    let _ = tx
+                        .send(LlmEvent::Status {
+                            severity: crate::RecoverySeverity::Warning.as_str().to_string(),
+                            component: crate::Component::Llm.as_str().to_string(),
+                            event: "restarting".to_string(),
+                            message: "LLM crashed — restarting and replaying your query"
+                                .to_string(),
+                        })
+                        .await;
+
+                    // Probe is guaranteed Some by the match guard.
+                    let probe = health.as_ref().expect("health Some by guard");
+                    let wait_result = tokio::select! {
+                        biased;
+                        () = cancel.cancelled() => {
+                            debug!(
+                                target: "assistd::agent",
+                                iteration,
+                                "cancellation fired while waiting for LLM restart"
+                            );
+                            return Ok(());
+                        }
+                        res = probe.wait_for_ready(REPLAY_WAIT_BUDGET) => res,
+                    };
+
+                    match wait_result {
+                        Ok(()) => {
+                            crate::recovery_event!(
+                                crate::RecoverySeverity::Info,
+                                crate::Component::Llm,
+                                "replay_ready",
+                                iteration = iteration,
+                                "supervisor reported Ready; replaying user query"
+                            );
+                            let _ = tx
+                                .send(LlmEvent::Status {
+                                    severity: crate::RecoverySeverity::Info.as_str().to_string(),
+                                    component: crate::Component::Llm.as_str().to_string(),
+                                    event: "replaying".to_string(),
+                                    message: "LLM restored — replaying your query".to_string(),
+                                })
+                                .await;
+                            // Retry the same iteration.
+                            continue;
+                        }
+                        Err(wait_err) => {
+                            crate::recovery_event!(
+                                crate::RecoverySeverity::Error,
+                                crate::Component::Llm,
+                                "replay_abandoned",
+                                iteration = iteration,
+                                wait_error = %wait_err,
+                                "supervisor did not return to Ready; abandoning replay"
+                            );
+                            let final_msg = match wait_err {
+                                HealthWaitError::Timeout => "LLM did not recover before timeout",
+                                HealthWaitError::Degraded => {
+                                    "LLM supervisor entered degraded state; restart abandoned"
+                                }
+                                HealthWaitError::NoService => {
+                                    "LLM service is not currently attached"
+                                }
+                            };
+                            let _ = tx
+                                .send(LlmEvent::Status {
+                                    severity: crate::RecoverySeverity::Error.as_str().to_string(),
+                                    component: crate::Component::Llm.as_str().to_string(),
+                                    event: "degraded".to_string(),
+                                    message: final_msg.to_string(),
+                                })
+                                .await;
+                            let _ = tx
+                                .send(LlmEvent::Delta {
+                                    text: format!("\n[agent error: {final_msg}]\n"),
+                                })
+                                .await;
+                            let _ = tx.send(LlmEvent::Done).await;
+                            return Err(anyhow::Error::new(LlmError::ServerRestarting(
+                                final_msg.to_string(),
+                            )));
+                        }
+                    }
+                }
                 Err(e) => {
                     // Surface the typed error category to the model so
                     // a transient HTTP hiccup doesn't read the same as
@@ -98,6 +222,9 @@ pub async fn run_agent_turn(
                         LlmError::Chat(_) => "chat backend",
                         LlmError::ToolCallParse(_) => "tool-call parse",
                         LlmError::Unavailable(_) => "backend unavailable",
+                        // Already-attempted restart, or no probe wired.
+                        // Fall through as a terminal failure.
+                        LlmError::ServerRestarting(_) => "llm restarting",
                     };
                     let _ = tx
                         .send(LlmEvent::Delta {
@@ -107,7 +234,7 @@ pub async fn run_agent_turn(
                     let _ = tx.send(LlmEvent::Done).await;
                     return Err(anyhow::Error::new(e));
                 }
-            },
+            }
         };
 
         match outcome {
@@ -474,6 +601,7 @@ mod tests {
             Vec::new(),
             tx,
             CancellationToken::new(),
+            None,
         )
         .await
         .unwrap();
@@ -500,6 +628,7 @@ mod tests {
             Vec::new(),
             tx,
             CancellationToken::new(),
+            None,
         )
         .await
         .unwrap();
@@ -563,6 +692,7 @@ mod tests {
             Vec::new(),
             tx,
             CancellationToken::new(),
+            None,
         )
         .await
         .unwrap();
@@ -606,6 +736,7 @@ mod tests {
             Vec::new(),
             tx,
             CancellationToken::new(),
+            None,
         )
         .await
         .unwrap();
@@ -647,6 +778,7 @@ mod tests {
             Vec::new(),
             tx,
             CancellationToken::new(),
+            None,
         )
         .await
         .unwrap();
@@ -700,6 +832,7 @@ mod tests {
             Vec::new(),
             tx,
             CancellationToken::new(),
+            None,
         )
         .await
         .unwrap();
@@ -735,6 +868,7 @@ mod tests {
             Vec::new(),
             tx,
             CancellationToken::new(),
+            None,
         )
         .await
         .unwrap();
@@ -768,6 +902,7 @@ mod tests {
             Vec::new(),
             tx,
             token,
+            None,
         )
         .await
         .unwrap();
@@ -849,6 +984,7 @@ mod tests {
             Vec::new(),
             tx,
             CancellationToken::new(),
+            None,
         )
         .await
         .unwrap();
@@ -978,6 +1114,7 @@ mod tests {
             Vec::new(),
             tx,
             CancellationToken::new(),
+            None,
         )
         .await
         .unwrap();
@@ -1053,6 +1190,7 @@ mod tests {
             Vec::new(),
             tx,
             CancellationToken::new(),
+            None,
         )
         .await
         .unwrap();
@@ -1105,6 +1243,7 @@ mod tests {
             Vec::new(),
             tx,
             token,
+            None,
         )
         .await
         .unwrap();
@@ -1115,6 +1254,267 @@ mod tests {
         assert!(
             elapsed < std::time::Duration::from_millis(500),
             "cancellation did not preempt slow step (elapsed: {elapsed:?})"
+        );
+    }
+
+    /// Mock probe that lets a test script the wait_for_ready outcome.
+    /// Used to drive the replay-on-ServerRestarting path without
+    /// standing up a real PresenceManager.
+    struct MockProbe {
+        pid: StdMutex<Option<u32>>,
+        state: StdMutex<assistd_llm::ReadyState>,
+        wait_result: StdMutex<Option<Result<(), assistd_llm::HealthWaitError>>>,
+        wait_calls: std::sync::atomic::AtomicUsize,
+    }
+
+    impl MockProbe {
+        fn ready_with_wait_ok(pid: u32) -> Arc<Self> {
+            Arc::new(Self {
+                pid: StdMutex::new(Some(pid)),
+                state: StdMutex::new(assistd_llm::ReadyState::Ready),
+                wait_result: StdMutex::new(Some(Ok(()))),
+                wait_calls: std::sync::atomic::AtomicUsize::new(0),
+            })
+        }
+
+        fn ready_with_wait_err(err: assistd_llm::HealthWaitError) -> Arc<Self> {
+            Arc::new(Self {
+                pid: StdMutex::new(Some(99)),
+                state: StdMutex::new(assistd_llm::ReadyState::Degraded),
+                wait_result: StdMutex::new(Some(Err(err))),
+                wait_calls: std::sync::atomic::AtomicUsize::new(0),
+            })
+        }
+    }
+
+    #[async_trait]
+    impl LlmHealthProbe for MockProbe {
+        fn pid(&self) -> Option<u32> {
+            *self.pid.lock().unwrap()
+        }
+
+        fn state(&self) -> Option<assistd_llm::ReadyState> {
+            Some(*self.state.lock().unwrap())
+        }
+
+        async fn wait_for_ready(
+            &self,
+            _budget: std::time::Duration,
+        ) -> Result<(), assistd_llm::HealthWaitError> {
+            self.wait_calls
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            self.wait_result.lock().unwrap().clone().unwrap_or(Ok(()))
+        }
+    }
+
+    /// Mock backend that injects errors before falling through to the
+    /// existing outcome queue. Used to exercise error-handling paths
+    /// (server-restart replay, terminal failures) without needing a
+    /// real LlamaChatClient.
+    struct ErrorInjectingBackend {
+        errors: StdMutex<Vec<LlmError>>,
+        outcomes: StdMutex<Vec<StepOutcome>>,
+        step_calls: std::sync::atomic::AtomicUsize,
+        pushed_users: StdMutex<Vec<String>>,
+    }
+
+    impl ErrorInjectingBackend {
+        fn new(errors: Vec<LlmError>, outcomes: Vec<StepOutcome>) -> Arc<Self> {
+            Arc::new(Self {
+                errors: StdMutex::new(errors),
+                outcomes: StdMutex::new(outcomes),
+                step_calls: std::sync::atomic::AtomicUsize::new(0),
+                pushed_users: StdMutex::new(Vec::new()),
+            })
+        }
+    }
+
+    #[async_trait]
+    impl LlmBackend for ErrorInjectingBackend {
+        async fn generate(
+            &self,
+            _prompt: String,
+            _tx: mpsc::Sender<LlmEvent>,
+        ) -> assistd_llm::LlmResult<()> {
+            unimplemented!("mock uses step path only")
+        }
+
+        async fn push_user(
+            &self,
+            text: String,
+            _attachments: Vec<Attachment>,
+        ) -> assistd_llm::LlmResult<()> {
+            self.pushed_users.lock().unwrap().push(text);
+            Ok(())
+        }
+
+        async fn push_tool_results(
+            &self,
+            _results: Vec<ToolResultPayload>,
+        ) -> assistd_llm::LlmResult<()> {
+            Ok(())
+        }
+
+        async fn step(
+            &self,
+            _tools: Vec<Value>,
+            tx: mpsc::Sender<LlmEvent>,
+        ) -> assistd_llm::LlmResult<StepOutcome> {
+            self.step_calls
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            // Errors first; once they're exhausted, fall through to
+            // outcomes. Lets a single test script "first attempt
+            // crashes, second attempt succeeds".
+            let next_err = self.errors.lock().unwrap().pop();
+            if let Some(e) = next_err {
+                return Err(e);
+            }
+            let outcome = self
+                .outcomes
+                .lock()
+                .unwrap()
+                .pop()
+                .unwrap_or(StepOutcome::Final);
+            if matches!(outcome, StepOutcome::Final) {
+                let _ = tx.send(LlmEvent::Delta { text: "ok".into() }).await;
+            }
+            Ok(outcome)
+        }
+    }
+
+    #[tokio::test]
+    async fn replay_once_on_server_restarting() {
+        // First attempt: ServerRestarting. Probe says Ready returns Ok.
+        // Second attempt: Final.
+        // Expected: exactly one step retry; Status events for restarting
+        // and replaying; final Done; no terminal Error.
+        let backend = ErrorInjectingBackend::new(
+            vec![LlmError::ServerRestarting("boom".into())],
+            vec![StepOutcome::Final],
+        );
+        let probe = MockProbe::ready_with_wait_ok(123);
+        let tools = tools_with_echo();
+        let (tx, mut rx) = mpsc::channel(32);
+        run_agent_turn(
+            backend.clone(),
+            tools,
+            10,
+            "hello".into(),
+            Vec::new(),
+            tx,
+            CancellationToken::new(),
+            Some(probe.clone()),
+        )
+        .await
+        .expect("replay should succeed");
+
+        let events = collect(&mut rx).await;
+        let restart_count = events
+            .iter()
+            .filter(|e| matches!(e, LlmEvent::Status { event, .. } if event == "restarting"))
+            .count();
+        let replaying_count = events
+            .iter()
+            .filter(|e| matches!(e, LlmEvent::Status { event, .. } if event == "replaying"))
+            .count();
+        assert_eq!(restart_count, 1, "expected one restarting Status event");
+        assert_eq!(replaying_count, 1, "expected one replaying Status event");
+        assert!(matches!(events.last(), Some(LlmEvent::Done)));
+        assert_eq!(
+            probe.wait_calls.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "wait_for_ready should be called exactly once"
+        );
+        // Two step calls: the failing one and the successful retry.
+        assert_eq!(
+            backend.step_calls.load(std::sync::atomic::Ordering::SeqCst),
+            2
+        );
+    }
+
+    #[tokio::test]
+    async fn replay_does_not_loop_on_repeated_server_restarting() {
+        // Two ServerRestarting in a row: the loop should retry once,
+        // see the second crash, and surface a terminal error rather
+        // than continue replaying. The supervisor's circuit-breaker
+        // (Degraded after 5 consecutive failures) is the daemon-level
+        // backstop; this test asserts the per-iteration cap.
+        let backend = ErrorInjectingBackend::new(
+            vec![
+                LlmError::ServerRestarting("second".into()),
+                LlmError::ServerRestarting("first".into()),
+            ],
+            vec![],
+        );
+        let probe = MockProbe::ready_with_wait_ok(123);
+        let tools = tools_with_echo();
+        let (tx, mut rx) = mpsc::channel(32);
+        let result = run_agent_turn(
+            backend.clone(),
+            tools,
+            10,
+            "hello".into(),
+            Vec::new(),
+            tx,
+            CancellationToken::new(),
+            Some(probe),
+        )
+        .await;
+        assert!(result.is_err(), "second ServerRestarting must be terminal");
+
+        let events = collect(&mut rx).await;
+        let restart_count = events
+            .iter()
+            .filter(|e| matches!(e, LlmEvent::Status { event, .. } if event == "restarting"))
+            .count();
+        assert_eq!(
+            restart_count, 1,
+            "should attempt replay only once, then surface error"
+        );
+        assert!(matches!(events.last(), Some(LlmEvent::Done)));
+        // Two step calls: original + one replay attempt.
+        assert_eq!(
+            backend.step_calls.load(std::sync::atomic::Ordering::SeqCst),
+            2
+        );
+    }
+
+    #[tokio::test]
+    async fn replay_abandons_on_degraded_supervisor() {
+        // ServerRestarting once, but the probe reports Degraded.
+        // Expected: a `degraded` Status event followed by a terminal
+        // error. No second step call.
+        let backend =
+            ErrorInjectingBackend::new(vec![LlmError::ServerRestarting("dead".into())], vec![]);
+        let probe = MockProbe::ready_with_wait_err(assistd_llm::HealthWaitError::Degraded);
+        let tools = tools_with_echo();
+        let (tx, mut rx) = mpsc::channel(32);
+        let result = run_agent_turn(
+            backend.clone(),
+            tools,
+            10,
+            "hello".into(),
+            Vec::new(),
+            tx,
+            CancellationToken::new(),
+            Some(probe),
+        )
+        .await;
+        assert!(result.is_err(), "Degraded probe must surface as error");
+
+        let events = collect(&mut rx).await;
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, LlmEvent::Status { event, .. } if event == "degraded")),
+            "expected a degraded Status event"
+        );
+        assert!(matches!(events.last(), Some(LlmEvent::Done)));
+        // Only one step call — wait_for_ready returned Err, so no
+        // replay step was attempted.
+        assert_eq!(
+            backend.step_calls.load(std::sync::atomic::Ordering::SeqCst),
+            1
         );
     }
 }

--- a/crates/assistd-core/src/lib.rs
+++ b/crates/assistd-core/src/lib.rs
@@ -37,10 +37,12 @@
 
 pub mod agent;
 pub mod presence;
+pub mod recovery;
 pub mod socket;
 pub mod state;
 
 pub use agent::run_agent_turn;
+pub use recovery::{Component, RecoverySeverity, install_panic_hook, spawn_supervised};
 
 // Re-exports from `assistd-config`. Config types are the boundary
 // between user-supplied TOML and subsystem constructors; the daemon

--- a/crates/assistd-core/src/presence.rs
+++ b/crates/assistd-core/src/presence.rs
@@ -33,7 +33,8 @@ use std::time::{Duration, Instant};
 use anyhow::{Context, Result, anyhow, bail};
 use assistd_config::{LlamaServerConfig, ModelConfig, TimeoutsConfig};
 use assistd_ipc::PresenceState;
-use assistd_llm::{LlamaServerControl, LlamaService};
+use assistd_llm::{HealthWaitError, LlamaServerControl, LlamaService, LlmHealthProbe, ReadyState};
+use async_trait::async_trait;
 use tokio::sync::{Mutex as AsyncMutex, OwnedRwLockReadGuard, RwLock, watch};
 use tokio::time::timeout;
 use tracing::{debug, info, warn};
@@ -115,6 +116,35 @@ pub struct RequestGuard {
     _guard: OwnedRwLockReadGuard<()>,
 }
 
+/// Wraps an `Arc<PresenceManager>` so the chat client can probe
+/// llama-server health (PID, state, wait-for-ready) without taking a
+/// circular dependency on `assistd-core`. The chat client only sees
+/// the [`LlmHealthProbe`] trait from `assistd-llm`.
+pub struct PresenceLlmHealthProbe {
+    presence: Arc<PresenceManager>,
+}
+
+impl PresenceLlmHealthProbe {
+    pub fn new(presence: Arc<PresenceManager>) -> Self {
+        Self { presence }
+    }
+}
+
+#[async_trait]
+impl LlmHealthProbe for PresenceLlmHealthProbe {
+    fn pid(&self) -> Option<u32> {
+        self.presence.llama_pid_blocking()
+    }
+
+    fn state(&self) -> Option<ReadyState> {
+        self.presence.llama_state_blocking()
+    }
+
+    async fn wait_for_ready(&self, budget: Duration) -> Result<(), HealthWaitError> {
+        self.presence.wait_llama_ready(budget).await
+    }
+}
+
 /// RAII counter for "an LLM stream is currently running". Bumps the
 /// shared count on construction and decrements on drop. Held by LLM
 /// query handlers for the duration of their streaming lifetime so the
@@ -184,18 +214,27 @@ impl PresenceManager {
         // down). `PresenceManager` also holds
         // `daemon_shutdown_keepalive: watch::Receiver` below to keep
         // the subscription valid for the manager's lifetime.
+        //
+        // Wrapped in `spawn_supervised` so a panic here (which would
+        // strand the daemon — every inner shutdown lives off this
+        // forwarder) emits a structured recovery event instead of
+        // dying silently.
         {
             let mut daemon_rx = daemon_shutdown.clone();
             let current = Arc::clone(&current_inner_shutdown);
-            tokio::spawn(async move {
-                if daemon_rx.wait_for(|v| *v).await.is_err() {
-                    return;
-                }
-                let tx = current.lock().unwrap_or_else(|e| e.into_inner()).clone();
-                if let Some(tx) = tx {
-                    let _ = tx.send(true);
-                }
-            });
+            crate::recovery::spawn_supervised(
+                "presence_shutdown_forwarder",
+                crate::recovery::Component::Daemon,
+                async move {
+                    if daemon_rx.wait_for(|v| *v).await.is_err() {
+                        return;
+                    }
+                    let tx = current.lock().unwrap_or_else(|e| e.into_inner()).clone();
+                    if let Some(tx) = tx {
+                        let _ = tx.send(true);
+                    }
+                },
+            );
         }
 
         let (state_tx, _) = watch::channel(PresenceState::Sleeping);
@@ -297,6 +336,66 @@ impl PresenceManager {
             .try_lock()
             .ok()
             .and_then(|svc| svc.as_ref().and_then(|s| s.pid()))
+    }
+
+    /// Snapshot of the llama-server supervisor's [`ReadyState`].
+    /// `None` when no service is attached (presence asleep, or
+    /// transitioning). Non-blocking — uses `try_lock` and returns
+    /// `None` if a transition holds the slot.
+    pub fn llama_state_blocking(&self) -> Option<ReadyState> {
+        self.llama
+            .try_lock()
+            .ok()
+            .and_then(|svc| svc.as_ref().map(|s| s.state()))
+    }
+
+    /// Block until the llama-server reports `ReadyState::Ready` or
+    /// `budget` elapses. Subscribes to the supervisor's ready watch and
+    /// awaits transitions; returns `Err(Degraded)` immediately if the
+    /// supervisor has already given up (waiting longer is futile), and
+    /// `Err(NoService)` if no service is currently attached.
+    ///
+    /// Used by the agent loop's replay path on `LlmError::ServerRestarting`
+    /// to wait for the supervisor to bring the server back before
+    /// re-running the LLM step.
+    pub async fn wait_llama_ready(&self, budget: Duration) -> Result<(), HealthWaitError> {
+        // Snapshot the watch receiver under the async-mutex; we hold
+        // the lock only long enough to clone, then release so concurrent
+        // sleep/drowse can still take it.
+        let mut rx = {
+            let guard = self.llama.lock().await;
+            match guard.as_ref() {
+                Some(svc) => svc.subscribe_ready(),
+                None => return Err(HealthWaitError::NoService),
+            }
+        };
+
+        // Fast path: already Ready.
+        if matches!(*rx.borrow(), ReadyState::Ready) {
+            return Ok(());
+        }
+        if matches!(*rx.borrow(), ReadyState::Degraded) {
+            return Err(HealthWaitError::Degraded);
+        }
+
+        let res = timeout(budget, async {
+            loop {
+                match rx.changed().await {
+                    Ok(()) => match *rx.borrow() {
+                        ReadyState::Ready => return Ok::<(), HealthWaitError>(()),
+                        ReadyState::Degraded => return Err(HealthWaitError::Degraded),
+                        ReadyState::Starting | ReadyState::BackingOff { .. } => continue,
+                    },
+                    Err(_) => return Err(HealthWaitError::NoService),
+                }
+            }
+        })
+        .await;
+
+        match res {
+            Ok(inner) => inner,
+            Err(_) => Err(HealthWaitError::Timeout),
+        }
     }
 
     /// Fast path for query handlers: if already `Active`, returns

--- a/crates/assistd-core/src/recovery.rs
+++ b/crates/assistd-core/src/recovery.rs
@@ -1,0 +1,346 @@
+//! Structured recovery vocabulary, supervised task spawning, and the
+//! daemon panic hook.
+//!
+//! Three responsibilities:
+//!
+//! 1. **Vocabulary** — [`Component`] and [`RecoverySeverity`] give every
+//!    recovery event a canonical `severity`/`component` field pair.
+//!    Filterable with `RUST_LOG=assistd::recovery=info`.
+//! 2. **Panic isolation** — [`spawn_supervised`] wraps a `tokio::spawn`
+//!    so panics in detached tasks emit a recovery event instead of
+//!    silently disappearing into a never-joined `JoinHandle`.
+//! 3. **Daemon panic hook** — [`install_panic_hook`] replaces the global
+//!    panic hook so that any panic also tries to SIGTERM the running
+//!    llama-server process group before propagating, keeping a child
+//!    from being orphaned when the daemon goes down via panic.
+
+#![allow(unsafe_code)] // libc::kill in the panic hook — locally justified
+
+use std::any::Any;
+use std::future::Future;
+use std::sync::{Mutex, Weak};
+
+use tokio::task::JoinHandle;
+
+use crate::PresenceManager;
+
+/// Severity of a recovery event. Maps 1:1 to a `tracing` log level and
+/// to the `severity` string field on the wire (`Event::Status`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RecoverySeverity {
+    /// Routine recovery progress (e.g. "replay started"). `info` level.
+    Info,
+    /// A recoverable failure was observed (e.g. "llama-server crashed,
+    /// restarting"). `warn` level.
+    Warning,
+    /// The recovery itself failed and the operation will not complete
+    /// (e.g. "supervisor degraded; replay aborted"). `error` level.
+    Error,
+}
+
+impl RecoverySeverity {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            RecoverySeverity::Info => "info",
+            RecoverySeverity::Warning => "warning",
+            RecoverySeverity::Error => "error",
+        }
+    }
+}
+
+/// Canonical component identifier carried as a structured field on every
+/// recovery event. New subsystems get a new variant rather than a free-form
+/// string so log filters and dashboards can rely on a fixed vocabulary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Component {
+    /// llama-server lifecycle, restarts, in-flight crash detection.
+    Llm,
+    /// MCP transport / supervisor.
+    Mcp,
+    /// Voice input/output (whisper, piper, mic, listen).
+    Voice,
+    /// SQLite-backed memory + conversation persistence.
+    Memory,
+    /// Window-manager backend (i3/sway/hyprland).
+    Wm,
+    /// Embedding service + worker task.
+    Embed,
+    /// Global hotkey listener.
+    Hotkey,
+    /// Top-level daemon orchestration (signal handler, panics with no
+    /// more specific subsystem attribution).
+    Daemon,
+    /// Idle-monitor task that auto-drowses/sleeps.
+    IdleMonitor,
+    /// GPU-monitor task that auto-sleeps when a foreground GPU consumer
+    /// (game, ML training) shows up.
+    GpuMonitor,
+    /// Continuous-listen utterance dispatcher.
+    ListenDispatcher,
+}
+
+impl Component {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Component::Llm => "llm",
+            Component::Mcp => "mcp",
+            Component::Voice => "voice",
+            Component::Memory => "memory",
+            Component::Wm => "wm",
+            Component::Embed => "embed",
+            Component::Hotkey => "hotkey",
+            Component::Daemon => "daemon",
+            Component::IdleMonitor => "idle_monitor",
+            Component::GpuMonitor => "gpu_monitor",
+            Component::ListenDispatcher => "listen_dispatcher",
+        }
+    }
+}
+
+/// Emit a structured recovery event at the given severity level.
+///
+/// Wraps the corresponding `tracing` macro so every recovery event is
+/// emitted under `target = "assistd::recovery"` with `severity` and
+/// `component` fields. Additional structured fields (pid, attempt,
+/// ran_for_secs, etc.) are passed via the trailing tt-munch.
+///
+/// # Example
+///
+/// ```ignore
+/// recovery_event!(
+///     RecoverySeverity::Warning,
+///     Component::Llm,
+///     "crash_detected",
+///     pid = old_pid,
+///     "llama-server died mid-response, restarting"
+/// );
+/// ```
+#[macro_export]
+macro_rules! recovery_event {
+    ($severity:expr, $component:expr, $event:literal, $($field:tt)+) => {{
+        let __component_str: &'static str = $crate::recovery::Component::as_str($component);
+        let __event_str: &'static str = $event;
+        match $severity {
+            $crate::recovery::RecoverySeverity::Info => ::tracing::info!(
+                target: "assistd::recovery",
+                severity = "info",
+                component = __component_str,
+                event = __event_str,
+                $($field)+
+            ),
+            $crate::recovery::RecoverySeverity::Warning => ::tracing::warn!(
+                target: "assistd::recovery",
+                severity = "warning",
+                component = __component_str,
+                event = __event_str,
+                $($field)+
+            ),
+            $crate::recovery::RecoverySeverity::Error => ::tracing::error!(
+                target: "assistd::recovery",
+                severity = "error",
+                component = __component_str,
+                event = __event_str,
+                $($field)+
+            ),
+        }
+    }};
+    ($severity:expr, $component:expr, $event:literal) => {{
+        let __component_str: &'static str = $crate::recovery::Component::as_str($component);
+        let __event_str: &'static str = $event;
+        match $severity {
+            $crate::recovery::RecoverySeverity::Info => ::tracing::info!(
+                target: "assistd::recovery",
+                severity = "info",
+                component = __component_str,
+                event = __event_str,
+            ),
+            $crate::recovery::RecoverySeverity::Warning => ::tracing::warn!(
+                target: "assistd::recovery",
+                severity = "warning",
+                component = __component_str,
+                event = __event_str,
+            ),
+            $crate::recovery::RecoverySeverity::Error => ::tracing::error!(
+                target: "assistd::recovery",
+                severity = "error",
+                component = __component_str,
+                event = __event_str,
+            ),
+        }
+    }};
+}
+
+/// `tokio::spawn` a future and emit a recovery event if it panics.
+///
+/// Detached tokio tasks normally swallow panics into their never-joined
+/// `JoinHandle`. This wrapper joins the handle from a sentinel task so
+/// the panic surfaces as a structured `target = "assistd::recovery"`
+/// log line attributed to the named component.
+///
+/// `name` is a short identifier (e.g. `"signal_handler"`) included as
+/// the `task` field on the panic event.
+pub fn spawn_supervised<F>(name: &'static str, component: Component, future: F) -> JoinHandle<()>
+where
+    F: Future<Output = ()> + Send + 'static,
+{
+    let inner = tokio::spawn(future);
+    tokio::spawn(async move {
+        match inner.await {
+            Ok(()) => {}
+            Err(join_err) if join_err.is_panic() => {
+                let payload = join_err.into_panic();
+                let msg = panic_message(&payload);
+                recovery_event!(
+                    RecoverySeverity::Error,
+                    component,
+                    "task_panic",
+                    task = name,
+                    panic = %msg,
+                    "supervised task panicked"
+                );
+            }
+            Err(join_err) if join_err.is_cancelled() => {
+                // Cancellation is normal during shutdown; do not
+                // promote to a recovery event.
+                ::tracing::debug!(
+                    target: "assistd::recovery",
+                    component = component.as_str(),
+                    task = name,
+                    "supervised task cancelled"
+                );
+            }
+            Err(_) => {}
+        }
+    })
+}
+
+/// Replace the global panic hook with one that logs structured recovery
+/// fields and best-effort SIGTERMs the running llama-server before
+/// chaining to the previous hook.
+///
+/// `presence` is a `Weak` so the hook does not keep the manager alive
+/// past daemon shutdown. Pass `Arc::downgrade(&presence_arc)`.
+///
+/// Idempotent: installing twice replaces the previous chain — tests can
+/// safely re-install in setup.
+pub fn install_panic_hook(presence: Weak<PresenceManager>) {
+    static PRESENCE: Mutex<Option<Weak<PresenceManager>>> = Mutex::new(None);
+    *PRESENCE.lock().unwrap_or_else(|e| e.into_inner()) = Some(presence);
+
+    let previous = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        let location = info
+            .location()
+            .map(|l| format!("{}:{}", l.file(), l.line()))
+            .unwrap_or_else(|| "<unknown>".to_string());
+        let payload_msg = panic_message(info.payload());
+
+        recovery_event!(
+            RecoverySeverity::Error,
+            Component::Daemon,
+            "panic",
+            location = %location,
+            message = %payload_msg,
+            "daemon panic; killing llama-server before propagating"
+        );
+
+        // Best-effort: try to SIGTERM the llama-server process group so
+        // the child doesn't outlive the daemon. We hold the lock only
+        // long enough to grab a strong ref + read the pid.
+        let pid_opt = PRESENCE
+            .lock()
+            .ok()
+            .and_then(|guard| guard.as_ref().and_then(|w| w.upgrade()))
+            .and_then(|p| p.llama_pid_blocking());
+        if let Some(pid) = pid_opt {
+            let gid: i32 = -(pid as i32);
+            // SAFETY: libc::kill is safe with any pid/signal; failure
+            // is observable only via the return code we deliberately
+            // ignore (the child may have exited between read and kill).
+            unsafe {
+                libc::kill(gid, libc::SIGTERM);
+            }
+            recovery_event!(
+                RecoverySeverity::Warning,
+                Component::Llm,
+                "panic_kill",
+                pid = pid,
+                "sent SIGTERM to llama-server process group from panic hook"
+            );
+        }
+
+        previous(info);
+    }));
+}
+
+fn panic_message(payload: &(dyn Any + Send)) -> String {
+    if let Some(s) = payload.downcast_ref::<&'static str>() {
+        (*s).to_string()
+    } else if let Some(s) = payload.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "<non-string panic payload>".to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn component_as_str_is_stable() {
+        assert_eq!(Component::Llm.as_str(), "llm");
+        assert_eq!(Component::IdleMonitor.as_str(), "idle_monitor");
+        assert_eq!(Component::ListenDispatcher.as_str(), "listen_dispatcher");
+    }
+
+    #[test]
+    fn severity_as_str_matches_tracing_levels() {
+        assert_eq!(RecoverySeverity::Info.as_str(), "info");
+        assert_eq!(RecoverySeverity::Warning.as_str(), "warning");
+        assert_eq!(RecoverySeverity::Error.as_str(), "error");
+    }
+
+    #[tokio::test]
+    async fn spawn_supervised_completes_normally_for_clean_task() {
+        let handle = spawn_supervised("ok_task", Component::Daemon, async {
+            tokio::task::yield_now().await;
+        });
+        // The sentinel handle resolves once the inner task finishes.
+        // We don't assert any panic logging here — the absence of a
+        // panic event is the whole point.
+        handle.await.expect("sentinel join");
+    }
+
+    #[tokio::test]
+    async fn spawn_supervised_logs_on_panic() {
+        // We don't have a captured-subscriber harness wired here; the
+        // assertion is that the sentinel itself does not panic and
+        // resolves cleanly even when the inner task panicked. Visual
+        // verification via test-log output covers the message shape.
+        let handle = spawn_supervised("panicker", Component::Llm, async {
+            panic!("boom");
+        });
+        handle
+            .await
+            .expect("sentinel must not panic on inner panic");
+    }
+
+    #[test]
+    fn panic_message_extracts_static_str() {
+        let payload: Box<dyn Any + Send> = Box::new("static panic text");
+        assert_eq!(panic_message(&*payload), "static panic text");
+    }
+
+    #[test]
+    fn panic_message_extracts_owned_string() {
+        let payload: Box<dyn Any + Send> = Box::new("owned panic text".to_string());
+        assert_eq!(panic_message(&*payload), "owned panic text");
+    }
+
+    #[test]
+    fn panic_message_falls_back_for_non_string_payload() {
+        let payload: Box<dyn Any + Send> = Box::new(42u32);
+        assert_eq!(panic_message(&*payload), "<non-string panic payload>");
+    }
+}

--- a/crates/assistd-core/src/state.rs
+++ b/crates/assistd-core/src/state.rs
@@ -1143,6 +1143,13 @@ impl AppState {
         let llm = self.llm.clone();
         let tools = self.tools.clone();
         let max_iterations = self.config.agent.max_iterations;
+        // Build the LLM health probe from the presence manager so the
+        // agent loop can wait for restart and replay on
+        // `LlmError::ServerRestarting`.
+        let health: Option<std::sync::Arc<dyn assistd_llm::LlmHealthProbe>> =
+            Some(std::sync::Arc::new(
+                crate::presence::PresenceLlmHealthProbe::new(self.presence.clone()),
+            ));
         // Cancellation token: wired to the agent loop so a slow LLM
         // step or tool dispatch can be preempted promptly. Today we
         // only fire it when this function returns (drop) — that
@@ -1166,6 +1173,7 @@ impl AppState {
                     attachments,
                     llm_tx,
                     cancel_for_agent,
+                    health,
                 )
                 .await
             }
@@ -1356,6 +1364,32 @@ impl AppState {
                             id: id.clone(),
                             name,
                             result,
+                        },
+                        Vec::new(),
+                    )
+                }
+                LlmEvent::Status {
+                    severity,
+                    component,
+                    event,
+                    message,
+                } => {
+                    // On a recoverable restart, drop any partial
+                    // accumulator state so a successful replay isn't
+                    // persisted as `<partial><replay>` concatenated.
+                    // The chat client likewise rolls back partial
+                    // assistant content on its side.
+                    if event == "restarting" {
+                        assistant_accum.clear();
+                        let _ = sentence_buf.finish();
+                    }
+                    (
+                        Event::Status {
+                            id: id.clone(),
+                            severity,
+                            component,
+                            event,
+                            message,
                         },
                         Vec::new(),
                     )

--- a/crates/assistd-ipc/src/lib.rs
+++ b/crates/assistd-ipc/src/lib.rs
@@ -461,6 +461,24 @@ pub enum Event {
         vision: bool,
         model_name: String,
     },
+    /// Non-terminal recovery / status update. Emitted mid-stream when
+    /// the daemon hits a recoverable condition (e.g. llama-server
+    /// restarting, MCP server bouncing). Clients should render but not
+    /// treat as a terminal event — a `Done` or `Error` still follows.
+    ///
+    /// `severity` is one of `info`, `warning`, `error` (matching
+    /// `RecoverySeverity::as_str`). `component` is the canonical
+    /// component name (matching `Component::as_str`). `event` is a
+    /// short machine-readable identifier (`restarting`, `replaying`,
+    /// `degraded`, ...) that clients can branch on if they need
+    /// behavior beyond rendering the message.
+    Status {
+        id: String,
+        severity: String,
+        component: String,
+        event: String,
+        message: String,
+    },
     /// Terminal error event — the stream is over.
     Error { id: String, message: String },
     /// Terminal success event — the stream is over.
@@ -492,6 +510,7 @@ impl Event {
             | Event::ReindexProgress { id, .. }
             | Event::ConfirmRequest { id, .. }
             | Event::Capabilities { id, .. }
+            | Event::Status { id, .. }
             | Event::Error { id, .. }
             | Event::Done { id } => id,
         }

--- a/crates/assistd-llm/src/chat/client.rs
+++ b/crates/assistd-llm/src/chat/client.rs
@@ -16,6 +16,7 @@
 //! `step` again, until `StepOutcome::Final`.
 
 use std::collections::BTreeMap;
+use std::sync::Arc;
 use std::time::Duration;
 
 use assistd_config::{ChatConfig, LlamaServerConfig, ModelConfig, TimeoutsConfig};
@@ -30,7 +31,10 @@ use super::conversation::{Conversation, Summarizer, ToolCallRecord};
 use super::error::ChatClientError;
 use super::sse::{SseEvent, SseLineReader};
 use super::wire;
-use crate::{LlmBackend, LlmError, LlmEvent, LlmResult, StepOutcome, ToolCall, ToolResultPayload};
+use crate::{
+    LlmBackend, LlmError, LlmEvent, LlmHealthProbe, LlmResult, ReadyState, StepOutcome, ToolCall,
+    ToolResultPayload,
+};
 
 const ERROR_BODY_CAP: usize = 1024;
 const SUMMARY_SYSTEM_PROMPT: &str = "You are a conversation summarizer. Produce a concise \
@@ -44,6 +48,11 @@ pub struct LlamaChatClient {
     model: ModelConfig,
     timeouts: TimeoutsConfig,
     conv: Mutex<Conversation>,
+    /// Optional handle into the supervisor so we can classify HTTP
+    /// errors as crash-induced (server died → reply `ServerRestarting`
+    /// so the agent loop can replay) vs. genuine transport faults.
+    /// `None` in tests that drive the client without a real supervisor.
+    health: Option<Arc<dyn LlmHealthProbe>>,
 }
 
 impl LlamaChatClient {
@@ -51,11 +60,18 @@ impl LlamaChatClient {
     /// the host:port the request is sent to, and `model` is the identifier
     /// llama-server has loaded (plus its context length for budget math).
     /// All three are cloned; the caller keeps ownership.
+    ///
+    /// `health` is the optional probe used to detect mid-stream
+    /// llama-server crashes. Pass `None` when there is no supervisor
+    /// (test backends, fake-server harnesses); production callers wire
+    /// the `PresenceManager`-backed probe so crash → restart → replay
+    /// works end-to-end.
     pub fn new(
         chat: &ChatConfig,
         server: &LlamaServerConfig,
         model: &ModelConfig,
         timeouts: &TimeoutsConfig,
+        health: Option<Arc<dyn LlmHealthProbe>>,
     ) -> Result<Self, ChatClientError> {
         let client = reqwest::Client::builder()
             .no_proxy()
@@ -71,11 +87,44 @@ impl LlamaChatClient {
             model: model.clone(),
             timeouts: timeouts.clone(),
             conv: Mutex::new(conv),
+            health,
         })
+    }
+
+    /// Snapshot the probe state at the moment of an HTTP failure.
+    /// Returns `Some((pid_at_request, current_state))` when a probe is
+    /// attached, allowing the caller to decide whether the failure
+    /// looks like a server crash (pid changed or state != Ready). The
+    /// outer `Option` is `None` when the client was built without a
+    /// probe — in that case the caller treats every error as a
+    /// transport fault (no replay).
+    fn classify_failure(&self, pid_at_request: Option<u32>) -> bool {
+        let Some(probe) = self.health.as_ref() else {
+            return false;
+        };
+        let current_pid = probe.pid();
+        let current_state = probe.state();
+        // Crash-induced when:
+        // - we had a pid before the request and either the pid has
+        //   changed (supervisor already respawned) or it's now None
+        //   (child died, supervisor not yet respawned), OR
+        // - the state went non-Ready (Starting / BackingOff / Degraded).
+        let pid_changed = match (pid_at_request, current_pid) {
+            (Some(_), None) => true,
+            (Some(a), Some(b)) => a != b,
+            _ => false,
+        };
+        let state_unhealthy = !matches!(current_state, Some(ReadyState::Ready) | None);
+        pid_changed || state_unhealthy
     }
 
     async fn stream_openai(&self, body: Vec<u8>, tx: &mpsc::Sender<LlmEvent>) -> StreamOutcome {
         let url = format!("{}/v1/chat/completions", self.base_url);
+        // Snapshot the supervisor's PID at request time so we can
+        // distinguish a crash-induced HTTP failure (pid changed or
+        // disappeared, state went non-Ready) from a transport-level
+        // hiccup (network, timeout) when classifying errors below.
+        let pid_at_request = self.health.as_ref().and_then(|h| h.pid());
         tracing::debug!(
             target: "assistd::voice::latency",
             stage = "llm_request_sent",
@@ -90,13 +139,38 @@ impl LlamaChatClient {
             .send()
             .await
         {
-            Ok(r) => r,
-            Err(e) => return StreamOutcome::PreEmitError(ChatClientError::Http(e)),
+            Ok(r) => {
+                if self.classify_failure(pid_at_request) {
+                    // Server crashed between snapshot and response; the
+                    // 200 we just received was racing the supervisor's
+                    // teardown. Treat as restart so the agent replays.
+                    return StreamOutcome::ServerRestart {
+                        accum: StreamAccum::default(),
+                        pre_emit: true,
+                    };
+                }
+                r
+            }
+            Err(e) => {
+                if self.classify_failure(pid_at_request) {
+                    return StreamOutcome::ServerRestart {
+                        accum: StreamAccum::default(),
+                        pre_emit: true,
+                    };
+                }
+                return StreamOutcome::PreEmitError(ChatClientError::Http(e));
+            }
         };
 
         let status = response.status();
         if !status.is_success() {
             let body = read_body_capped(&mut response, ERROR_BODY_CAP).await;
+            if self.classify_failure(pid_at_request) {
+                return StreamOutcome::ServerRestart {
+                    accum: StreamAccum::default(),
+                    pre_emit: true,
+                };
+            }
             return StreamOutcome::PreEmitError(ChatClientError::Server {
                 status: status.as_u16(),
                 body,
@@ -113,6 +187,10 @@ impl LlamaChatClient {
                 Ok(Ok(Some(c))) => c,
                 Ok(Ok(None)) => break,
                 Ok(Err(e)) => {
+                    if self.classify_failure(pid_at_request) {
+                        let pre_emit = !accum_was_emitted(&accum);
+                        return StreamOutcome::ServerRestart { accum, pre_emit };
+                    }
                     return fold_mid_stream_error(accum, ChatClientError::Http(e));
                 }
                 Err(_) => {
@@ -123,6 +201,10 @@ impl LlamaChatClient {
                         tool_call_builders = accum.tool_calls.len(),
                         "SSE stream inactive past deadline; aborting read"
                     );
+                    if self.classify_failure(pid_at_request) {
+                        let pre_emit = !accum_was_emitted(&accum);
+                        return StreamOutcome::ServerRestart { accum, pre_emit };
+                    }
                     return fold_mid_stream_error(
                         accum,
                         ChatClientError::Sse(format!(
@@ -139,6 +221,10 @@ impl LlamaChatClient {
                     Ok(Some(e)) => e,
                     Ok(None) => break,
                     Err(e) => {
+                        if self.classify_failure(pid_at_request) {
+                            let pre_emit = !accum_was_emitted(&accum);
+                            return StreamOutcome::ServerRestart { accum, pre_emit };
+                        }
                         return fold_mid_stream_error(accum, e);
                     }
                 };
@@ -148,6 +234,10 @@ impl LlamaChatClient {
                         {
                             Ok(p) => p,
                             Err(e) => {
+                                if self.classify_failure(pid_at_request) {
+                                    let pre_emit = !accum_was_emitted(&accum);
+                                    return StreamOutcome::ServerRestart { accum, pre_emit };
+                                }
                                 return fold_mid_stream_error(accum, ChatClientError::Json(e));
                             }
                         };
@@ -282,6 +372,18 @@ impl LlmBackend for LlamaChatClient {
                 conv.rollback_last_user();
                 Err(LlmError::Chat(e))
             }
+            StreamOutcome::ServerRestart { .. } => {
+                // Generate is the legacy single-turn API used by code
+                // paths that don't run the agent loop, so they cannot
+                // replay. Surface the restart as a typed error and
+                // leave the user message in place — the caller can
+                // re-issue if they choose. Unlike PreEmitError, we do
+                // NOT roll back the user message: a follow-up call
+                // would re-push, and double-pushing would duplicate.
+                Err(LlmError::ServerRestarting(
+                    "llama-server crashed during generate".into(),
+                ))
+            }
         }
     }
 
@@ -366,6 +468,34 @@ impl LlmBackend for LlamaChatClient {
                 result
             }
             StreamOutcome::PreEmitError(e) => Err(LlmError::Chat(e)),
+            StreamOutcome::ServerRestart { accum, pre_emit } => {
+                // Crash detected. The conversation state on this side
+                // is already clean (we never reached `commit_step`),
+                // but we may have streamed partial bytes to the client
+                // — the agent loop's Status emission tells the client
+                // to bracket those before the replay's deltas arrive.
+                //
+                // Important: we do NOT roll back the user message on
+                // pre_emit, even though `PreEmitError` does. The user
+                // push happens once before the agent loop iterates;
+                // rolling it back here would mean the replay's
+                // re-rendered wire payload has no user prompt at the
+                // tail and the model would see an empty turn.
+                //
+                // We also preserve the transient context (skip
+                // `consume_transient_context`) so the replay sees the
+                // same retrieval block it would have seen on the
+                // original attempt.
+                let bytes_so_far = accum.text.len();
+                let tool_builders = accum.tool_calls.len();
+                drop(accum);
+                Err(LlmError::ServerRestarting(format!(
+                    "llama-server died mid-{} ({} bytes / {} tool-call builders streamed)",
+                    if pre_emit { "request" } else { "response" },
+                    bytes_so_far,
+                    tool_builders,
+                )))
+            }
         }
     }
 
@@ -540,6 +670,15 @@ enum StreamOutcome {
     ClientDisconnected(StreamAccum),
     /// Stream errored before any deltas were forwarded — propagate as `Err`.
     PreEmitError(ChatClientError),
+    /// The HTTP failure looks crash-induced: the supervisor's PID
+    /// changed under us or the readiness state went non-Ready. The
+    /// agent loop will see [`LlmError::ServerRestarting`] and replay
+    /// the same payload once after waiting for the supervisor to
+    /// restore Ready. `pre_emit` distinguishes "no deltas streamed
+    /// yet" (so the caller can clean up an unstreamed response) from
+    /// "had partial output" (caller must consider what the user has
+    /// already seen on the wire).
+    ServerRestart { accum: StreamAccum, pre_emit: bool },
 }
 
 fn fold_mid_stream_error(accum: StreamAccum, err: ChatClientError) -> StreamOutcome {
@@ -554,6 +693,10 @@ fn fold_mid_stream_error(accum: StreamAccum, err: ChatClientError) -> StreamOutc
     } else {
         StreamOutcome::PreEmitError(err)
     }
+}
+
+fn accum_was_emitted(accum: &StreamAccum) -> bool {
+    accum.has_emitted || !accum.tool_calls.is_empty()
 }
 
 async fn read_body_capped(response: &mut reqwest::Response, cap: usize) -> String {

--- a/crates/assistd-llm/src/lib.rs
+++ b/crates/assistd-llm/src/lib.rs
@@ -28,8 +28,65 @@ use assistd_tools::Attachment;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::time::Duration;
 use thiserror::Error;
 use tokio::sync::{Mutex, mpsc};
+
+/// Reason an [`LlmHealthProbe::wait_for_ready`] call ended without
+/// observing `ReadyState::Ready`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HealthWaitError {
+    /// The wait budget elapsed before the supervisor reported Ready.
+    Timeout,
+    /// The supervisor entered `Degraded` (gave up after consecutive
+    /// failures); waiting longer will not help.
+    Degraded,
+    /// No managed service is currently attached. The daemon is
+    /// `Sleeping`, or the probe was constructed against a presence
+    /// manager that hasn't woken yet.
+    NoService,
+}
+
+impl std::fmt::Display for HealthWaitError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            HealthWaitError::Timeout => f.write_str("LLM did not become ready before timeout"),
+            HealthWaitError::Degraded => {
+                f.write_str("LLM supervisor entered Degraded; restart abandoned")
+            }
+            HealthWaitError::NoService => {
+                f.write_str("no llama-server is currently managed (presence asleep?)")
+            }
+        }
+    }
+}
+
+impl std::error::Error for HealthWaitError {}
+
+/// Health/restart probe used by the chat client to classify HTTP
+/// failures as crash-induced (worth replaying) vs. transport-level
+/// (propagate as error).
+///
+/// Implemented in `assistd-core` over `Arc<PresenceManager>`. The
+/// trait lives in this crate so [`LlamaChatClient`] can depend on it
+/// without taking a circular dep on `assistd-core`.
+#[async_trait]
+pub trait LlmHealthProbe: Send + Sync {
+    /// Current PID of the managed llama-server child, or `None` if
+    /// none is alive (sleeping, or in mid-restart with the child not
+    /// yet spawned).
+    fn pid(&self) -> Option<u32>;
+
+    /// Snapshot of the supervisor's readiness state. Returns `None`
+    /// when no service is attached (presence asleep / not yet woken).
+    fn state(&self) -> Option<ReadyState>;
+
+    /// Block until the supervisor reports `ReadyState::Ready` or
+    /// `timeout` elapses. Maps `Degraded` to `HealthWaitError::Degraded`
+    /// immediately so the caller can give up rather than wait the full
+    /// budget on a hopeless restart.
+    async fn wait_for_ready(&self, timeout: Duration) -> Result<(), HealthWaitError>;
+}
 
 /// Errors surfaced by the [`LlmBackend`] trait.
 ///
@@ -59,6 +116,13 @@ pub enum LlmError {
 
     #[error("LLM backend unavailable: {0}")]
     Unavailable(String),
+
+    /// The llama-server child crashed mid-request and the chat client
+    /// detected the supervisor is restarting it. The agent loop sees
+    /// this and handles replay (emit a Status event, wait for ready,
+    /// retry once) — it never reaches the IPC layer as an error.
+    #[error("llama-server is restarting: {0}")]
+    ServerRestarting(String),
 }
 
 /// Convenience result alias. Library code should prefer `LlmError`
@@ -84,6 +148,15 @@ pub enum LlmEvent {
         id: String,
         name: String,
         result: Value,
+    },
+    /// Non-terminal recovery / status update emitted by the agent loop
+    /// or chat backend. Mirrors the wire `Event::Status` shape so the
+    /// state-layer translator can map 1:1 without re-deriving fields.
+    Status {
+        severity: String,
+        component: String,
+        event: String,
+        message: String,
     },
     /// The model has finished generating.
     Done,

--- a/crates/assistd-llm/src/llama_server/process.rs
+++ b/crates/assistd-llm/src/llama_server/process.rs
@@ -88,6 +88,28 @@ impl ChildProcess {
             cmd.process_group(0);
         }
 
+        // Orphan prevention: when the daemon dies (including the SIGKILL
+        // path that bypasses Drop and `kill_on_drop`), the kernel
+        // delivers SIGTERM to this child. `pre_exec` runs in the forked
+        // child between fork() and exec(); `prctl(PR_SET_PDEATHSIG)` is
+        // async-signal-safe.
+        #[cfg(target_os = "linux")]
+        {
+            // SAFETY: prctl is async-signal-safe; the closure captures
+            // nothing that could be in an inconsistent state across
+            // fork(). On error we surface the libc errno so the caller
+            // sees the spawn failure rather than a silently-orphaned
+            // child.
+            unsafe {
+                cmd.pre_exec(|| {
+                    if libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGTERM) == -1 {
+                        return Err(std::io::Error::last_os_error());
+                    }
+                    Ok(())
+                });
+            }
+        }
+
         let mut child = cmd.spawn().map_err(|source| LlamaServerError::Spawn {
             path: cfg.binary_path.clone(),
             source,

--- a/crates/assistd-llm/src/llama_server/service.rs
+++ b/crates/assistd-llm/src/llama_server/service.rs
@@ -97,6 +97,13 @@ impl LlamaService {
         *self.ready_rx.borrow()
     }
 
+    /// Subscribe to the supervisor's readiness watch. Used by callers
+    /// that need to await a transition (e.g. crash → restart → Ready)
+    /// rather than just snapshot the current state.
+    pub fn subscribe_ready(&self) -> watch::Receiver<ReadyState> {
+        self.ready_rx.clone()
+    }
+
     /// PID of the currently-running child, or `None` if no child is alive.
     /// The value changes as the supervisor restarts the child.
     pub fn pid(&self) -> Option<u32> {

--- a/crates/assistd-llm/tests/chat_client.rs
+++ b/crates/assistd-llm/tests/chat_client.rs
@@ -374,7 +374,7 @@ fn chat_spec(port: u16) -> ClientCfg {
 }
 
 fn build_client(cfg: &ClientCfg) -> LlamaChatClient {
-    LlamaChatClient::new(&cfg.chat, &cfg.server, &cfg.model, &cfg.timeouts).unwrap()
+    LlamaChatClient::new(&cfg.chat, &cfg.server, &cfg.model, &cfg.timeouts, None).unwrap()
 }
 
 async fn drain(rx: &mut mpsc::Receiver<LlmEvent>) -> Vec<LlmEvent> {
@@ -581,7 +581,7 @@ async fn stalled_stream_aborts_within_inactivity_timeout() {
     let mut spec = chat_spec(port);
     spec.timeouts.stream_inactivity_secs = 1;
     let client =
-        LlamaChatClient::new(&spec.chat, &spec.server, &spec.model, &spec.timeouts).unwrap();
+        LlamaChatClient::new(&spec.chat, &spec.server, &spec.model, &spec.timeouts, None).unwrap();
 
     let (tx, mut rx) = mpsc::channel(32);
     let started = std::time::Instant::now();

--- a/crates/assistd-voice/src/bin/voice_latency_bench.rs
+++ b/crates/assistd-voice/src/bin/voice_latency_bench.rs
@@ -377,9 +377,7 @@ async fn run_one(
             // events never appear. Status events likewise only fire on
             // a managed-server crash, which the bench's stub backend
             // can't trigger. Ignore for completeness.
-            LlmEvent::ToolCall { .. }
-            | LlmEvent::ToolResult { .. }
-            | LlmEvent::Status { .. } => {}
+            LlmEvent::ToolCall { .. } | LlmEvent::ToolResult { .. } | LlmEvent::Status { .. } => {}
         }
     }
     drop(speech_tx);

--- a/crates/assistd-voice/src/bin/voice_latency_bench.rs
+++ b/crates/assistd-voice/src/bin/voice_latency_bench.rs
@@ -210,7 +210,7 @@ async fn main() -> Result<()> {
         // Fresh LlamaChatClient per iter so accumulated history doesn't
         // skew results across runs. New reqwest::Client costs <1 ms.
         let llm: Arc<dyn LlmBackend> = Arc::new(
-            LlamaChatClient::new(&chat_cfg, &server_cfg, &model_cfg, &timeouts)
+            LlamaChatClient::new(&chat_cfg, &server_cfg, &model_cfg, &timeouts, None)
                 .context("building LLM client")?,
         );
 
@@ -374,8 +374,12 @@ async fn run_one(
             }
             // The bench's prompt is a single user message and the LLM
             // is invoked via generate() (not the agent loop), so tool
-            // events never appear. Ignore for completeness.
-            LlmEvent::ToolCall { .. } | LlmEvent::ToolResult { .. } => {}
+            // events never appear. Status events likewise only fire on
+            // a managed-server crash, which the bench's stub backend
+            // can't trigger. Ignore for completeness.
+            LlmEvent::ToolCall { .. }
+            | LlmEvent::ToolResult { .. }
+            | LlmEvent::Status { .. } => {}
         }
     }
     drop(speech_tx);

--- a/crates/assistd/src/chat/app.rs
+++ b/crates/assistd/src/chat/app.rs
@@ -545,6 +545,21 @@ impl App {
                     self.model_name = model_name;
                 }
             }
+            Event::Status {
+                severity,
+                component,
+                event,
+                message,
+                ..
+            } => {
+                self.set_notice(&message);
+                if event == "restarting" {
+                    self.output.finish_assistant();
+                    self.output.push_info(&format!("[{component} restarting…]"));
+                } else if severity == "error" {
+                    self.output.push_info(&format!("[{component}: {message}]"));
+                }
+            }
             Event::Done { .. } => {
                 self.throughput.on_done(now);
                 self.output.finish_assistant();

--- a/crates/assistd/src/daemon.rs
+++ b/crates/assistd/src/daemon.rs
@@ -80,20 +80,24 @@ pub async fn run(args: DaemonArgs) -> Result<()> {
 
     {
         let signal_tx = shutdown_tx.clone();
-        tokio::spawn(async move {
-            let mut term = match signal(SignalKind::terminate()) {
-                Ok(s) => s,
-                Err(e) => {
-                    tracing::error!("failed to install SIGTERM handler: {e}");
-                    return;
+        assistd_core::spawn_supervised(
+            "signal_handler",
+            assistd_core::Component::Daemon,
+            async move {
+                let mut term = match signal(SignalKind::terminate()) {
+                    Ok(s) => s,
+                    Err(e) => {
+                        tracing::error!("failed to install SIGTERM handler: {e}");
+                        return;
+                    }
+                };
+                tokio::select! {
+                    _ = tokio::signal::ctrl_c() => info!("received SIGINT"),
+                    _ = term.recv() => info!("received SIGTERM"),
                 }
-            };
-            tokio::select! {
-                _ = tokio::signal::ctrl_c() => info!("received SIGINT"),
-                _ = term.recv() => info!("received SIGTERM"),
-            }
-            let _ = signal_tx.send(true);
-        });
+                let _ = signal_tx.send(true);
+            },
+        );
     }
 
     // Bring the daemon up in Active: PresenceManager cold-starts llama-server
@@ -110,6 +114,15 @@ pub async fn run(args: DaemonArgs) -> Result<()> {
         "presence: Active (llama-server ready on {}:{})",
         config.llama_server.host, config.llama_server.port
     );
+
+    // Install the recovery panic hook now that we have a presence
+    // handle. Any panic from this point forward (including in detached
+    // tasks via the default panic hook chain) will SIGTERM the running
+    // llama-server before propagating, and emit a structured recovery
+    // event with the panic location and message. The hook holds a
+    // `Weak<PresenceManager>` so it cannot keep the manager alive past
+    // daemon shutdown.
+    assistd_core::install_panic_hook(Arc::downgrade(&presence));
 
     // Capability probe: ask the now-ready llama-server for the loaded
     // model id and whether it has a vision encoder. The shared
@@ -131,11 +144,18 @@ pub async fn run(args: DaemonArgs) -> Result<()> {
         config.llama_server.port,
     );
 
+    // Build the health probe over the presence manager so the chat
+    // client can detect mid-stream llama-server crashes and the agent
+    // loop can wait for the supervisor to recover before replaying.
+    let health_probe: std::sync::Arc<dyn assistd_llm::LlmHealthProbe> = std::sync::Arc::new(
+        assistd_core::presence::PresenceLlmHealthProbe::new(presence.clone()),
+    );
     let chat = LlamaChatClient::new(
         &config.chat,
         &config.llama_server,
         &config.model,
         &config.timeouts,
+        Some(health_probe.clone()),
     )?;
 
     // Voice input: build the mic-backed implementation when the user

--- a/crates/assistd/src/ptt.rs
+++ b/crates/assistd/src/ptt.rs
@@ -82,6 +82,14 @@ pub async fn run(action: PttAction) -> Result<()> {
             Event::Presence { .. } => {}
             Event::ListenState { .. } => {}
             Event::VoiceOutputState { .. } => {}
+            Event::Status {
+                severity,
+                component,
+                message,
+                ..
+            } => {
+                eprintln!("[{severity} {component}: {message}]");
+            }
             Event::SemanticHit { .. }
             | Event::MemoryValue { .. }
             | Event::MemoryKeys { .. }

--- a/crates/assistd/src/query.rs
+++ b/crates/assistd/src/query.rs
@@ -130,6 +130,14 @@ pub async fn run(args: QueryArgs) -> Result<()> {
             // Memory* events shouldn't appear on a Query stream — the
             // daemon only emits them on `Request::Memory*`. Tolerate
             // them silently in case a future feature reuses the wire.
+            Event::Status {
+                severity,
+                component,
+                message,
+                ..
+            } => {
+                eprintln!("[{severity} {component}: {message}]");
+            }
             Event::SemanticHit { .. }
             | Event::MemoryValue { .. }
             | Event::MemoryKeys { .. }


### PR DESCRIPTION
                                 
  - crates/assistd-core/src/recovery.rs (new): Component enum (11 variants),
   RecoverySeverity, recovery_event! macro emitting structured              
  target=assistd::recovery logs with severity/component/event fields        
  - Event::Status { id, severity, component, event, message } non-terminal  
  wire variant in assistd-ipc                                             
  - LlmEvent::Status mirror in assistd-llm; translated 1:1 in state.rs      
  event-loop with assistant_accum cleared on event=="restarting"      
  - TUI app, query CLI, ptt CLI all render Status events                                                                                                          
  - prctl(PR_SET_PDEATHSIG, SIGTERM) set in pre_exec callback in process.rs
  — Linux kernel kills llama-server when daemon dies, including SIGKILL/OOM 
  where userspace can't run                                                                                                                                                 
  - install_panic_hook(Weak<PresenceManager>) replaces global hook; logs    
  panic location/message via recovery_event!, SIGTERMs the llama-server     
  process group, then chains to previous hook                                                                                                        
  - LlmHealthProbe trait in assistd-llm (pid/state/wait_for_ready) +        
  HealthWaitError enum (Timeout/Degraded/NoService)                         
  - PresenceLlmHealthProbe impl in assistd-core over Arc<PresenceManager>   
  - LlamaChatClient::new accepts Option<Arc<dyn LlmHealthProbe>>; threaded  
  through daemon + state                                                                                                                                                   
  - LlamaChatClient::classify_failure snapshots PID at request time;        
  classifies HTTP errors as crash-induced if PID changed or state went      
  non-Ready                                                                 
  - StreamOutcome::ServerRestart { accum, pre_emit } variant returned at    
  every error site                                                      
  - step() phase-3 returns LlmError::ServerRestarting (preserves user       
  message + transient context for replay)                            
  - run_agent_turn retries once per iteration on ServerRestarting: emits    
  Status{event:"restarting"}, wait_for_ready(75s),                      
  Status{event:"replaying"}, retry. On Degraded/Timeout/NoService, emits    
  Status{event:"degraded"} and terminates                                                                                                                        
  - spawn_supervised watches a tokio task and emits a recovery event on     
  panic                                                                     
  - Wired around the daemon's signal handler and the presence-shutdown      
  forwarder (the two truly silent detached spawns)