### PR TITLE
Implement conversation branching

### DIFF
--- a/crates/assistd-core/src/lib.rs
+++ b/crates/assistd-core/src/lib.rs
@@ -85,7 +85,7 @@ pub use assistd_wm::{NoWindowManager, WindowManager};
 // `PresenceManager` owns the presence machine and llama-server lifecycle;
 // `RequestGuard` is the RAII handle held for the duration of a request.
 pub use presence::{PresenceManager, RequestGuard};
-pub use state::AppState;
+pub use state::{AppState, ConversationContext};
 
 use anyhow::{Context, Result};
 use assistd_embed::{EmbedJob, Embedder};

--- a/crates/assistd-core/src/state.rs
+++ b/crates/assistd-core/src/state.rs
@@ -5,7 +5,7 @@ use assistd_embed::{EmbedJob, Embedder, NoEmbedder};
 use assistd_ipc::{Event, PresenceState, Request, VoiceCaptureState};
 use assistd_llm::{LlmBackend, LlmEvent};
 use assistd_memory::{
-    ChunkingConfig, ConversationStore, MemoryStore, NoConversationStore, NoMemoryStore,
+    BranchId, ChunkingConfig, ConversationStore, MemoryStore, NoConversationStore, NoMemoryStore,
     NoSemanticStore, PersistedMessage, PersistedRole, SemanticStore, SessionId, SqliteHandle,
     TurnId, chunk_message,
 };
@@ -38,6 +38,19 @@ fn truncate_for_context(s: &str, max_chars: usize) -> String {
     head
 }
 
+/// Translate a [`assistd_memory::PersistedRole`] into the equivalent
+/// [`assistd_llm::HistoryRole`] for branch-history replay. Identity
+/// mapping; lives in this crate because `assistd-llm` doesn't depend
+/// on `assistd-memory`.
+fn persisted_role_to_history_role(role: PersistedRole) -> assistd_llm::HistoryRole {
+    match role {
+        PersistedRole::System => assistd_llm::HistoryRole::System,
+        PersistedRole::User => assistd_llm::HistoryRole::User,
+        PersistedRole::Assistant => assistd_llm::HistoryRole::Assistant,
+        PersistedRole::Tool => assistd_llm::HistoryRole::Tool,
+    }
+}
+
 /// Convert wire-level [`assistd_ipc::ImageAttachment`] entries into the
 /// internal [`Attachment`] type the agent loop expects. Returns the first
 /// decode error so the caller can surface it cleanly to the client.
@@ -55,6 +68,57 @@ fn decode_wire_attachments(
             })
         })
         .collect()
+}
+
+/// Active (session, branch) pointer shared by every persistence write
+/// site. Held under a `RwLock` because the persistence path takes a
+/// read lock on every message append (cheap, lock-free in practice
+/// under WAL) while `/switch` takes a write lock once per command. We
+/// hold `Arc<SessionId>` inside so reads return a cheap `Arc::clone`
+/// without copying the underlying string.
+pub struct ConversationContext {
+    inner: tokio::sync::RwLock<ConversationContextInner>,
+}
+
+#[derive(Clone)]
+struct ConversationContextInner {
+    session_id: Arc<SessionId>,
+    branch_id: BranchId,
+}
+
+impl ConversationContext {
+    pub fn new(session_id: SessionId, branch_id: BranchId) -> Self {
+        Self {
+            inner: tokio::sync::RwLock::new(ConversationContextInner {
+                session_id: Arc::new(session_id),
+                branch_id,
+            }),
+        }
+    }
+
+    pub fn from_arc(session_id: Arc<SessionId>, branch_id: BranchId) -> Self {
+        Self {
+            inner: tokio::sync::RwLock::new(ConversationContextInner {
+                session_id,
+                branch_id,
+            }),
+        }
+    }
+
+    /// Read snapshot under a brief shared lock. The `Arc<SessionId>`
+    /// clone is reference-count only.
+    pub async fn current(&self) -> (Arc<SessionId>, BranchId) {
+        let g = self.inner.read().await;
+        (g.session_id.clone(), g.branch_id)
+    }
+
+    /// Atomically swap to a different (session, branch). Used by
+    /// `/switch` and by daemon-startup resume.
+    pub async fn replace(&self, session_id: Arc<SessionId>, branch_id: BranchId) {
+        let mut g = self.inner.write().await;
+        g.session_id = session_id;
+        g.branch_id = branch_id;
+    }
 }
 
 /// Shared, long-lived daemon state handed to every request handler.
@@ -94,11 +158,15 @@ pub struct AppState {
     /// the richer [`Self::conversations`] under one handle. Used by the
     /// IPC dispatch arms for `Request::Memory*`.
     pub memory_ops: Arc<MemoryOps>,
-    /// Identifier for this daemon process's session, set at startup by
-    /// [`assistd_memory::ConversationStore::begin_session`]. Every row
-    /// the persistence hook writes gets tagged with it so a future
-    /// `assistd memory reminisce` knows which daemon run produced it.
-    pub session_id: Arc<SessionId>,
+    /// Active conversation context: the session id and current branch
+    /// id, both swappable at runtime by `/switch`. Persistence reads
+    /// it once per message append; `/fork` and `/switch` mutate it
+    /// after acquiring the agent_turn_lock.
+    ///
+    /// At daemon startup this is either resumed from the most recent
+    /// unended session or freshly minted via
+    /// [`assistd_memory::ConversationStore::begin_session_with_main_branch`].
+    pub conversation_ctx: Arc<ConversationContext>,
     /// Embedder used for query-side embedding (`inject_semantic_context`)
     /// and for the LLM-callable `recall` / `reminisce` tools. The
     /// background embedder task that processes [`Self::embed_tx`] holds
@@ -187,7 +255,7 @@ impl AppState {
             memory,
             conversations,
             memory_ops,
-            session_id: Arc::new(SessionId::new()),
+            conversation_ctx: Arc::new(ConversationContext::new(SessionId::new(), BranchId(0))),
             embedder: Arc::new(NoEmbedder),
             semantic: Arc::new(NoSemanticStore),
             embed_tx,
@@ -239,11 +307,19 @@ impl AppState {
     }
 
     /// Override the daemon's session id. Set at startup once
-    /// [`assistd_memory::ConversationStore::begin_session`] has
-    /// returned the persisted uuid; tests skip this and inherit the
-    /// auto-generated default.
+    /// [`assistd_memory::ConversationStore::begin_session_with_main_branch`]
+    /// has returned the persisted uuid + branch id; tests skip this
+    /// and inherit the auto-generated default.
     pub fn with_session(mut self, s: Arc<SessionId>) -> Self {
-        self.session_id = s;
+        self.conversation_ctx = Arc::new(ConversationContext::from_arc(s, BranchId(0)));
+        self
+    }
+
+    /// Builder-style setter for the full conversation context (session +
+    /// active branch). Replaces [`Self::with_session`] when callers also
+    /// need to set the active branch id at startup.
+    pub fn with_conversation_ctx(mut self, ctx: Arc<ConversationContext>) -> Self {
+        self.conversation_ctx = ctx;
         self
     }
 
@@ -383,6 +459,10 @@ impl AppState {
             }
             Request::MemoryReindex { id } => self.handle_memory_reindex(id, tx).await,
             Request::GetCapabilities { id } => self.handle_get_capabilities(id, tx).await,
+            Request::Fork { id, name } => self.handle_fork(id, name, tx).await,
+            Request::Branches { id } => self.handle_branches(id, tx).await,
+            Request::Switch { id, target } => self.handle_switch(id, target, tx).await,
+            Request::Undo { id } => self.handle_undo(id, tx).await,
             // ConfirmResponse is intercepted by the connection-level
             // read loop (see `assistd-core/src/socket.rs`) and routed to
             // the active confirmation gate's pending oneshot. If we see
@@ -418,7 +498,7 @@ impl AppState {
     /// backfill pass.
     fn persist_message_fire_and_forget(&self, turn: Option<TurnId>, msg: PersistedMessage) {
         let conv = self.conversations.clone();
-        let session = self.session_id.clone();
+        let conversation_ctx = self.conversation_ctx.clone();
         let chunks_handle = self.chunks.clone();
         let embed_tx = self.embed_tx.clone();
         let embedding_enabled = self.embedding_cfg.enabled;
@@ -441,7 +521,11 @@ impl AppState {
             None
         };
         self.persistence_tracker.spawn(async move {
-            let row_id = match conv.append_message(&session, turn, msg).await {
+            let (session, branch) = conversation_ctx.current().await;
+            let row_id = match conv
+                .append_message_to_branch(&session, branch, turn, msg)
+                .await
+            {
                 Ok(id) => id,
                 Err(e) => {
                     tracing::warn!(
@@ -1082,8 +1166,9 @@ impl AppState {
         // here because every following persistence call needs the
         // resulting `TurnId` — but it's a single channel hop, not a
         // disk write of the streaming response.
+        let (current_session, _current_branch) = self.conversation_ctx.current().await;
         let turn_id: Option<TurnId> =
-            match self.conversations.begin_turn(&self.session_id, &text).await {
+            match self.conversations.begin_turn(&current_session, &text).await {
                 Ok(t) if t.0 != 0 => Some(t),
                 // NoConversationStore returns TurnId(0); treat that as "no
                 // persistence configured" without logging.
@@ -1811,6 +1896,351 @@ impl AppState {
             .await;
         let _ = tx.send(Event::Done { id }).await;
         Ok(())
+    }
+
+    /// `/fork <name>` — snapshot the current branch into a new branch
+    /// and switch to it. The shared agent_turn_lock + a drain of
+    /// `persistence_tracker` guarantees no in-flight turn races the
+    /// snapshot. The new branch shares conversation rows with its
+    /// parent (no row duplication); only branch_messages get copied.
+    #[tracing::instrument(skip_all, fields(correlation_id = %id, branch = %name))]
+    async fn handle_fork(
+        self: Arc<Self>,
+        id: String,
+        name: String,
+        tx: mpsc::Sender<Event>,
+    ) -> Result<()> {
+        if name.trim().is_empty() {
+            let _ = tx
+                .send(Event::Error {
+                    id,
+                    message: "/fork: name must not be empty".into(),
+                })
+                .await;
+            return Ok(());
+        }
+        // Lock first, then drain — order matters: holding the lock
+        // prevents new persistence tasks from being spawned, then we
+        // wait for already-spawned ones to finish.
+        let _agent_guard = self.agent_turn_lock.clone().lock_owned().await;
+        self.drain_persistence_inflight().await;
+
+        let (session, current_branch) = self.conversation_ctx.current().await;
+        let new_branch = match self.conversations.fork_branch(current_branch, &name).await {
+            Ok(b) => b,
+            Err(e) => {
+                let _ = tx
+                    .send(Event::Error {
+                        id,
+                        message: format!("/fork: {e:#}"),
+                    })
+                    .await;
+                return Ok(());
+            }
+        };
+        if let Err(e) = self
+            .conversations
+            .set_current_branch(&session, new_branch)
+            .await
+        {
+            let _ = tx
+                .send(Event::Error {
+                    id,
+                    message: format!("/fork: failed to update current branch: {e:#}"),
+                })
+                .await;
+            return Ok(());
+        }
+        self.conversation_ctx
+            .replace(session.clone(), new_branch)
+            .await;
+
+        // Echo the fork point back to the client. Look up the freshly
+        // created branch so we can emit the canonical metadata
+        // (parent name, fork_point_seq) without recomputing.
+        let parent_name = self.lookup_branch_name(current_branch).await;
+        let fork_point_seq = self.lookup_branch_tail_seq(current_branch).await;
+        let _ = tx
+            .send(Event::BranchSwitched {
+                id: id.clone(),
+                branch_id: new_branch.0,
+                session_id: session.0.clone(),
+                name,
+                parent_branch_name: parent_name,
+                fork_point_seq,
+            })
+            .await;
+        let _ = tx.send(Event::Done { id }).await;
+        Ok(())
+    }
+
+    /// `/branches` — enumerate every branch across every session, with
+    /// the active session's branches surfaced first.
+    #[tracing::instrument(skip_all, fields(correlation_id = %id))]
+    async fn handle_branches(self: Arc<Self>, id: String, tx: mpsc::Sender<Event>) -> Result<()> {
+        let branches = match self.conversations.list_branches().await {
+            Ok(v) => v,
+            Err(e) => {
+                let _ = tx
+                    .send(Event::Error {
+                        id,
+                        message: format!("/branches: {e:#}"),
+                    })
+                    .await;
+                return Ok(());
+            }
+        };
+        let (active_session, _) = self.conversation_ctx.current().await;
+        // Active-session-first ordering: keep the original list_branches
+        // sort but pull active-session branches to the top.
+        let mut active = Vec::new();
+        let mut other = Vec::new();
+        for b in branches {
+            if b.session_id == active_session.0 {
+                active.push(b);
+            } else {
+                other.push(b);
+            }
+        }
+        for b in active.into_iter().chain(other) {
+            let is_active_session = b.session_id == active_session.0;
+            let _ = tx
+                .send(Event::BranchInfo {
+                    id: id.clone(),
+                    branch_id: b.branch_id.0,
+                    session_id: b.session_id,
+                    session_started_at: b.session_started_at,
+                    session_ended_at: b.session_ended_at,
+                    name: b.name,
+                    parent_branch_name: b.parent_branch_name,
+                    fork_point_seq: b.fork_point_seq,
+                    created_at: b.created_at,
+                    message_count: b.message_count,
+                    is_current_in_session: b.is_current_in_session,
+                    is_active_session,
+                })
+                .await;
+        }
+        let _ = tx.send(Event::Done { id }).await;
+        Ok(())
+    }
+
+    /// `/switch <target>` — drain in-flight writes, swap the active
+    /// (session, branch) pointer, replay the target branch's history
+    /// into the LLM backend, and stream the loaded turns back to the
+    /// client so the TUI can repaint the chat pane.
+    #[tracing::instrument(skip_all, fields(correlation_id = %id, target = %target))]
+    async fn handle_switch(
+        self: Arc<Self>,
+        id: String,
+        target: String,
+        tx: mpsc::Sender<Event>,
+    ) -> Result<()> {
+        let _agent_guard = self.agent_turn_lock.clone().lock_owned().await;
+        self.drain_persistence_inflight().await;
+
+        let (active_session, _active_branch) = self.conversation_ctx.current().await;
+        let resolved = match self
+            .conversations
+            .resolve_branch(&target, Some(&active_session))
+            .await
+        {
+            Ok(Some(pair)) => pair,
+            Ok(None) => {
+                let _ = tx
+                    .send(Event::Error {
+                        id,
+                        message: format!("/switch: no branch named {target:?}"),
+                    })
+                    .await;
+                return Ok(());
+            }
+            Err(e) => {
+                let _ = tx
+                    .send(Event::Error {
+                        id,
+                        message: format!("/switch: {e:#}"),
+                    })
+                    .await;
+                return Ok(());
+            }
+        };
+        let (target_session, target_branch) = resolved;
+
+        // Update DB pointer first; if the daemon crashes between this
+        // and the in-memory swap, the next startup resumes the *new*
+        // active branch (consistent), not the old one.
+        if let Err(e) = self
+            .conversations
+            .set_current_branch(&target_session, target_branch)
+            .await
+        {
+            let _ = tx
+                .send(Event::Error {
+                    id,
+                    message: format!("/switch: failed to update current branch: {e:#}"),
+                })
+                .await;
+            return Ok(());
+        }
+        let target_session_arc = Arc::new(target_session.clone());
+        self.conversation_ctx
+            .replace(target_session_arc.clone(), target_branch)
+            .await;
+
+        // Reload history into the LLM backend.
+        let rows = match self.conversations.load_branch_history(target_branch).await {
+            Ok(v) => v,
+            Err(e) => {
+                let _ = tx
+                    .send(Event::Error {
+                        id,
+                        message: format!("/switch: load_branch_history: {e:#}"),
+                    })
+                    .await;
+                return Ok(());
+            }
+        };
+        let entries: Vec<assistd_llm::HistoryEntry> = rows
+            .iter()
+            .map(|r| assistd_llm::HistoryEntry {
+                role: persisted_role_to_history_role(r.role),
+                content: r.content.clone(),
+                tool_calls_json: r.tool_calls.clone(),
+                tool_call_id: r.tool_call_id.clone(),
+                tool_name: r.tool_name.clone(),
+            })
+            .collect();
+        if let Err(e) = self.llm.replace_history(entries).await {
+            tracing::warn!(
+                target: "assistd::state",
+                error = %e,
+                "replace_history failed (non-fatal)"
+            );
+        }
+
+        // Look up the new branch's metadata for the BranchSwitched event.
+        let (branch_name, parent_name, fork_point_seq) =
+            self.lookup_branch_meta(target_branch).await;
+
+        let _ = tx
+            .send(Event::BranchSwitched {
+                id: id.clone(),
+                branch_id: target_branch.0,
+                session_id: target_session.0.clone(),
+                name: branch_name.unwrap_or_default(),
+                parent_branch_name: parent_name,
+                fork_point_seq,
+            })
+            .await;
+        for r in rows {
+            let _ = tx
+                .send(Event::HistoryEntry {
+                    id: id.clone(),
+                    seq: r.seq,
+                    role: r.role.as_wire().to_string(),
+                    content: r.content,
+                    tool_name: r.tool_name,
+                })
+                .await;
+        }
+        let _ = tx.send(Event::Done { id }).await;
+        Ok(())
+    }
+
+    /// `/undo` — drop the latest user prompt and the entire assistant
+    /// reply that followed it from the current branch. Both DB and
+    /// in-memory state are updated atomically with the agent_turn_lock
+    /// held.
+    #[tracing::instrument(skip_all, fields(correlation_id = %id))]
+    async fn handle_undo(self: Arc<Self>, id: String, tx: mpsc::Sender<Event>) -> Result<()> {
+        let _agent_guard = self.agent_turn_lock.clone().lock_owned().await;
+        self.drain_persistence_inflight().await;
+        let (_, branch) = self.conversation_ctx.current().await;
+        let outcome = match self.conversations.undo_last_turn(branch).await {
+            Ok(o) => o,
+            Err(e) => {
+                let _ = tx
+                    .send(Event::Error {
+                        id,
+                        message: format!("/undo: {e:#}"),
+                    })
+                    .await;
+                return Ok(());
+            }
+        };
+        if outcome.removed_messages > 0 {
+            // Mirror the deletion in the in-memory conversation. We
+            // call `truncate_to_last_real_user` rather than recompute
+            // from the DB because the DB is now authoritative — the
+            // backend's job is just to align.
+            if let Err(e) = self.llm.truncate_to_last_real_user().await {
+                tracing::warn!(
+                    target: "assistd::state",
+                    error = %e,
+                    "truncate_to_last_real_user failed (non-fatal)"
+                );
+            }
+        }
+        let _ = tx
+            .send(Event::UndoApplied {
+                id: id.clone(),
+                removed_messages: outcome.removed_messages,
+                last_user_text: outcome.last_user_text,
+            })
+            .await;
+        let _ = tx.send(Event::Done { id }).await;
+        Ok(())
+    }
+
+    /// Block until every previously-spawned `persist_message_fire_and_forget`
+    /// task has landed. Held inside `agent_turn_lock` so no new tasks
+    /// can spawn during the wait.
+    async fn drain_persistence_inflight(&self) {
+        // `TaskTracker::wait()` on a *closed* tracker is permanent; we
+        // don't want to close it. Instead we just wait briefly via a
+        // probe — there's no public "wait for current tasks" API on
+        // the tracker. As a workaround, sample with a fixed budget:
+        // most persistence tasks finish in microseconds (one DB hop).
+        let deadline = std::time::Instant::now() + std::time::Duration::from_millis(500);
+        while !self.persistence_tracker.is_empty() && std::time::Instant::now() < deadline {
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+        if !self.persistence_tracker.is_empty() {
+            tracing::warn!(
+                target: "assistd::state",
+                "persistence drain timed out; in-flight writes may race branch op"
+            );
+        }
+    }
+
+    async fn lookup_branch_name(&self, branch: BranchId) -> Option<String> {
+        for b in self.conversations.list_branches().await.ok()? {
+            if b.branch_id == branch {
+                return Some(b.name);
+            }
+        }
+        None
+    }
+
+    async fn lookup_branch_tail_seq(&self, branch: BranchId) -> Option<i64> {
+        let rows = self.conversations.load_branch_history(branch).await.ok()?;
+        rows.last().map(|r| r.seq)
+    }
+
+    async fn lookup_branch_meta(
+        &self,
+        branch: BranchId,
+    ) -> (Option<String>, Option<String>, Option<i64>) {
+        let Ok(branches) = self.conversations.list_branches().await else {
+            return (None, None, None);
+        };
+        for b in branches {
+            if b.branch_id == branch {
+                return (Some(b.name), b.parent_branch_name, b.fork_point_seq);
+            }
+        }
+        (None, None, None)
     }
 
     /// End the push-to-talk recording, transcribe, and — if the
@@ -3158,5 +3588,292 @@ mod tests {
     #[test]
     fn combine_context_blocks_returns_none_for_both_none() {
         assert!(combine_context_blocks(None, None).is_none());
+    }
+
+    // --- Branch-handler integration tests --------------------------------
+    //
+    // These exercise the four `/fork` `/branches` `/switch` `/undo`
+    // handlers against an SQLite-backed ConversationStore so the
+    // dispatcher → writer-task → DB → in-memory replay round trip is
+    // covered end-to-end. Uses an in-memory backend (EchoBackend, which
+    // gets `replace_history` / `truncate_to_last_real_user` no-op
+    // defaults) so the tests don't require llama-server.
+
+    async fn fresh_branch_state() -> (
+        Arc<AppState>,
+        Arc<dyn ConversationStore>,
+        assistd_memory::SessionId,
+        assistd_memory::BranchId,
+    ) {
+        use assistd_memory::{SqliteConversationStore, SqliteHandle};
+        use tokio::sync::watch;
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("memory.db");
+        std::mem::forget(temp);
+        let (_tx, rx) = watch::channel(false);
+        let (handle, _writer_handle) = SqliteHandle::open(&path, rx).await.unwrap();
+        let handle = Arc::new(handle);
+        let conv: Arc<dyn ConversationStore> =
+            Arc::new(SqliteConversationStore::new(handle.clone()));
+        let (session, branch) = conv.begin_session_with_main_branch(123).await.unwrap();
+        let ctx = Arc::new(ConversationContext::new(session.clone(), branch));
+        let state = Arc::new(
+            AppState::new(
+                Config::default(),
+                Arc::new(EchoBackend::new()),
+                PresenceManager::stub(PresenceState::Active),
+                Arc::new(ToolRegistry::default()),
+                Arc::new(assistd_voice::NoVoiceInput::new()),
+                Arc::new(assistd_voice::NoContinuousListener::new()),
+                VoiceOutputController::new(Arc::new(assistd_voice::NoVoiceOutput), true),
+            )
+            .with_conversations(conv.clone())
+            .with_conversation_ctx(ctx),
+        );
+        (state, conv, session, branch)
+    }
+
+    async fn drain_events(mut rx: mpsc::Receiver<Event>) -> Vec<Event> {
+        let mut out = Vec::new();
+        while let Some(ev) = rx.recv().await {
+            out.push(ev);
+        }
+        out
+    }
+
+    #[tokio::test]
+    async fn fork_creates_branch_and_switches() {
+        let (state, conv, session, _main_branch) = fresh_branch_state().await;
+        let (tx, rx) = mpsc::channel::<Event>(16);
+        state
+            .clone()
+            .dispatch(
+                Request::Fork {
+                    id: "rq".into(),
+                    name: "experiment".into(),
+                },
+                tx,
+            )
+            .await
+            .unwrap();
+        let events = drain_events(rx).await;
+        // Last event must be Done; some prior event must be BranchSwitched.
+        assert!(matches!(events.last(), Some(Event::Done { .. })));
+        let switched = events
+            .iter()
+            .find(|e| matches!(e, Event::BranchSwitched { .. }))
+            .expect("expected BranchSwitched");
+        if let Event::BranchSwitched {
+            name,
+            parent_branch_name,
+            ..
+        } = switched
+        {
+            assert_eq!(name, "experiment");
+            assert_eq!(parent_branch_name.as_deref(), Some("main"));
+        } else {
+            unreachable!()
+        }
+        // Active branch in DB now points at the new branch.
+        let new_current = conv.get_current_branch(&session).await.unwrap();
+        assert!(new_current.is_some());
+        // ConversationContext also rotated.
+        let (active_session, _) = state.conversation_ctx.current().await;
+        assert_eq!(active_session.0, session.0);
+    }
+
+    #[tokio::test]
+    async fn fork_with_empty_name_emits_error() {
+        let (state, _conv, _session, _branch) = fresh_branch_state().await;
+        let (tx, rx) = mpsc::channel::<Event>(16);
+        state
+            .clone()
+            .dispatch(
+                Request::Fork {
+                    id: "rq".into(),
+                    name: "   ".into(),
+                },
+                tx,
+            )
+            .await
+            .unwrap();
+        let events = drain_events(rx).await;
+        assert!(events.iter().any(|e| matches!(e, Event::Error { .. })));
+    }
+
+    #[tokio::test]
+    async fn branches_lists_active_session_first() {
+        let (state, conv, session, _main_branch) = fresh_branch_state().await;
+        // Create an extra branch so list isn't trivial.
+        let _alt = conv
+            .create_branch(&session, "alt", None, None)
+            .await
+            .unwrap();
+        let (tx, rx) = mpsc::channel::<Event>(16);
+        state
+            .clone()
+            .dispatch(Request::Branches { id: "rq".into() }, tx)
+            .await
+            .unwrap();
+        let events = drain_events(rx).await;
+        let infos: Vec<_> = events
+            .iter()
+            .filter_map(|e| match e {
+                Event::BranchInfo { name, .. } => Some(name.clone()),
+                _ => None,
+            })
+            .collect();
+        assert!(infos.contains(&"main".to_string()));
+        assert!(infos.contains(&"alt".to_string()));
+        assert!(matches!(events.last(), Some(Event::Done { .. })));
+    }
+
+    #[tokio::test]
+    async fn switch_replays_history_into_event_stream() {
+        let (state, conv, session, main_branch) = fresh_branch_state().await;
+        // Append a couple messages to main so /switch has content.
+        let turn = conv.begin_turn(&session, "hello").await.unwrap();
+        conv.append_message_to_branch(
+            &session,
+            main_branch,
+            Some(turn),
+            assistd_memory::PersistedMessage::user("hello"),
+        )
+        .await
+        .unwrap();
+        conv.append_message_to_branch(
+            &session,
+            main_branch,
+            Some(turn),
+            assistd_memory::PersistedMessage::assistant_text("world"),
+        )
+        .await
+        .unwrap();
+        // Fork into "alt", then switch back to main.
+        let _alt = conv.fork_branch(main_branch, "alt").await.unwrap();
+        let (tx, rx) = mpsc::channel::<Event>(16);
+        state
+            .clone()
+            .dispatch(
+                Request::Switch {
+                    id: "rq".into(),
+                    target: "alt".into(),
+                },
+                tx,
+            )
+            .await
+            .unwrap();
+        let events = drain_events(rx).await;
+        let history_count = events
+            .iter()
+            .filter(|e| matches!(e, Event::HistoryEntry { .. }))
+            .count();
+        assert_eq!(history_count, 2, "fork's branch_messages also has 2 rows");
+        assert!(matches!(events.last(), Some(Event::Done { .. })));
+    }
+
+    #[tokio::test]
+    async fn switch_unknown_branch_emits_error() {
+        let (state, _conv, _session, _branch) = fresh_branch_state().await;
+        let (tx, rx) = mpsc::channel::<Event>(16);
+        state
+            .clone()
+            .dispatch(
+                Request::Switch {
+                    id: "rq".into(),
+                    target: "no-such-branch".into(),
+                },
+                tx,
+            )
+            .await
+            .unwrap();
+        let events = drain_events(rx).await;
+        assert!(events.iter().any(|e| matches!(e, Event::Error { .. })));
+    }
+
+    #[tokio::test]
+    async fn undo_drops_last_turn_and_emits_count() {
+        let (state, conv, session, main_branch) = fresh_branch_state().await;
+        // Two turns on main: "first" and "second".
+        let t1 = conv.begin_turn(&session, "first").await.unwrap();
+        conv.append_message_to_branch(
+            &session,
+            main_branch,
+            Some(t1),
+            assistd_memory::PersistedMessage::user("first"),
+        )
+        .await
+        .unwrap();
+        conv.append_message_to_branch(
+            &session,
+            main_branch,
+            Some(t1),
+            assistd_memory::PersistedMessage::assistant_text("a"),
+        )
+        .await
+        .unwrap();
+        conv.end_turn(t1).await.unwrap();
+        let t2 = conv.begin_turn(&session, "second").await.unwrap();
+        conv.append_message_to_branch(
+            &session,
+            main_branch,
+            Some(t2),
+            assistd_memory::PersistedMessage::user("second"),
+        )
+        .await
+        .unwrap();
+        conv.append_message_to_branch(
+            &session,
+            main_branch,
+            Some(t2),
+            assistd_memory::PersistedMessage::assistant_text("b"),
+        )
+        .await
+        .unwrap();
+        conv.end_turn(t2).await.unwrap();
+        let (tx, rx) = mpsc::channel::<Event>(16);
+        state
+            .clone()
+            .dispatch(Request::Undo { id: "rq".into() }, tx)
+            .await
+            .unwrap();
+        let events = drain_events(rx).await;
+        let applied = events
+            .iter()
+            .find_map(|e| match e {
+                Event::UndoApplied {
+                    removed_messages,
+                    last_user_text,
+                    ..
+                } => Some((*removed_messages, last_user_text.clone())),
+                _ => None,
+            })
+            .expect("expected UndoApplied");
+        assert_eq!(applied.0, 2);
+        assert_eq!(applied.1.as_deref(), Some("second"));
+        let history = conv.load_branch_history(main_branch).await.unwrap();
+        assert_eq!(history.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn undo_on_empty_branch_returns_zero() {
+        let (state, _conv, _session, _branch) = fresh_branch_state().await;
+        let (tx, rx) = mpsc::channel::<Event>(16);
+        state
+            .clone()
+            .dispatch(Request::Undo { id: "rq".into() }, tx)
+            .await
+            .unwrap();
+        let events = drain_events(rx).await;
+        let applied = events
+            .iter()
+            .find_map(|e| match e {
+                Event::UndoApplied {
+                    removed_messages, ..
+                } => Some(*removed_messages),
+                _ => None,
+            })
+            .expect("expected UndoApplied even on empty branch");
+        assert_eq!(applied, 0);
     }
 }

--- a/crates/assistd-ipc/src/lib.rs
+++ b/crates/assistd-ipc/src/lib.rs
@@ -243,6 +243,26 @@ pub enum Request {
     /// Called by clients (TUI, CLI) at startup to render UI state that
     /// otherwise required them to reach into llama-server directly.
     GetCapabilities { id: String },
+    /// Snapshot the current conversation state into a new branch named
+    /// `name` and switch to it. Emits a single [`Event::BranchSwitched`]
+    /// describing the new branch, then `Done`. Errors when the name is
+    /// already taken or empty.
+    Fork { id: String, name: String },
+    /// Enumerate every branch across every session. Emits zero or more
+    /// [`Event::BranchInfo`] events (active session first), then `Done`.
+    Branches { id: String },
+    /// Switch the active conversation to a different branch.
+    /// `target` is either a bare branch name (resolved to the current
+    /// session's branch first, then most-recent session on collision)
+    /// or `<session_prefix>/<name>` for an explicit cross-session jump.
+    /// Emits a [`Event::BranchSwitched`] followed by one
+    /// [`Event::HistoryEntry`] per loaded message, then `Done`.
+    Switch { id: String, target: String },
+    /// Drop the most recent user message and the entire assistant
+    /// reply that followed it (including any tool-call/result rounds)
+    /// from the current branch. Emits a single [`Event::UndoApplied`]
+    /// reporting how many messages were removed, then `Done`.
+    Undo { id: String },
 }
 
 impl Request {
@@ -299,7 +319,11 @@ impl Request {
             | Request::MemorySemanticSearch { id, .. }
             | Request::MemoryReindex { id, .. }
             | Request::ConfirmResponse { id, .. }
-            | Request::GetCapabilities { id, .. } => id,
+            | Request::GetCapabilities { id, .. }
+            | Request::Fork { id, .. }
+            | Request::Branches { id }
+            | Request::Switch { id, .. }
+            | Request::Undo { id } => id,
         }
     }
 
@@ -330,6 +354,10 @@ impl Request {
             Request::MemoryReindex { .. } => "memory_reindex",
             Request::ConfirmResponse { .. } => "confirm_response",
             Request::GetCapabilities { .. } => "get_capabilities",
+            Request::Fork { .. } => "fork",
+            Request::Branches { .. } => "branches",
+            Request::Switch { .. } => "switch",
+            Request::Undo { .. } => "undo",
         }
     }
 }
@@ -479,6 +507,57 @@ pub enum Event {
         event: String,
         message: String,
     },
+    /// One branch entry emitted by [`Request::Branches`]. Multiple
+    /// events stream out (one per branch) in active-session-first
+    /// order, terminated by `Done`. `is_active_session` is true when
+    /// `session_id` matches the daemon's currently-active session.
+    BranchInfo {
+        id: String,
+        branch_id: i64,
+        session_id: String,
+        session_started_at: String,
+        session_ended_at: Option<String>,
+        name: String,
+        parent_branch_name: Option<String>,
+        fork_point_seq: Option<i64>,
+        created_at: String,
+        message_count: i64,
+        is_current_in_session: bool,
+        is_active_session: bool,
+    },
+    /// Emitted by [`Request::Fork`] and [`Request::Switch`] to confirm
+    /// the active branch changed. For `/switch` cross-session moves,
+    /// `session_id` is the session the daemon is now active in.
+    BranchSwitched {
+        id: String,
+        branch_id: i64,
+        session_id: String,
+        name: String,
+        parent_branch_name: Option<String>,
+        fork_point_seq: Option<i64>,
+    },
+    /// One message of branch history emitted during [`Request::Switch`]
+    /// so the TUI can repaint the chat pane with the loaded branch's
+    /// turns. `role` is `system|user|assistant|tool`. Tool-result rows
+    /// arrive as `role=tool` (TUI may render them as a dim "tool: …"
+    /// line); plain user/assistant rows render as the corresponding
+    /// chat bubbles.
+    HistoryEntry {
+        id: String,
+        seq: i64,
+        role: String,
+        content: String,
+        tool_name: Option<String>,
+    },
+    /// Emitted by [`Request::Undo`]. `removed_messages` is the count of
+    /// rows dropped from the current branch; 0 means "nothing to undo"
+    /// (the branch had no real user turn). `last_user_text` echoes the
+    /// undone prompt for the TUI to surface (e.g. "undone: hello world").
+    UndoApplied {
+        id: String,
+        removed_messages: u32,
+        last_user_text: Option<String>,
+    },
     /// Terminal error event — the stream is over.
     Error { id: String, message: String },
     /// Terminal success event — the stream is over.
@@ -511,6 +590,10 @@ impl Event {
             | Event::ConfirmRequest { id, .. }
             | Event::Capabilities { id, .. }
             | Event::Status { id, .. }
+            | Event::BranchInfo { id, .. }
+            | Event::BranchSwitched { id, .. }
+            | Event::HistoryEntry { id, .. }
+            | Event::UndoApplied { id, .. }
             | Event::Error { id, .. }
             | Event::Done { id } => id,
         }
@@ -593,6 +676,112 @@ mod tests {
             }
             _ => panic!("expected Query"),
         }
+    }
+
+    #[test]
+    fn fork_request_round_trips() {
+        let req = Request::Fork {
+            id: "r-1".into(),
+            name: "experiment".into(),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        let parsed: Request = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, req);
+        assert_eq!(req.kind(), "fork");
+        assert_eq!(req.id(), "r-1");
+    }
+
+    #[test]
+    fn branches_request_round_trips() {
+        let req = Request::Branches { id: "r-2".into() };
+        let json = serde_json::to_string(&req).unwrap();
+        let parsed: Request = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, req);
+        assert_eq!(req.kind(), "branches");
+    }
+
+    #[test]
+    fn switch_request_round_trips() {
+        let req = Request::Switch {
+            id: "r-3".into(),
+            target: "abc12345/main".into(),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        let parsed: Request = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, req);
+        assert_eq!(req.kind(), "switch");
+    }
+
+    #[test]
+    fn undo_request_round_trips() {
+        let req = Request::Undo { id: "r-4".into() };
+        let json = serde_json::to_string(&req).unwrap();
+        let parsed: Request = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, req);
+        assert_eq!(req.kind(), "undo");
+    }
+
+    #[test]
+    fn branch_info_event_round_trips() {
+        let ev = Event::BranchInfo {
+            id: "r-1".into(),
+            branch_id: 7,
+            session_id: "abc12345-...".into(),
+            session_started_at: "2026-01-01T00:00:00Z".into(),
+            session_ended_at: None,
+            name: "main".into(),
+            parent_branch_name: None,
+            fork_point_seq: None,
+            created_at: "2026-01-01T00:00:00Z".into(),
+            message_count: 4,
+            is_current_in_session: true,
+            is_active_session: true,
+        };
+        let json = serde_json::to_string(&ev).unwrap();
+        let parsed: Event = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, ev);
+        assert_eq!(ev.id(), "r-1");
+    }
+
+    #[test]
+    fn branch_switched_event_round_trips() {
+        let ev = Event::BranchSwitched {
+            id: "r-2".into(),
+            branch_id: 9,
+            session_id: "sess".into(),
+            name: "experiment".into(),
+            parent_branch_name: Some("main".into()),
+            fork_point_seq: Some(5),
+        };
+        let json = serde_json::to_string(&ev).unwrap();
+        let parsed: Event = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, ev);
+    }
+
+    #[test]
+    fn history_entry_event_round_trips() {
+        let ev = Event::HistoryEntry {
+            id: "r-3".into(),
+            seq: 3,
+            role: "assistant".into(),
+            content: "hello".into(),
+            tool_name: None,
+        };
+        let json = serde_json::to_string(&ev).unwrap();
+        let parsed: Event = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, ev);
+    }
+
+    #[test]
+    fn undo_applied_event_round_trips() {
+        let ev = Event::UndoApplied {
+            id: "r-4".into(),
+            removed_messages: 2,
+            last_user_text: Some("hi".into()),
+        };
+        let json = serde_json::to_string(&ev).unwrap();
+        let parsed: Event = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, ev);
     }
 
     #[test]

--- a/crates/assistd-llm/src/chat/client.rs
+++ b/crates/assistd-llm/src/chat/client.rs
@@ -28,12 +28,13 @@ use tokio::time::timeout;
 use tracing::{debug, warn};
 
 use super::conversation::{Conversation, Summarizer, ToolCallRecord};
+use super::conversation::{Message, Role};
 use super::error::ChatClientError;
 use super::sse::{SseEvent, SseLineReader};
 use super::wire;
 use crate::{
-    LlmBackend, LlmError, LlmEvent, LlmHealthProbe, LlmResult, ReadyState, StepOutcome, ToolCall,
-    ToolResultPayload,
+    HistoryEntry, HistoryRole, LlmBackend, LlmError, LlmEvent, LlmHealthProbe, LlmResult,
+    ReadyState, StepOutcome, ToolCall, ToolResultPayload,
 };
 
 const ERROR_BODY_CAP: usize = 1024;
@@ -504,6 +505,93 @@ impl LlmBackend for LlamaChatClient {
         conv.set_transient_context(text);
         Ok(())
     }
+
+    async fn replace_history(&self, entries: Vec<HistoryEntry>) -> LlmResult<()> {
+        let mut msgs = Vec::with_capacity(entries.len());
+        for entry in entries {
+            match entry.role {
+                HistoryRole::System => msgs.push(Message {
+                    role: Role::System,
+                    content: entry.content,
+                    attachments: Vec::new(),
+                    tool_calls: Vec::new(),
+                }),
+                HistoryRole::User => msgs.push(Message {
+                    role: Role::User,
+                    content: entry.content,
+                    attachments: Vec::new(),
+                    tool_calls: Vec::new(),
+                }),
+                HistoryRole::Assistant => {
+                    let calls = parse_tool_calls(&entry.tool_calls_json)?;
+                    msgs.push(Message {
+                        role: Role::Assistant,
+                        content: entry.content,
+                        attachments: Vec::new(),
+                        tool_calls: calls,
+                    });
+                }
+                HistoryRole::Tool => {
+                    // Tool results round-trip as Role::User with the
+                    // [tool:<name>]\n prefix the truncator depends on
+                    // for tool-call/result pair detection.
+                    let name = entry.tool_name.unwrap_or_default();
+                    let tagged = format!("[tool:{name}]\n{}", entry.content);
+                    msgs.push(Message {
+                        role: Role::User,
+                        content: tagged,
+                        attachments: Vec::new(),
+                        tool_calls: Vec::new(),
+                    });
+                }
+            }
+        }
+        let mut conv = self.conv.lock().await;
+        conv.replace_messages(msgs);
+        Ok(())
+    }
+
+    async fn truncate_to_last_real_user(&self) -> LlmResult<usize> {
+        let mut conv = self.conv.lock().await;
+        Ok(conv.truncate_to_last_real_user())
+    }
+}
+
+fn parse_tool_calls(json: &Option<Value>) -> LlmResult<Vec<super::conversation::ToolCallRecord>> {
+    use super::conversation::ToolCallRecord;
+    let Some(value) = json else {
+        return Ok(Vec::new());
+    };
+    let Some(arr) = value.as_array() else {
+        return Ok(Vec::new());
+    };
+    let mut out = Vec::with_capacity(arr.len());
+    for entry in arr {
+        let id = entry
+            .get("id")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string();
+        let name = entry
+            .get("name")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| LlmError::ToolCallParse("history tool_call missing name".into()))?
+            .to_string();
+        // arguments is stored verbatim as JSON. It may be either a
+        // JSON-encoded string or an object — store the literal string
+        // so the wire payload matches what the model originally emitted.
+        let arguments = match entry.get("arguments") {
+            Some(Value::String(s)) => s.clone(),
+            Some(other) => other.to_string(),
+            None => "{}".to_string(),
+        };
+        out.push(ToolCallRecord {
+            id,
+            name,
+            arguments,
+        });
+    }
+    Ok(out)
 }
 
 /// Translate a completed stream into conversation commits + [`StepOutcome`].

--- a/crates/assistd-llm/src/chat/conversation.rs
+++ b/crates/assistd-llm/src/chat/conversation.rs
@@ -198,6 +198,38 @@ impl Conversation {
         }
     }
 
+    /// Replace the running message list wholesale and clear any pending
+    /// transient context. Used by branch /switch and daemon-startup
+    /// resume to repopulate the conversation from persisted history.
+    pub fn replace_messages(&mut self, msgs: Vec<Message>) {
+        self.messages = msgs;
+        self.transient_context = None;
+    }
+
+    /// Drop everything after — and including — the latest "real" user
+    /// message. A "real" user message is [`Role::User`] whose content
+    /// does NOT start with [`TOOL_RESULT_PREFIX`]; tool-result rows
+    /// share the User role but are part of the assistant's reply, so
+    /// they get dropped alongside it. Also clears `transient_context`
+    /// (we are at a turn boundary). Returns the count of removed
+    /// entries; 0 when no real user message exists.
+    pub fn truncate_to_last_real_user(&mut self) -> usize {
+        let mut last_real_user = None;
+        for (i, m) in self.messages.iter().enumerate().rev() {
+            if matches!(m.role, Role::User) && !m.content.starts_with(TOOL_RESULT_PREFIX) {
+                last_real_user = Some(i);
+                break;
+            }
+        }
+        let Some(idx) = last_real_user else {
+            return 0;
+        };
+        let removed = self.messages.len() - idx;
+        self.messages.truncate(idx);
+        self.transient_context = None;
+        removed
+    }
+
     pub fn approx_total_tokens(&self) -> u32 {
         let mut total = 0u32;
         if !self.system_prompt.is_empty() {
@@ -678,6 +710,78 @@ mod tests {
             with_ctx > baseline,
             "transient context must contribute to budget math: {baseline} → {with_ctx}"
         );
+    }
+
+    #[test]
+    fn replace_messages_swaps_history_and_clears_transient() {
+        let mut c = Conversation::new("sys".into());
+        c.push_user("first".into());
+        c.set_transient_context("ctx".into());
+        c.replace_messages(vec![
+            Message {
+                role: Role::User,
+                content: "loaded user".into(),
+                attachments: Vec::new(),
+                tool_calls: Vec::new(),
+            },
+            Message {
+                role: Role::Assistant,
+                content: "loaded assistant".into(),
+                attachments: Vec::new(),
+                tool_calls: Vec::new(),
+            },
+        ]);
+        let wire = c.as_wire_messages();
+        // [system=sys, user=loaded user, assistant=loaded assistant] — transient gone.
+        assert_eq!(wire.len(), 3);
+        assert_eq!(wire[0].role, "system");
+        assert_eq!(wire[1].role, "user");
+        match &wire[1].content {
+            Some(wire::ContentBody::Text(t)) => assert_eq!(*t, "loaded user"),
+            _ => panic!("expected text body"),
+        }
+        assert!(c.transient_context().is_none());
+    }
+
+    #[test]
+    fn truncate_to_last_real_user_drops_through_assistant_chain() {
+        let mut c = Conversation::new("sys".into());
+        c.push_user("first".into());
+        c.push_assistant("a1".into());
+        c.push_user("second".into());
+        c.push_assistant("a2".into());
+        let removed = c.truncate_to_last_real_user();
+        assert_eq!(removed, 2, "drops 'second' user + 'a2' assistant");
+        assert_eq!(c.messages.len(), 2);
+        assert_eq!(c.messages[0].content, "first");
+        assert_eq!(c.messages[1].content, "a1");
+    }
+
+    #[test]
+    fn truncate_to_last_real_user_skips_tool_results_to_real_user() {
+        let mut c = Conversation::new("sys".into());
+        c.push_user("real q".into());
+        // Tool-call pair, ending with a tool-result user message.
+        c.push_assistant_with_tool_calls(
+            None,
+            vec![ToolCallRecord {
+                id: "c-1".into(),
+                name: "run".into(),
+                arguments: "{}".into(),
+            }],
+        );
+        c.push_user("[tool:run]\noutput".into());
+        c.push_assistant("final".into());
+        let removed = c.truncate_to_last_real_user();
+        assert_eq!(removed, 4);
+        assert!(c.messages.is_empty());
+    }
+
+    #[test]
+    fn truncate_to_last_real_user_returns_zero_when_no_user_present() {
+        let mut c = Conversation::new("sys".into());
+        let removed = c.truncate_to_last_real_user();
+        assert_eq!(removed, 0);
     }
 
     #[test]

--- a/crates/assistd-llm/src/lib.rs
+++ b/crates/assistd-llm/src/lib.rs
@@ -18,6 +18,7 @@
 pub mod chat;
 pub mod llama_server;
 
+pub use chat::conversation::ToolCallRecord;
 pub use chat::{ChatClientError, LlamaChatClient};
 pub use llama_server::{
     LlamaServerControl, LlamaServerError, LlamaService, ReadyState, VisionState,
@@ -204,6 +205,31 @@ pub enum StepOutcome {
     ToolCalls(Vec<ToolCall>),
 }
 
+/// Persistence-shaped role for [`HistoryEntry`]. Mirrors
+/// `assistd_memory::PersistedRole` so the daemon can translate row →
+/// entry without pulling `assistd-memory` into this crate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum HistoryRole {
+    System,
+    User,
+    Assistant,
+    Tool,
+}
+
+/// One persisted message reconstructed for replay into a backend's
+/// in-memory conversation (used by branch /switch and daemon-startup
+/// resume). `tool_calls_json` is verbatim JSON straight from the DB —
+/// the concrete backend parses it back into its native shape so the
+/// trait stays free of `ToolCallRecord` references.
+#[derive(Debug, Clone)]
+pub struct HistoryEntry {
+    pub role: HistoryRole,
+    pub content: String,
+    pub tool_calls_json: Option<Value>,
+    pub tool_call_id: Option<String>,
+    pub tool_name: Option<String>,
+}
+
 #[async_trait]
 pub trait LlmBackend: Send + Sync + 'static {
     /// Generate a response to `prompt`, streaming tokens through `tx`.
@@ -252,6 +278,26 @@ pub trait LlmBackend: Send + Sync + 'static {
     /// future stubs don't need to track per-turn context.
     async fn set_transient_context(&self, _text: String) -> LlmResult<()> {
         Ok(())
+    }
+
+    /// Replace the backend's in-memory conversation with `entries`,
+    /// preserving the static system prompt. Used by `/switch` and by
+    /// daemon-startup resume to align the LLM's view of history with
+    /// the persisted DB state of a different branch.
+    ///
+    /// Default no-op so test/echo backends don't need to track history.
+    async fn replace_history(&self, _entries: Vec<HistoryEntry>) -> LlmResult<()> {
+        Ok(())
+    }
+
+    /// Drop the most recent "real" user message and everything after
+    /// it from the in-memory conversation. A "real" user message is
+    /// `Role::User` whose content does NOT start with the
+    /// tool-result prefix. Returns the count of messages removed.
+    ///
+    /// Default no-op so test/echo backends are unaffected.
+    async fn truncate_to_last_real_user(&self) -> LlmResult<usize> {
+        Ok(0)
     }
 }
 

--- a/crates/assistd-memory/src/lib.rs
+++ b/crates/assistd-memory/src/lib.rs
@@ -44,10 +44,10 @@ pub mod sqlite;
 
 pub use chunking::{ChunkingConfig, chunk_message};
 pub use sqlite::{
-    ConversationStore, EmbeddingHit, MemoryHit, NoConversationStore, NoSemanticStore,
-    PersistedMessage, PersistedRole, SearchHit, SemanticStore, SessionId, SqliteConversationStore,
-    SqliteHandle, SqliteMemoryStore, SqliteSemanticStore, TurnId, TurnSummary, WriteOp,
-    vector_to_blob,
+    BranchId, BranchInfo, ConversationStore, EmbeddingHit, HistoryRow, MemoryHit,
+    NoConversationStore, NoSemanticStore, PersistedMessage, PersistedRole, ResumeCandidate,
+    SearchHit, SemanticStore, SessionId, SqliteConversationStore, SqliteHandle, SqliteMemoryStore,
+    SqliteSemanticStore, TurnId, TurnSummary, UndoOutcome, WriteOp, vector_to_blob,
 };
 
 use anyhow::Result;

--- a/crates/assistd-memory/src/migrations.rs
+++ b/crates/assistd-memory/src/migrations.rs
@@ -108,6 +108,59 @@ CREATE TABLE embeddings (
 CREATE INDEX idx_embeddings_model ON embeddings(model);
 "#;
 
+/// V3: conversation branching.
+///
+/// Adds named branches per session plus a `branch_messages` join table
+/// that maps `(branch_id, branch-local seq) -> conversation_id`. We
+/// deliberately do NOT duplicate `conversations` rows on fork — a single
+/// conversation row can be reachable from multiple branches at
+/// different (or the same) seq via separate `branch_messages` entries.
+/// This avoids FTS5 trigger-driven duplication and keeps
+/// `conversation_chunks` / `embeddings` referentially clean.
+///
+/// `sessions` gains `current_branch_id` (NULL on legacy rows; backfilled
+/// to the freshly-inserted "main" branch in this migration). The
+/// existing `conversations.seq` column stays as the session-wide insert
+/// order used by FTS5 ranking; branch-local order lives in
+/// `branch_messages.seq`.
+const V3_SQL: &str = r#"
+CREATE TABLE branches (
+    id                INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id        TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    name              TEXT NOT NULL,
+    parent_branch_id  INTEGER REFERENCES branches(id) ON DELETE SET NULL,
+    fork_point_seq    INTEGER,
+    created_at        TEXT NOT NULL,
+    UNIQUE(session_id, name)
+);
+CREATE INDEX idx_branches_session ON branches(session_id);
+
+CREATE TABLE branch_messages (
+    branch_id       INTEGER NOT NULL REFERENCES branches(id) ON DELETE CASCADE,
+    seq             INTEGER NOT NULL,
+    conversation_id INTEGER NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+    PRIMARY KEY (branch_id, seq)
+);
+CREATE INDEX idx_branch_messages_branch_seq ON branch_messages(branch_id, seq);
+CREATE INDEX idx_branch_messages_conv ON branch_messages(conversation_id);
+
+ALTER TABLE sessions ADD COLUMN current_branch_id INTEGER REFERENCES branches(id);
+
+INSERT INTO branches (session_id, name, parent_branch_id, fork_point_seq, created_at)
+    SELECT id, 'main', NULL, NULL, started_at FROM sessions;
+
+INSERT INTO branch_messages (branch_id, seq, conversation_id)
+    SELECT b.id, c.seq, c.id
+    FROM conversations c
+    JOIN branches b ON b.session_id = c.session_id AND b.name = 'main';
+
+UPDATE sessions
+    SET current_branch_id = (
+        SELECT id FROM branches
+        WHERE branches.session_id = sessions.id AND name = 'main'
+    );
+"#;
+
 /// V2: per-memory embeddings.
 ///
 /// Adds a sibling table to `embeddings` that indexes the `memories` KV
@@ -136,7 +189,7 @@ CREATE INDEX idx_memory_embeddings_model ON memory_embeddings(model);
 /// Build the full migration set. `'static` because the SQL is embedded
 /// in the binary; rusqlite_migration just needs read access.
 pub fn migrations() -> Migrations<'static> {
-    Migrations::new(vec![M::up(V1_SQL), M::up(V2_SQL)])
+    Migrations::new(vec![M::up(V1_SQL), M::up(V2_SQL), M::up(V3_SQL)])
 }
 
 /// Apply all pending migrations to `conn`. Idempotent: re-running on an
@@ -177,6 +230,8 @@ mod tests {
             .collect();
 
         for expected in [
+            "branch_messages",
+            "branches",
             "conv_fts_ad",
             "conv_fts_ai",
             "conv_fts_au",
@@ -184,6 +239,9 @@ mod tests {
             "conversations",
             "conversations_fts",
             "embeddings",
+            "idx_branch_messages_branch_seq",
+            "idx_branch_messages_conv",
+            "idx_branches_session",
             "idx_chunks_conv",
             "idx_conversations_session_seq",
             "idx_conversations_turn",

--- a/crates/assistd-memory/src/sqlite/conversations.rs
+++ b/crates/assistd-memory/src/sqlite/conversations.rs
@@ -49,6 +49,10 @@ impl std::fmt::Display for SessionId {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct TurnId(pub i64);
 
+/// Opaque branch identifier (rowid in `branches`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct BranchId(pub i64);
+
 /// Role of a persisted message. Mirrors `assistd_llm::chat::conversation::Role`
 /// plus a `Tool` variant for tool-result rows.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -168,6 +172,54 @@ pub struct TurnSummary {
     pub message_count: i64,
 }
 
+/// Per-branch metadata returned by [`ConversationStore::list_branches`].
+/// `is_current_in_session` flags the branch that `sessions.current_branch_id`
+/// points at; the active session can be cross-referenced via the
+/// daemon-held [`SessionId`].
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BranchInfo {
+    pub branch_id: BranchId,
+    pub session_id: String,
+    pub session_started_at: String,
+    pub session_ended_at: Option<String>,
+    pub name: String,
+    pub parent_branch_id: Option<BranchId>,
+    pub parent_branch_name: Option<String>,
+    pub fork_point_seq: Option<i64>,
+    pub created_at: String,
+    pub message_count: i64,
+    pub is_current_in_session: bool,
+}
+
+/// One persisted message reconstructed from the DB for replay into the
+/// LLM backend's in-memory conversation. Carries enough fields to
+/// faithfully reproduce both plain user/assistant rows AND
+/// assistant-with-tool-calls / tool-result rows.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HistoryRow {
+    pub conversation_id: i64,
+    pub seq: i64,
+    pub role: PersistedRole,
+    pub content: String,
+    /// JSON array of `{id, name, arguments}` when the row is an
+    /// assistant-with-tool-calls; `None` for plain rows.
+    pub tool_calls: Option<serde_json::Value>,
+    pub tool_call_id: Option<String>,
+    pub tool_name: Option<String>,
+}
+
+/// Result of [`ConversationStore::undo_last_turn`]. `removed_messages`
+/// is the count of `branch_messages` rows dropped from the branch (so
+/// the TUI can render "removed N entries" feedback). `last_user_text`
+/// echoes back the user prompt that was undone, used by callers that
+/// want to surface "undone: <text>".
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct UndoOutcome {
+    pub removed_messages: u32,
+    pub last_user_text: Option<String>,
+    pub removed_turn_id: Option<i64>,
+}
+
 /// Conversation persistence trait. Sibling to [`crate::MemoryStore`];
 /// implementations may share underlying storage (the SQLite impls
 /// below do — both hold an `Arc<SqliteHandle>`).
@@ -185,6 +237,101 @@ pub trait ConversationStore: Send + Sync + 'static {
     ) -> Result<i64>;
     async fn search(&self, query: &str, limit: usize) -> Result<Vec<SearchHit>>;
     async fn recent_turns(&self, limit: usize) -> Result<Vec<TurnSummary>>;
+
+    // --- Branch operations -------------------------------------------
+
+    /// Atomically begin a session and create its default `main` branch.
+    /// Returns both ids; the caller stores them in `AppState`. Replaces
+    /// the [`Self::begin_session`] call at daemon startup so a crash
+    /// between the two writes can't orphan a session without a branch.
+    async fn begin_session_with_main_branch(
+        &self,
+        daemon_pid: u32,
+    ) -> Result<(SessionId, BranchId)>;
+
+    /// Create a new branch in `session` with the given name. Used by
+    /// `begin_session_with_main_branch` internally and by direct
+    /// branch-creation paths during recovery / tests.
+    async fn create_branch(
+        &self,
+        session: &SessionId,
+        name: &str,
+        parent: Option<BranchId>,
+        fork_point_seq: Option<i64>,
+    ) -> Result<BranchId>;
+
+    /// Update `sessions.current_branch_id` to point at `branch`.
+    async fn set_current_branch(&self, session: &SessionId, branch: BranchId) -> Result<()>;
+
+    /// Read the current branch pointer for `session`, if any.
+    async fn get_current_branch(&self, session: &SessionId) -> Result<Option<BranchId>>;
+
+    /// Append `msg` to the conversations table AND to the
+    /// `branch_messages` join under `branch`. Atomic via a single
+    /// transaction. Returns the conversations.id rowid.
+    async fn append_message_to_branch(
+        &self,
+        session: &SessionId,
+        branch: BranchId,
+        turn: Option<TurnId>,
+        msg: PersistedMessage,
+    ) -> Result<i64>;
+
+    /// Enumerate every branch across every session. Sorted by
+    /// session.started_at DESC, then branches.id ASC. The caller
+    /// (handle_branches) re-orders so the active session shows first.
+    async fn list_branches(&self) -> Result<Vec<BranchInfo>>;
+
+    /// Look up a branch by name, optionally qualified by an 8-char
+    /// session id prefix. Returns the matching `(SessionId, BranchId)`
+    /// pair or `None` when no match exists. Ambiguous matches
+    /// (multiple branches with the same name across sessions) return
+    /// the first hit ordered by session.started_at DESC; callers can
+    /// detect ambiguity by passing the qualified form.
+    async fn resolve_branch(
+        &self,
+        target: &str,
+        prefer_session: Option<&SessionId>,
+    ) -> Result<Option<(SessionId, BranchId)>>;
+
+    /// Snapshot a branch by copying every `branch_messages` row from
+    /// `src` into a freshly-created branch named `new_name` with
+    /// `parent = src` and `fork_point_seq = max seq on src`. Returns
+    /// the new BranchId. Atomic in a single transaction.
+    async fn fork_branch(&self, src: BranchId, new_name: &str) -> Result<BranchId>;
+
+    /// Load every message row referenced by `branch`, ordered by
+    /// `branch_messages.seq`. Used by `/switch` and by daemon-startup
+    /// resume to repopulate the in-memory `Conversation`.
+    async fn load_branch_history(&self, branch: BranchId) -> Result<Vec<HistoryRow>>;
+
+    /// Drop the latest turn from `branch`. Implementation:
+    /// 1. find max(turn_id) for messages reachable from `branch`,
+    /// 2. delete the matching `branch_messages` rows for `branch`,
+    /// 3. orphan-sweep `conversations` rows now unreferenced by ANY
+    ///    `branch_messages`,
+    /// 4. delete the matching `turns` row when no other branch still
+    ///    references it.
+    /// Returns count + last user_text + the dropped turn id (when any).
+    async fn undo_last_turn(&self, branch: BranchId) -> Result<UndoOutcome>;
+
+    /// Find the most recent session with `ended_at IS NULL` whose
+    /// `daemon_pid` is no longer alive. The caller then resumes by
+    /// loading `current_branch_id`'s messages back into memory. Returns
+    /// `None` when nothing is resumable (first-ever startup, or the
+    /// only candidate is owned by a still-running daemon).
+    async fn find_resumable_session(&self) -> Result<Option<ResumeCandidate>>;
+}
+
+/// Candidate session returned by [`ConversationStore::find_resumable_session`].
+/// `daemon_pid` lets the caller decide whether the prior owner is still
+/// alive (`kill -0`) before claiming the session.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResumeCandidate {
+    pub session_id: SessionId,
+    pub current_branch_id: BranchId,
+    pub daemon_pid: u32,
+    pub started_at: String,
 }
 
 /// No-op fallback used when memory is disabled in config or in tests
@@ -218,6 +365,66 @@ impl ConversationStore for NoConversationStore {
     }
     async fn recent_turns(&self, _l: usize) -> Result<Vec<TurnSummary>> {
         Ok(Vec::new())
+    }
+
+    async fn begin_session_with_main_branch(&self, _pid: u32) -> Result<(SessionId, BranchId)> {
+        Ok((SessionId::new(), BranchId(0)))
+    }
+
+    async fn create_branch(
+        &self,
+        _s: &SessionId,
+        _name: &str,
+        _parent: Option<BranchId>,
+        _fp: Option<i64>,
+    ) -> Result<BranchId> {
+        Ok(BranchId(0))
+    }
+
+    async fn set_current_branch(&self, _s: &SessionId, _b: BranchId) -> Result<()> {
+        Ok(())
+    }
+
+    async fn get_current_branch(&self, _s: &SessionId) -> Result<Option<BranchId>> {
+        Ok(None)
+    }
+
+    async fn append_message_to_branch(
+        &self,
+        _s: &SessionId,
+        _b: BranchId,
+        _t: Option<TurnId>,
+        _m: PersistedMessage,
+    ) -> Result<i64> {
+        Ok(0)
+    }
+
+    async fn list_branches(&self) -> Result<Vec<BranchInfo>> {
+        Ok(Vec::new())
+    }
+
+    async fn resolve_branch(
+        &self,
+        _t: &str,
+        _p: Option<&SessionId>,
+    ) -> Result<Option<(SessionId, BranchId)>> {
+        Ok(None)
+    }
+
+    async fn fork_branch(&self, _src: BranchId, _name: &str) -> Result<BranchId> {
+        Ok(BranchId(0))
+    }
+
+    async fn load_branch_history(&self, _b: BranchId) -> Result<Vec<HistoryRow>> {
+        Ok(Vec::new())
+    }
+
+    async fn undo_last_turn(&self, _b: BranchId) -> Result<UndoOutcome> {
+        Ok(UndoOutcome::default())
+    }
+
+    async fn find_resumable_session(&self) -> Result<Option<ResumeCandidate>> {
+        Ok(None)
     }
 }
 
@@ -385,6 +592,302 @@ impl ConversationStore for SqliteConversationStore {
             .await
             .context("recent_turns")
     }
+
+    async fn begin_session_with_main_branch(
+        &self,
+        daemon_pid: u32,
+    ) -> Result<(SessionId, BranchId)> {
+        let id = SessionId::new();
+        let session_id = id.0.clone();
+        let branch = WriteCall::run(self.handle.writer(), |ack| {
+            WriteOp::BeginSessionWithMainBranch {
+                session_id,
+                daemon_pid,
+                ack,
+            }
+        })
+        .await?;
+        Ok((id, branch))
+    }
+
+    async fn create_branch(
+        &self,
+        session: &SessionId,
+        name: &str,
+        parent: Option<BranchId>,
+        fork_point_seq: Option<i64>,
+    ) -> Result<BranchId> {
+        let session_id = session.0.clone();
+        let name = name.to_string();
+        WriteCall::run(self.handle.writer(), |ack| WriteOp::CreateBranch {
+            session_id,
+            name,
+            parent_branch_id: parent,
+            fork_point_seq,
+            ack,
+        })
+        .await
+    }
+
+    async fn set_current_branch(&self, session: &SessionId, branch: BranchId) -> Result<()> {
+        let session_id = session.0.clone();
+        WriteCall::run(self.handle.writer(), |ack| WriteOp::SetCurrentBranch {
+            session_id,
+            branch_id: branch,
+            ack,
+        })
+        .await
+    }
+
+    async fn get_current_branch(&self, session: &SessionId) -> Result<Option<BranchId>> {
+        let session_id = session.0.clone();
+        let id: Option<i64> = self
+            .handle
+            .conn()
+            .call(move |c| {
+                Ok(c.query_row(
+                    "SELECT current_branch_id FROM sessions WHERE id = ?1",
+                    rusqlite::params![session_id],
+                    |r| r.get::<_, Option<i64>>(0),
+                )
+                .ok()
+                .flatten())
+            })
+            .await
+            .context("get_current_branch")?;
+        Ok(id.map(BranchId))
+    }
+
+    async fn append_message_to_branch(
+        &self,
+        session: &SessionId,
+        branch: BranchId,
+        turn: Option<TurnId>,
+        msg: PersistedMessage,
+    ) -> Result<i64> {
+        let session_id = session.0.clone();
+        WriteCall::run(self.handle.writer(), |ack| WriteOp::AppendMessageToBranch {
+            session_id,
+            branch_id: branch,
+            turn_id: turn,
+            msg,
+            ack,
+        })
+        .await
+    }
+
+    async fn list_branches(&self) -> Result<Vec<BranchInfo>> {
+        self.handle
+            .conn()
+            .call(|c| {
+                let sql = "
+                    SELECT  b.id,
+                            b.session_id,
+                            s.started_at,
+                            s.ended_at,
+                            b.name,
+                            b.parent_branch_id,
+                            (SELECT name FROM branches p WHERE p.id = b.parent_branch_id),
+                            b.fork_point_seq,
+                            b.created_at,
+                            (SELECT COUNT(*) FROM branch_messages bm WHERE bm.branch_id = b.id),
+                            (b.id = s.current_branch_id) AS is_current
+                    FROM branches b JOIN sessions s ON s.id = b.session_id
+                    ORDER BY s.started_at DESC, b.id ASC
+                ";
+                let mut stmt = c.prepare(sql)?;
+                let rows: Vec<BranchInfo> = stmt
+                    .query_map([], |row| {
+                        let parent_id: Option<i64> = row.get(5)?;
+                        let is_current: i64 = row.get(10)?;
+                        Ok(BranchInfo {
+                            branch_id: BranchId(row.get(0)?),
+                            session_id: row.get(1)?,
+                            session_started_at: row.get(2)?,
+                            session_ended_at: row.get(3)?,
+                            name: row.get(4)?,
+                            parent_branch_id: parent_id.map(BranchId),
+                            parent_branch_name: row.get(6)?,
+                            fork_point_seq: row.get(7)?,
+                            created_at: row.get(8)?,
+                            message_count: row.get(9)?,
+                            is_current_in_session: is_current != 0,
+                        })
+                    })?
+                    .collect::<std::result::Result<_, _>>()?;
+                Ok(rows)
+            })
+            .await
+            .context("list_branches")
+    }
+
+    async fn resolve_branch(
+        &self,
+        target: &str,
+        prefer_session: Option<&SessionId>,
+    ) -> Result<Option<(SessionId, BranchId)>> {
+        // Accept "session_prefix/name" (8-char hex prefix) or just
+        // "name". Bare name disambiguates by preferring the active
+        // session, then by most-recent session.
+        let (session_prefix, name) = match target.split_once('/') {
+            Some((p, n)) => (Some(p.to_string()), n.to_string()),
+            None => (None, target.to_string()),
+        };
+        let prefer_session = prefer_session.map(|s| s.0.clone());
+        let row: Option<(String, i64)> = self
+            .handle
+            .conn()
+            .call(move |c| {
+                if let Some(prefix) = session_prefix {
+                    let pattern = format!("{prefix}%");
+                    let row = c
+                        .query_row(
+                            "SELECT b.session_id, b.id
+                             FROM branches b JOIN sessions s ON s.id = b.session_id
+                             WHERE b.name = ?1 AND b.session_id LIKE ?2
+                             ORDER BY s.started_at DESC LIMIT 1",
+                            rusqlite::params![name, pattern],
+                            |r| Ok((r.get::<_, String>(0)?, r.get::<_, i64>(1)?)),
+                        )
+                        .ok();
+                    Ok(row)
+                } else if let Some(pref) = prefer_session {
+                    // Look first inside the preferred session, then fall
+                    // back to "any session, most-recent first".
+                    if let Ok(row) = c.query_row(
+                        "SELECT session_id, id FROM branches WHERE name = ?1 AND session_id = ?2",
+                        rusqlite::params![name, pref],
+                        |r| Ok((r.get::<_, String>(0)?, r.get::<_, i64>(1)?)),
+                    ) {
+                        return Ok(Some(row));
+                    }
+                    Ok(c.query_row(
+                        "SELECT b.session_id, b.id
+                         FROM branches b JOIN sessions s ON s.id = b.session_id
+                         WHERE b.name = ?1
+                         ORDER BY s.started_at DESC LIMIT 1",
+                        rusqlite::params![name],
+                        |r| Ok((r.get::<_, String>(0)?, r.get::<_, i64>(1)?)),
+                    )
+                    .ok())
+                } else {
+                    Ok(c.query_row(
+                        "SELECT b.session_id, b.id
+                         FROM branches b JOIN sessions s ON s.id = b.session_id
+                         WHERE b.name = ?1
+                         ORDER BY s.started_at DESC LIMIT 1",
+                        rusqlite::params![name],
+                        |r| Ok((r.get::<_, String>(0)?, r.get::<_, i64>(1)?)),
+                    )
+                    .ok())
+                }
+            })
+            .await
+            .context("resolve_branch")?;
+        Ok(row.map(|(s, b)| (SessionId(s), BranchId(b))))
+    }
+
+    async fn fork_branch(&self, src: BranchId, new_name: &str) -> Result<BranchId> {
+        let new_name = new_name.to_string();
+        WriteCall::run(self.handle.writer(), |ack| WriteOp::ForkBranch {
+            src_branch_id: src,
+            new_name,
+            ack,
+        })
+        .await
+    }
+
+    async fn load_branch_history(&self, branch: BranchId) -> Result<Vec<HistoryRow>> {
+        self.handle
+            .conn()
+            .call(move |c| {
+                let sql = "
+                    SELECT  c.id,
+                            bm.seq,
+                            c.role,
+                            c.content,
+                            c.tool_calls,
+                            c.tool_call_id,
+                            c.tool_name
+                    FROM branch_messages bm JOIN conversations c ON c.id = bm.conversation_id
+                    WHERE bm.branch_id = ?1
+                    ORDER BY bm.seq ASC
+                ";
+                let mut stmt = c.prepare(sql)?;
+                let rows = stmt
+                    .query_map(rusqlite::params![branch.0], |row| {
+                        let role_str: String = row.get(2)?;
+                        let tool_calls_str: Option<String> = row.get(4)?;
+                        let role = PersistedRole::parse(&role_str).ok_or_else(|| {
+                            rusqlite::Error::FromSqlConversionFailure(
+                                2,
+                                rusqlite::types::Type::Text,
+                                Box::new(std::io::Error::other(format!(
+                                    "unknown role in DB: {role_str}"
+                                ))),
+                            )
+                        })?;
+                        Ok(HistoryRow {
+                            conversation_id: row.get(0)?,
+                            seq: row.get(1)?,
+                            role,
+                            content: row.get(3)?,
+                            tool_calls: tool_calls_str.map(|s| {
+                                serde_json::from_str(&s).unwrap_or(serde_json::Value::Null)
+                            }),
+                            tool_call_id: row.get(5)?,
+                            tool_name: row.get(6)?,
+                        })
+                    })?
+                    .collect::<std::result::Result<Vec<_>, _>>()?;
+                Ok(rows)
+            })
+            .await
+            .context("load_branch_history")
+    }
+
+    async fn undo_last_turn(&self, branch: BranchId) -> Result<UndoOutcome> {
+        WriteCall::run(self.handle.writer(), |ack| WriteOp::UndoLastTurn {
+            branch_id: branch,
+            ack,
+        })
+        .await
+    }
+
+    async fn find_resumable_session(&self) -> Result<Option<ResumeCandidate>> {
+        self.handle
+            .conn()
+            .call(|c| {
+                let row = c
+                    .query_row(
+                        "SELECT id, current_branch_id, daemon_pid, started_at
+                         FROM sessions
+                         WHERE ended_at IS NULL AND current_branch_id IS NOT NULL
+                         ORDER BY started_at DESC LIMIT 1",
+                        [],
+                        |r| {
+                            Ok((
+                                r.get::<_, String>(0)?,
+                                r.get::<_, i64>(1)?,
+                                r.get::<_, u32>(2)?,
+                                r.get::<_, String>(3)?,
+                            ))
+                        },
+                    )
+                    .ok();
+                Ok(row)
+            })
+            .await
+            .context("find_resumable_session")
+            .map(|row| {
+                row.map(|(id, branch, pid, started)| ResumeCandidate {
+                    session_id: SessionId(id),
+                    current_branch_id: BranchId(branch),
+                    daemon_pid: pid,
+                    started_at: started,
+                })
+            })
+    }
 }
 
 // `WriteCall::run` returns an `oneshot::Receiver<Result<T>>` style
@@ -547,5 +1050,169 @@ mod tests {
         assert_eq!(fts5_literal("foo"), "\"foo\"");
         assert_eq!(fts5_literal("say \"hi\""), "\"say \"\"hi\"\"\"");
         assert_eq!(fts5_literal(""), "\"\"");
+    }
+
+    #[tokio::test]
+    async fn begin_session_with_main_branch_inserts_session_and_main_branch() {
+        let (store, _w) = fresh_store().await;
+        let (session, branch) = store.begin_session_with_main_branch(123).await.unwrap();
+        let current = store.get_current_branch(&session).await.unwrap();
+        assert_eq!(current, Some(branch));
+        let branches = store.list_branches().await.unwrap();
+        assert_eq!(branches.len(), 1);
+        assert_eq!(branches[0].name, "main");
+        assert!(branches[0].is_current_in_session);
+        assert_eq!(branches[0].parent_branch_id, None);
+        assert_eq!(branches[0].message_count, 0);
+    }
+
+    #[tokio::test]
+    async fn fork_creates_independent_branch_sharing_history() {
+        let (store, _w) = fresh_store().await;
+        let (session, main) = store.begin_session_with_main_branch(1).await.unwrap();
+        let turn = store.begin_turn(&session, "hello").await.unwrap();
+        store
+            .append_message_to_branch(&session, main, Some(turn), PersistedMessage::user("hello"))
+            .await
+            .unwrap();
+        store
+            .append_message_to_branch(
+                &session,
+                main,
+                Some(turn),
+                PersistedMessage::assistant_text("hi"),
+            )
+            .await
+            .unwrap();
+        store.end_turn(turn).await.unwrap();
+
+        let fork = store.fork_branch(main, "experiment").await.unwrap();
+        let main_history = store.load_branch_history(main).await.unwrap();
+        let fork_history = store.load_branch_history(fork).await.unwrap();
+        assert_eq!(main_history.len(), 2);
+        assert_eq!(fork_history.len(), 2);
+        // Same conversation rows are referenced — no row duplication.
+        assert_eq!(
+            main_history
+                .iter()
+                .map(|r| r.conversation_id)
+                .collect::<Vec<_>>(),
+            fork_history
+                .iter()
+                .map(|r| r.conversation_id)
+                .collect::<Vec<_>>()
+        );
+        let branches = store.list_branches().await.unwrap();
+        let fork_info = branches.iter().find(|b| b.name == "experiment").unwrap();
+        assert_eq!(fork_info.parent_branch_name.as_deref(), Some("main"));
+        assert_eq!(fork_info.fork_point_seq, Some(1));
+        assert_eq!(fork_info.message_count, 2);
+    }
+
+    #[tokio::test]
+    async fn append_to_one_branch_does_not_show_on_the_other() {
+        let (store, _w) = fresh_store().await;
+        let (session, main) = store.begin_session_with_main_branch(1).await.unwrap();
+        let turn = store.begin_turn(&session, "q").await.unwrap();
+        store
+            .append_message_to_branch(&session, main, Some(turn), PersistedMessage::user("q"))
+            .await
+            .unwrap();
+        let fork = store.fork_branch(main, "alt").await.unwrap();
+        // Append to fork only.
+        let alt_turn = store.begin_turn(&session, "alt q").await.unwrap();
+        store
+            .append_message_to_branch(
+                &session,
+                fork,
+                Some(alt_turn),
+                PersistedMessage::user("alt q"),
+            )
+            .await
+            .unwrap();
+        let main_history = store.load_branch_history(main).await.unwrap();
+        let fork_history = store.load_branch_history(fork).await.unwrap();
+        assert_eq!(main_history.len(), 1);
+        assert_eq!(fork_history.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn undo_removes_last_turn_from_branch_only() {
+        let (store, _w) = fresh_store().await;
+        let (session, main) = store.begin_session_with_main_branch(1).await.unwrap();
+        // Two turns: "first", "second".
+        let t1 = store.begin_turn(&session, "first").await.unwrap();
+        store
+            .append_message_to_branch(&session, main, Some(t1), PersistedMessage::user("first"))
+            .await
+            .unwrap();
+        store
+            .append_message_to_branch(
+                &session,
+                main,
+                Some(t1),
+                PersistedMessage::assistant_text("a"),
+            )
+            .await
+            .unwrap();
+        store.end_turn(t1).await.unwrap();
+
+        let t2 = store.begin_turn(&session, "second").await.unwrap();
+        store
+            .append_message_to_branch(&session, main, Some(t2), PersistedMessage::user("second"))
+            .await
+            .unwrap();
+        store
+            .append_message_to_branch(
+                &session,
+                main,
+                Some(t2),
+                PersistedMessage::assistant_text("b"),
+            )
+            .await
+            .unwrap();
+        store.end_turn(t2).await.unwrap();
+
+        let outcome = store.undo_last_turn(main).await.unwrap();
+        assert_eq!(outcome.removed_messages, 2);
+        assert_eq!(outcome.last_user_text.as_deref(), Some("second"));
+
+        let history = store.load_branch_history(main).await.unwrap();
+        assert_eq!(history.len(), 2);
+        assert_eq!(history[0].content, "first");
+        assert_eq!(history[1].content, "a");
+    }
+
+    #[tokio::test]
+    async fn resolve_branch_qualified_form() {
+        let (store, _w) = fresh_store().await;
+        let (s1, _) = store.begin_session_with_main_branch(1).await.unwrap();
+        let (s2, _) = store.begin_session_with_main_branch(2).await.unwrap();
+        // Two sessions, both with a "main" branch.
+        let bare = store.resolve_branch("main", Some(&s1)).await.unwrap();
+        assert!(bare.is_some());
+        assert_eq!(bare.unwrap().0, s1);
+        let prefix = &s2.0[..8];
+        let qualified = store
+            .resolve_branch(&format!("{prefix}/main"), None)
+            .await
+            .unwrap();
+        assert!(qualified.is_some());
+        assert_eq!(qualified.unwrap().0, s2);
+    }
+
+    #[tokio::test]
+    async fn find_resumable_session_returns_unended() {
+        let (store, _w) = fresh_store().await;
+        let (s, _) = store.begin_session_with_main_branch(99).await.unwrap();
+        let resume = store.find_resumable_session().await.unwrap();
+        assert!(resume.is_some());
+        let cand = resume.unwrap();
+        assert_eq!(cand.session_id, s);
+        assert_eq!(cand.daemon_pid, 99);
+        store.end_session(&s).await.unwrap();
+        // Once ended, no longer resumable.
+        let resume2 = store.find_resumable_session().await.unwrap();
+        assert!(resume2.is_none());
     }
 }

--- a/crates/assistd-memory/src/sqlite/mod.rs
+++ b/crates/assistd-memory/src/sqlite/mod.rs
@@ -22,8 +22,9 @@ pub mod writer;
 
 pub use connection::SqliteHandle;
 pub use conversations::{
-    ConversationStore, NoConversationStore, PersistedMessage, PersistedRole, SearchHit, SessionId,
-    SqliteConversationStore, TurnId, TurnSummary,
+    BranchId, BranchInfo, ConversationStore, HistoryRow, NoConversationStore, PersistedMessage,
+    PersistedRole, ResumeCandidate, SearchHit, SessionId, SqliteConversationStore, TurnId,
+    TurnSummary, UndoOutcome,
 };
 pub use embeddings::{
     EmbeddingHit, MemoryHit, NoSemanticStore, SemanticStore, SqliteSemanticStore, vector_to_blob,

--- a/crates/assistd-memory/src/sqlite/writer.rs
+++ b/crates/assistd-memory/src/sqlite/writer.rs
@@ -22,7 +22,7 @@ use tokio::sync::{mpsc, oneshot, watch};
 use tokio::task::JoinHandle;
 use tokio_rusqlite::Connection;
 
-use super::conversations::{PersistedMessage, PersistedRole, TurnId};
+use super::conversations::{BranchId, PersistedMessage, PersistedRole, TurnId, UndoOutcome};
 
 /// Typed write operations. Each carries a `oneshot` ack so callers can
 /// either await the result (CLI / IPC handlers) or fire-and-forget plus
@@ -112,6 +112,56 @@ pub enum WriteOp {
     DeleteChunksForConversation {
         conversation_id: i64,
         ack: oneshot::Sender<Result<()>>,
+    },
+    /// Atomically begin a session and create its default `main` branch
+    /// in one transaction. Used at daemon startup; replaces the
+    /// previously-discrete `BeginSession` write op so a crash between
+    /// the two writes can't orphan a session without a branch.
+    BeginSessionWithMainBranch {
+        session_id: String,
+        daemon_pid: u32,
+        ack: oneshot::Sender<Result<BranchId>>,
+    },
+    /// Insert one row into `branches`. Returns the new BranchId.
+    CreateBranch {
+        session_id: String,
+        name: String,
+        parent_branch_id: Option<BranchId>,
+        fork_point_seq: Option<i64>,
+        ack: oneshot::Sender<Result<BranchId>>,
+    },
+    /// Update `sessions.current_branch_id`.
+    SetCurrentBranch {
+        session_id: String,
+        branch_id: BranchId,
+        ack: oneshot::Sender<Result<()>>,
+    },
+    /// Append `msg` and reference it from `branch_messages`. The writer
+    /// runs both inserts in a single transaction so reads cannot observe
+    /// an intermediate state where a `conversations` row has no
+    /// matching `branch_messages` entry.
+    AppendMessageToBranch {
+        session_id: String,
+        branch_id: BranchId,
+        turn_id: Option<TurnId>,
+        msg: PersistedMessage,
+        ack: oneshot::Sender<Result<i64>>,
+    },
+    /// Snapshot a branch: insert a new `branches` row and copy every
+    /// `branch_messages` row from `src` into the new branch, preserving
+    /// seq. Returns the new BranchId.
+    ForkBranch {
+        src_branch_id: BranchId,
+        new_name: String,
+        ack: oneshot::Sender<Result<BranchId>>,
+    },
+    /// Drop the most recent turn from `branch`: delete its
+    /// `branch_messages` rows, sweep newly-orphaned `conversations`
+    /// rows, drop the `turns` row when no other branch still references
+    /// it. Returns counts so the IPC layer can echo the outcome.
+    UndoLastTurn {
+        branch_id: BranchId,
+        ack: oneshot::Sender<Result<UndoOutcome>>,
     },
 }
 
@@ -262,6 +312,54 @@ async fn handle_op(conn: &Connection, op: WriteOp) {
             ack,
         } => {
             let res = delete_chunks_for_conversation(conn, conversation_id).await;
+            let _ = ack.send(res);
+        }
+        WriteOp::BeginSessionWithMainBranch {
+            session_id,
+            daemon_pid,
+            ack,
+        } => {
+            let res = begin_session_with_main_branch(conn, session_id, daemon_pid).await;
+            let _ = ack.send(res);
+        }
+        WriteOp::CreateBranch {
+            session_id,
+            name,
+            parent_branch_id,
+            fork_point_seq,
+            ack,
+        } => {
+            let res = create_branch(conn, session_id, name, parent_branch_id, fork_point_seq).await;
+            let _ = ack.send(res);
+        }
+        WriteOp::SetCurrentBranch {
+            session_id,
+            branch_id,
+            ack,
+        } => {
+            let res = set_current_branch(conn, session_id, branch_id).await;
+            let _ = ack.send(res);
+        }
+        WriteOp::AppendMessageToBranch {
+            session_id,
+            branch_id,
+            turn_id,
+            msg,
+            ack,
+        } => {
+            let res = append_message_to_branch(conn, session_id, branch_id, turn_id, msg).await;
+            let _ = ack.send(res);
+        }
+        WriteOp::ForkBranch {
+            src_branch_id,
+            new_name,
+            ack,
+        } => {
+            let res = fork_branch(conn, src_branch_id, new_name).await;
+            let _ = ack.send(res);
+        }
+        WriteOp::UndoLastTurn { branch_id, ack } => {
+            let res = undo_last_turn(conn, branch_id).await;
             let _ = ack.send(res);
         }
     }
@@ -533,6 +631,282 @@ async fn delete_chunks_for_conversation(conn: &Connection, conversation_id: i64)
     })
     .await
     .context("delete_chunks_for_conversation")
+}
+
+async fn begin_session_with_main_branch(
+    conn: &Connection,
+    id: String,
+    pid: u32,
+) -> Result<BranchId> {
+    let started = Utc::now().to_rfc3339();
+    let created = started.clone();
+    let branch_rowid = conn
+        .call(move |c| {
+            // One transaction so a crash midway can't leave a session
+            // without its main branch (the daemon-startup code reads
+            // current_branch_id and panics on NULL otherwise).
+            let tx = c.transaction()?;
+            tx.execute(
+                "INSERT INTO sessions (id, started_at, daemon_pid) VALUES (?1, ?2, ?3)",
+                rusqlite::params![id, started, pid],
+            )?;
+            tx.execute(
+                "INSERT INTO branches (session_id, name, parent_branch_id, fork_point_seq, created_at)
+                 VALUES (?1, 'main', NULL, NULL, ?2)",
+                rusqlite::params![id, created],
+            )?;
+            let branch_id = tx.last_insert_rowid();
+            tx.execute(
+                "UPDATE sessions SET current_branch_id = ?1 WHERE id = ?2",
+                rusqlite::params![branch_id, id],
+            )?;
+            tx.commit()?;
+            Ok(branch_id)
+        })
+        .await
+        .context("begin_session_with_main_branch")?;
+    Ok(BranchId(branch_rowid))
+}
+
+async fn create_branch(
+    conn: &Connection,
+    session_id: String,
+    name: String,
+    parent: Option<BranchId>,
+    fork_point_seq: Option<i64>,
+) -> Result<BranchId> {
+    let created = Utc::now().to_rfc3339();
+    let parent_id = parent.map(|b| b.0);
+    let id = conn
+        .call(move |c| {
+            c.execute(
+                "INSERT INTO branches (session_id, name, parent_branch_id, fork_point_seq, created_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5)",
+                rusqlite::params![session_id, name, parent_id, fork_point_seq, created],
+            )?;
+            Ok(c.last_insert_rowid())
+        })
+        .await
+        .context("create_branch")?;
+    Ok(BranchId(id))
+}
+
+async fn set_current_branch(
+    conn: &Connection,
+    session_id: String,
+    branch_id: BranchId,
+) -> Result<()> {
+    conn.call(move |c| {
+        c.execute(
+            "UPDATE sessions SET current_branch_id = ?1 WHERE id = ?2",
+            rusqlite::params![branch_id.0, session_id],
+        )?;
+        Ok(())
+    })
+    .await
+    .context("set_current_branch")
+}
+
+async fn append_message_to_branch(
+    conn: &Connection,
+    session: String,
+    branch_id: BranchId,
+    turn: Option<TurnId>,
+    msg: PersistedMessage,
+) -> Result<i64> {
+    let timestamp = Utc::now().to_rfc3339();
+    let role = msg.role.as_wire().to_string();
+    let tool_calls_json = match msg.tool_calls {
+        Some(v) => Some(serde_json::to_string(&v).context("serialize tool_calls")?),
+        None => None,
+    };
+    let turn_id = turn.map(|t| t.0);
+    let id = conn
+        .call(move |c| {
+            // Insert the conversations row, the branch_messages row,
+            // and assign a branch-local seq atomically. The session-wide
+            // `conversations.seq` keeps its previous "max+1 over the
+            // session" semantics so FTS5 ranking is unchanged.
+            let tx = c.transaction()?;
+            let seq: i64 = tx.query_row(
+                "SELECT COALESCE(MAX(seq), -1) + 1 FROM conversations WHERE session_id = ?1",
+                rusqlite::params![session],
+                |r| r.get(0),
+            )?;
+            tx.execute(
+                "INSERT INTO conversations
+                    (session_id, turn_id, seq, timestamp, role, content, tool_calls, tool_call_id, tool_name)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+                rusqlite::params![
+                    session,
+                    turn_id,
+                    seq,
+                    timestamp,
+                    role,
+                    msg.content,
+                    tool_calls_json,
+                    msg.tool_call_id,
+                    msg.tool_name,
+                ],
+            )?;
+            let conv_id = tx.last_insert_rowid();
+            let branch_seq: i64 = tx.query_row(
+                "SELECT COALESCE(MAX(seq), -1) + 1 FROM branch_messages WHERE branch_id = ?1",
+                rusqlite::params![branch_id.0],
+                |r| r.get(0),
+            )?;
+            tx.execute(
+                "INSERT INTO branch_messages (branch_id, seq, conversation_id) VALUES (?1, ?2, ?3)",
+                rusqlite::params![branch_id.0, branch_seq, conv_id],
+            )?;
+            tx.commit()?;
+            Ok(conv_id)
+        })
+        .await
+        .context("append_message_to_branch")?;
+    Ok(id)
+}
+
+async fn fork_branch(conn: &Connection, src: BranchId, new_name: String) -> Result<BranchId> {
+    let created = Utc::now().to_rfc3339();
+    let id = conn
+        .call(move |c| {
+            let tx = c.transaction()?;
+            // Pull the source branch's session id and its tail seq —
+            // both go onto the new branches row.
+            let session_id: String = tx.query_row(
+                "SELECT session_id FROM branches WHERE id = ?1",
+                rusqlite::params![src.0],
+                |r| r.get(0),
+            )?;
+            let fork_point_seq: Option<i64> = tx
+                .query_row(
+                    "SELECT MAX(seq) FROM branch_messages WHERE branch_id = ?1",
+                    rusqlite::params![src.0],
+                    |r| r.get(0),
+                )
+                .ok();
+            tx.execute(
+                "INSERT INTO branches (session_id, name, parent_branch_id, fork_point_seq, created_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5)",
+                rusqlite::params![session_id, new_name, src.0, fork_point_seq, created],
+            )?;
+            let new_branch_id = tx.last_insert_rowid();
+            // Copy every join-table row, preserving the branch-local seq.
+            // The `conversations` rows themselves are NOT duplicated — both
+            // branches reference the same row ids.
+            tx.execute(
+                "INSERT INTO branch_messages (branch_id, seq, conversation_id)
+                 SELECT ?1, seq, conversation_id
+                 FROM branch_messages WHERE branch_id = ?2",
+                rusqlite::params![new_branch_id, src.0],
+            )?;
+            tx.commit()?;
+            Ok(new_branch_id)
+        })
+        .await
+        .context("fork_branch")?;
+    Ok(BranchId(id))
+}
+
+async fn undo_last_turn(conn: &Connection, branch: BranchId) -> Result<UndoOutcome> {
+    conn.call(move |c| {
+        let tx = c.transaction()?;
+        // Find the latest turn_id reachable through this branch. If
+        // every reachable message has NULL turn_id (e.g. system-only
+        // history), there is nothing to undo.
+        let last_turn: Option<i64> = tx
+            .query_row(
+                "SELECT MAX(c.turn_id)
+                 FROM branch_messages bm JOIN conversations c ON c.id = bm.conversation_id
+                 WHERE bm.branch_id = ?1 AND c.turn_id IS NOT NULL",
+                rusqlite::params![branch.0],
+                |r| r.get::<_, Option<i64>>(0),
+            )
+            .ok()
+            .flatten();
+        let Some(turn_id) = last_turn else {
+            tx.commit()?;
+            return Ok(UndoOutcome::default());
+        };
+        // Snapshot the user_text for echo before the row goes away.
+        let last_user_text: Option<String> = tx
+            .query_row(
+                "SELECT user_text FROM turns WHERE id = ?1",
+                rusqlite::params![turn_id],
+                |r| r.get(0),
+            )
+            .ok();
+
+        // Conversations rows reachable from this branch tagged with
+        // the doomed turn_id. Capture before we delete the
+        // branch_messages rows so we know which conversations rows
+        // become orphan candidates.
+        let target_conv_ids: Vec<i64> = {
+            let mut stmt = tx.prepare(
+                "SELECT bm.conversation_id
+                 FROM branch_messages bm JOIN conversations c ON c.id = bm.conversation_id
+                 WHERE bm.branch_id = ?1 AND c.turn_id = ?2",
+            )?;
+            let rows: Vec<i64> = stmt
+                .query_map(rusqlite::params![branch.0, turn_id], |r| r.get(0))?
+                .collect::<std::result::Result<_, _>>()?;
+            rows
+        };
+
+        // Drop the join-table rows from this branch.
+        let removed: usize = tx.execute(
+            "DELETE FROM branch_messages
+             WHERE branch_id = ?1
+               AND conversation_id IN (
+                   SELECT id FROM conversations WHERE turn_id = ?2
+               )",
+            rusqlite::params![branch.0, turn_id],
+        )?;
+
+        // Sweep any conversations rows now without ANY remaining
+        // branch_messages references. The FK from
+        // `conversation_chunks` cascades, which cascades to
+        // `embeddings`, so semantic-search hits also get cleaned up.
+        for cid in &target_conv_ids {
+            let still_referenced: i64 = tx.query_row(
+                "SELECT COUNT(*) FROM branch_messages WHERE conversation_id = ?1",
+                rusqlite::params![cid],
+                |r| r.get(0),
+            )?;
+            if still_referenced == 0 {
+                tx.execute(
+                    "DELETE FROM conversations WHERE id = ?1",
+                    rusqlite::params![cid],
+                )?;
+            }
+        }
+
+        // Drop the turns row when no surviving conversations row points
+        // at it. Could happen if the user undid on a forked branch and
+        // the parent branch already preserved that turn — leave the
+        // turns row in place in that case.
+        let turn_still_used: i64 = tx.query_row(
+            "SELECT COUNT(*) FROM conversations WHERE turn_id = ?1",
+            rusqlite::params![turn_id],
+            |r| r.get(0),
+        )?;
+        if turn_still_used == 0 {
+            tx.execute(
+                "DELETE FROM turns WHERE id = ?1",
+                rusqlite::params![turn_id],
+            )?;
+        }
+
+        tx.commit()?;
+        Ok(UndoOutcome {
+            removed_messages: removed as u32,
+            last_user_text,
+            removed_turn_id: Some(turn_id),
+        })
+    })
+    .await
+    .context("undo_last_turn")
 }
 
 /// Re-export the role wire mapping used by [`append_message`] so callers

--- a/crates/assistd/src/chat/app.rs
+++ b/crates/assistd/src/chat/app.rs
@@ -172,7 +172,38 @@ pub struct App {
     /// `Request::ConfirmResponse` for the writer task to forward.
     /// `None` between queries.
     active_writer: Option<mpsc::Sender<Request>>,
+    /// Tracks an in-flight branch command so [`Self::on_wire_event`]
+    /// can route `BranchInfo` / `BranchSwitched` / `HistoryEntry` /
+    /// `UndoApplied` events into the right rendering path. Cleared on
+    /// terminal `Done` / `Error`.
+    in_flight_branch_op: Option<BranchOp>,
+    /// Buffer for `/branches` rows accumulated until the terminal
+    /// `Done` so the table renders as one cohesive block.
+    branches_buffer: Vec<BranchListEntry>,
     chat_tx: mpsc::Sender<ChatEvent>,
+}
+
+/// Which branch slash-command is currently in flight, if any. Used to
+/// distinguish `Event::BranchSwitched` arriving from `/fork` (no chat
+/// repaint) from one arriving from `/switch` (clear + replay).
+#[derive(Debug, Clone, Copy)]
+enum BranchOp {
+    Fork,
+    Branches,
+    Switch,
+    Undo,
+}
+
+/// One row buffered during a `/branches` listing.
+#[derive(Debug, Clone)]
+struct BranchListEntry {
+    name: String,
+    parent_branch_name: Option<String>,
+    fork_point_seq: Option<i64>,
+    message_count: i64,
+    is_current_in_session: bool,
+    is_active_session: bool,
+    session_short: String,
 }
 
 impl App {
@@ -208,6 +239,8 @@ impl App {
             picker,
             ipc,
             active_writer: None,
+            in_flight_branch_op: None,
+            branches_buffer: Vec::new(),
             chat_tx,
         }
     }
@@ -560,11 +593,118 @@ impl App {
                     self.output.push_info(&format!("[{component}: {message}]"));
                 }
             }
+            Event::BranchInfo {
+                name,
+                parent_branch_name,
+                fork_point_seq,
+                message_count,
+                is_current_in_session,
+                is_active_session,
+                session_id,
+                ..
+            } => {
+                let session_short = session_id.chars().take(8).collect::<String>();
+                self.branches_buffer.push(BranchListEntry {
+                    name,
+                    parent_branch_name,
+                    fork_point_seq,
+                    message_count,
+                    is_current_in_session,
+                    is_active_session,
+                    session_short,
+                });
+            }
+            Event::BranchSwitched {
+                name,
+                parent_branch_name,
+                fork_point_seq,
+                ..
+            } => match self.in_flight_branch_op {
+                Some(BranchOp::Switch) => {
+                    // Wipe the chat pane; HistoryEntry events follow,
+                    // each pushed into the now-empty pane to repaint
+                    // the loaded branch.
+                    self.output.clear();
+                    self.output
+                        .push_info(&format!("[switched to branch '{name}']"));
+                }
+                _ => {
+                    let detail = match (parent_branch_name.as_deref(), fork_point_seq) {
+                        (Some(p), Some(seq)) => {
+                            format!("[forked from '{p}'@seq{seq} into '{name}']")
+                        }
+                        _ => format!("[branch '{name}' is now active]"),
+                    };
+                    self.output.push_info(&detail);
+                }
+            },
+            Event::HistoryEntry {
+                role,
+                content,
+                tool_name,
+                ..
+            } => {
+                // Render replayed history into the output pane. We
+                // intentionally re-use push_user / append_assistant so
+                // styling matches a live conversation. System messages
+                // (e.g. summarized history) render as info lines so
+                // they're visually distinct from the prompt/reply pair.
+                match role.as_str() {
+                    "user" => {
+                        // Tool-result rows are persisted as role=tool,
+                        // not role=user, so anything we see here is a
+                        // genuine user prompt.
+                        self.output.push_user(&content);
+                    }
+                    "assistant" => {
+                        if !content.is_empty() {
+                            self.output.begin_assistant();
+                            self.output.append_assistant(&content);
+                            self.output.finish_assistant();
+                        }
+                    }
+                    "tool" => {
+                        let name = tool_name.unwrap_or_default();
+                        // Render tool-result rows as a collapsed tool
+                        // block with placeholder timing — we don't have
+                        // the original duration on replay.
+                        self.output.push_tool_block(name, content, 0, 0);
+                    }
+                    "system" => {
+                        self.output.push_info(&content);
+                    }
+                    _ => self.output.push_info(&content),
+                }
+            }
+            Event::UndoApplied {
+                removed_messages,
+                last_user_text,
+                ..
+            } => {
+                if removed_messages == 0 {
+                    self.set_notice("nothing to undo");
+                } else {
+                    self.output.pop_last_user_exchange();
+                    let preview = last_user_text
+                        .as_deref()
+                        .map(|t| t.chars().take(48).collect::<String>())
+                        .unwrap_or_default();
+                    if preview.is_empty() {
+                        self.set_notice(&format!("undid {removed_messages} message(s)"));
+                    } else {
+                        self.set_notice(&format!("undid: {preview}"));
+                    }
+                }
+            }
             Event::Done { .. } => {
                 self.throughput.on_done(now);
                 self.output.finish_assistant();
                 self.generating = false;
                 self.active_writer = None;
+                if matches!(self.in_flight_branch_op, Some(BranchOp::Branches)) {
+                    self.render_branches_buffer();
+                }
+                self.in_flight_branch_op = None;
             }
             Event::Error { message, .. } => {
                 self.throughput.on_done(now);
@@ -572,6 +712,8 @@ impl App {
                 self.output.push_error(&message);
                 self.generating = false;
                 self.active_writer = None;
+                self.in_flight_branch_op = None;
+                self.branches_buffer.clear();
             }
             // Memory* events shouldn't appear on a query/PTT stream —
             // the daemon only emits them on `Request::Memory*`.
@@ -581,6 +723,45 @@ impl App {
             | Event::MemoryRow { .. }
             | Event::MemoryForgetResult { .. }
             | Event::ReindexProgress { .. } => {}
+        }
+    }
+
+    /// Flush the buffered `/branches` listing into the chat pane as a
+    /// table-ish block. Active session branches render first (already
+    /// sorted by the daemon), each line shows current marker + name +
+    /// parent + msg count.
+    fn render_branches_buffer(&mut self) {
+        if self.branches_buffer.is_empty() {
+            self.output.push_info("[no branches]");
+            return;
+        }
+        let entries = std::mem::take(&mut self.branches_buffer);
+        let mut last_session: Option<String> = None;
+        for entry in entries {
+            if last_session.as_deref() != Some(entry.session_short.as_str()) {
+                let header = if entry.is_active_session {
+                    format!("[session {} (active)]", entry.session_short)
+                } else {
+                    format!("[session {}]", entry.session_short)
+                };
+                self.output.push_info(&header);
+                last_session = Some(entry.session_short.clone());
+            }
+            let star = if entry.is_current_in_session {
+                "* "
+            } else {
+                "  "
+            };
+            let parent = match (entry.parent_branch_name.as_deref(), entry.fork_point_seq) {
+                (Some(p), Some(seq)) => format!(" (from '{p}'@seq{seq})"),
+                (Some(p), None) => format!(" (from '{p}')"),
+                _ => String::new(),
+            };
+            let msgs = entry.message_count;
+            self.output.push_info(&format!(
+                "  {star}{name}{parent}  [{msgs} msg]",
+                name = entry.name
+            ));
         }
     }
 
@@ -691,6 +872,22 @@ impl App {
             self.set_notice("/attach: missing path");
             return;
         }
+        if let Some(name) = parse_slash_arg(&text, "/fork") {
+            self.handle_fork_cmd(name.to_string());
+            return;
+        }
+        if text.trim() == "/branches" {
+            self.handle_branches_cmd();
+            return;
+        }
+        if let Some(target) = parse_slash_arg(&text, "/switch") {
+            self.handle_switch_cmd(target.to_string());
+            return;
+        }
+        if text.trim() == "/undo" {
+            self.handle_undo_cmd();
+            return;
+        }
         if self.generating {
             self.set_notice("still generating — please wait");
             return;
@@ -786,6 +983,104 @@ impl App {
                 }
             }
         });
+    }
+
+    /// Spawn a one-shot daemon connection for a branch command and
+    /// pump its streaming events onto `chat_tx::Wire`. The TUI's
+    /// `on_wire_event` then routes by `in_flight_branch_op` to the
+    /// right rendering path. Single-flight: rejects when one branch
+    /// command (or a generation) is already in flight.
+    fn spawn_branch_command(&mut self, op: BranchOp, req: Request) {
+        if self.in_flight_branch_op.is_some() {
+            self.set_notice("branch command in flight — please wait");
+            return;
+        }
+        if self.generating {
+            self.set_notice("still generating — please wait");
+            return;
+        }
+        self.in_flight_branch_op = Some(op);
+        self.branches_buffer.clear();
+        let ipc = self.ipc.clone();
+        let chat_tx = self.chat_tx.clone();
+        tokio::spawn(async move {
+            let mut stream = match ipc.one_shot(req).await {
+                Ok(s) => s,
+                Err(e) => {
+                    let _ = chat_tx
+                        .send(ChatEvent::WireError(format!("branch connect: {e}")))
+                        .await;
+                    return;
+                }
+            };
+            loop {
+                match stream.next_event().await {
+                    Ok(Some(ev)) => {
+                        let terminal = ev.is_terminal();
+                        let _ = chat_tx.send(ChatEvent::Wire(ev)).await;
+                        if terminal {
+                            return;
+                        }
+                    }
+                    Ok(None) => {
+                        let _ = chat_tx
+                            .send(ChatEvent::WireError(
+                                "daemon closed branch stream mid-flight".into(),
+                            ))
+                            .await;
+                        return;
+                    }
+                    Err(e) => {
+                        let _ = chat_tx
+                            .send(ChatEvent::WireError(format!("branch read: {e}")))
+                            .await;
+                        return;
+                    }
+                }
+            }
+        });
+    }
+
+    fn handle_fork_cmd(&mut self, name: String) {
+        if name.trim().is_empty() {
+            self.output
+                .push_error("/fork: expected a name. Usage: /fork <name>");
+            self.set_notice("/fork: missing name");
+            return;
+        }
+        let req = Request::Fork {
+            id: Uuid::new_v4().to_string(),
+            name,
+        };
+        self.spawn_branch_command(BranchOp::Fork, req);
+    }
+
+    fn handle_branches_cmd(&mut self) {
+        let req = Request::Branches {
+            id: Uuid::new_v4().to_string(),
+        };
+        self.spawn_branch_command(BranchOp::Branches, req);
+    }
+
+    fn handle_switch_cmd(&mut self, target: String) {
+        if target.trim().is_empty() {
+            self.output
+                .push_error("/switch: expected a target. Usage: /switch <name>");
+            self.set_notice("/switch: missing target");
+            return;
+        }
+        let req = Request::Switch {
+            id: Uuid::new_v4().to_string(),
+            target,
+        };
+        self.spawn_branch_command(BranchOp::Switch, req);
+    }
+
+    fn handle_undo_cmd(&mut self) {
+        let req = Request::Undo {
+            id: Uuid::new_v4().to_string(),
+        };
+        self.spawn_branch_command(BranchOp::Undo, req);
     }
 
     /// Open a daemon dialog connection for a Query and pump its
@@ -892,6 +1187,20 @@ impl App {
             }
         });
     }
+}
+
+/// Parse a slash command of the shape `/<verb> <arg…>`. Returns
+/// `Some(arg)` when `text` starts with `<verb> ` (note the trailing
+/// space), `None` otherwise. Trailing whitespace is trimmed; the
+/// `text == verb` form returns `Some("")` so callers can distinguish
+/// "no argument" from "not this verb".
+fn parse_slash_arg<'a>(text: &'a str, verb: &str) -> Option<&'a str> {
+    let trimmed = text.trim_end();
+    if trimmed == verb {
+        return Some("");
+    }
+    let prefix = format!("{verb} ");
+    trimmed.strip_prefix(&prefix).map(|rest| rest.trim())
 }
 
 fn expand_tilde(p: &str) -> PathBuf {

--- a/crates/assistd/src/chat/output.rs
+++ b/crates/assistd/src/chat/output.rs
@@ -210,6 +210,43 @@ impl OutputPane {
         false
     }
 
+    /// Wipe every visible item. Used by `/switch` before replaying the
+    /// target branch's history and by `/clear`-style commands. Resets
+    /// the scroll offset so the next content lands at the top.
+    pub fn clear(&mut self) {
+        self.items.clear();
+        self.open_assistant = None;
+        self.scroll_offset = 0;
+        self.dirty = true;
+    }
+
+    /// Drop the trailing items belonging to the last user-prompt-and-reply
+    /// exchange. Walks backward through `items`, dropping the trailing
+    /// blank-separator line and every item until (and including) the
+    /// most recent user prompt (a `Text(Line)` whose first span content
+    /// starts with `"> "`). Returns the count of items removed; 0 when
+    /// there is no user prompt to undo.
+    pub fn pop_last_user_exchange(&mut self) -> usize {
+        let mut idx = self.items.len();
+        while idx > 0 {
+            idx -= 1;
+            if let OutputItem::Text(line) = &self.items[idx]
+                && line
+                    .spans
+                    .first()
+                    .map(|s| s.content.starts_with("> "))
+                    .unwrap_or(false)
+            {
+                let removed = self.items.len() - idx;
+                self.items.truncate(idx);
+                self.open_assistant = None;
+                self.dirty = true;
+                return removed;
+            }
+        }
+        0
+    }
+
     pub fn scroll_page_up(&mut self, viewport_height: u16) {
         let step = (viewport_height / 2).max(1);
         self.scroll_offset = self.scroll_offset.saturating_add(step);

--- a/crates/assistd/src/daemon.rs
+++ b/crates/assistd/src/daemon.rs
@@ -335,6 +335,8 @@ pub async fn run(args: DaemonArgs) -> Result<()> {
         conversation_store,
         memory_writer_handle,
         session_id_for_state,
+        branch_id_for_state,
+        resumed_history,
         sqlite_handle,
     ) = if config.memory.enabled {
         let db_path = std::path::PathBuf::from(&config.memory.db_path);
@@ -343,25 +345,83 @@ pub async fn run(args: DaemonArgs) -> Result<()> {
                 let handle = Arc::new(handle);
                 let conv_store = Arc::new(SqliteConversationStore::new(handle.clone()));
                 let mem_store = Arc::new(SqliteMemoryStore::new(handle.clone()));
-                let session = match conv_store.begin_session(std::process::id()).await {
-                    Ok(s) => Arc::new(s),
+                // Try to resume the most recent unended session whose
+                // prior daemon is no longer alive (`kill -0` returns
+                // ESRCH). On success we reuse session_id + branch_id
+                // and replay the active branch's messages back into
+                // the chat backend; on miss / liveness conflict we
+                // start fresh.
+                let mut resumed_history: Vec<assistd_memory::HistoryRow> = Vec::new();
+                let (session, branch) = match conv_store.find_resumable_session().await {
+                    Ok(Some(cand)) if !pid_is_alive(cand.daemon_pid) => {
+                        info!(
+                            "memory: resuming prior session {} (branch={})",
+                            cand.session_id, cand.current_branch_id.0
+                        );
+                        match conv_store.load_branch_history(cand.current_branch_id).await {
+                            Ok(rows) => {
+                                resumed_history = rows;
+                            }
+                            Err(e) => tracing::warn!(
+                                "memory: load_branch_history failed for resume ({e:#})"
+                            ),
+                        }
+                        (Arc::new(cand.session_id), cand.current_branch_id)
+                    }
+                    Ok(_) => {
+                        match conv_store
+                            .begin_session_with_main_branch(std::process::id())
+                            .await
+                        {
+                            Ok((s, b)) => {
+                                info!(
+                                    "memory: SQLite ready at {} (session={}, branch={})",
+                                    db_path.display(),
+                                    s,
+                                    b.0
+                                );
+                                (Arc::new(s), b)
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    "memory: begin_session_with_main_branch failed: {e:#}; \
+                                     continuing without session row"
+                                );
+                                (
+                                    Arc::new(assistd_memory::SessionId::new()),
+                                    assistd_memory::BranchId(0),
+                                )
+                            }
+                        }
+                    }
                     Err(e) => {
                         tracing::warn!(
-                            "memory: begin_session failed: {e:#}; continuing without session row"
+                            "memory: find_resumable_session failed: {e:#}; starting fresh"
                         );
-                        Arc::new(assistd_memory::SessionId::new())
+                        match conv_store
+                            .begin_session_with_main_branch(std::process::id())
+                            .await
+                        {
+                            Ok((s, b)) => (Arc::new(s), b),
+                            Err(e) => {
+                                tracing::warn!(
+                                    "memory: begin_session_with_main_branch failed: {e:#}"
+                                );
+                                (
+                                    Arc::new(assistd_memory::SessionId::new()),
+                                    assistd_memory::BranchId(0),
+                                )
+                            }
+                        }
                     }
                 };
-                info!(
-                    "memory: SQLite ready at {} (session={})",
-                    db_path.display(),
-                    session
-                );
                 (
                     mem_store as Arc<dyn MemoryStore>,
                     conv_store as Arc<dyn ConversationStore>,
                     Some(writer_handle),
                     session,
+                    branch,
+                    resumed_history,
                     Some(handle),
                 )
             }
@@ -375,6 +435,8 @@ pub async fn run(args: DaemonArgs) -> Result<()> {
                     Arc::new(NoConversationStore) as Arc<dyn ConversationStore>,
                     None,
                     Arc::new(assistd_memory::SessionId::new()),
+                    assistd_memory::BranchId(0),
+                    Vec::new(),
                     None,
                 )
             }
@@ -386,6 +448,8 @@ pub async fn run(args: DaemonArgs) -> Result<()> {
             Arc::new(NoConversationStore) as Arc<dyn ConversationStore>,
             None,
             Arc::new(assistd_memory::SessionId::new()),
+            assistd_memory::BranchId(0),
+            Vec::new(),
             None,
         )
     };
@@ -692,9 +756,36 @@ pub async fn run(args: DaemonArgs) -> Result<()> {
     let continuous_start_on_launch = config.voice.continuous.start_on_launch;
 
     let embedding_cfg_for_state = config.embedding.clone();
+    let conversation_ctx = Arc::new(assistd_core::ConversationContext::from_arc(
+        session_id_for_state.clone(),
+        branch_id_for_state,
+    ));
+    let chat: Arc<dyn assistd_llm::LlmBackend> = Arc::new(chat);
+    // Replay resumed history into the chat backend BEFORE the socket
+    // starts serving so the first incoming query sees a populated
+    // conversation. Failures are logged but never block startup —
+    // worst case the user gets a pristine context window.
+    if !resumed_history.is_empty() {
+        let entries: Vec<assistd_llm::HistoryEntry> = resumed_history
+            .into_iter()
+            .map(|r| assistd_llm::HistoryEntry {
+                role: persisted_role_to_history_role(r.role),
+                content: r.content,
+                tool_calls_json: r.tool_calls,
+                tool_call_id: r.tool_call_id,
+                tool_name: r.tool_name,
+            })
+            .collect();
+        let count = entries.len();
+        if let Err(e) = chat.replace_history(entries).await {
+            tracing::warn!("memory: resume replay failed: {e:#}");
+        } else {
+            info!("memory: resumed {count} message(s) from prior branch");
+        }
+    }
     let mut state_builder = AppState::new(
         config,
-        Arc::new(chat),
+        chat,
         presence.clone(),
         tools,
         voice.clone(),
@@ -704,7 +795,7 @@ pub async fn run(args: DaemonArgs) -> Result<()> {
     .with_vision_revalidator(vision_revalidator)
     .with_memory(memory_store)
     .with_conversations(conversation_store)
-    .with_session(session_id_for_state)
+    .with_conversation_ctx(conversation_ctx)
     .with_embedder(embedder)
     .with_semantic(semantic_store)
     .with_embed_tx(embed_tx)
@@ -819,6 +910,43 @@ pub async fn run(args: DaemonArgs) -> Result<()> {
     serve_result?;
     info!("assistd stopped");
     Ok(())
+}
+
+/// `kill -0 <pid>`: succeeds when the process exists (regardless of
+/// whether we have permission to signal it), fails with ESRCH when no
+/// such pid is alive. We use it as the daemon-liveness check before
+/// claiming a "resumable" session — if the prior daemon is still
+/// running, two daemons trampling on the same `current_branch_id`
+/// would race on every `/switch`.
+#[allow(unsafe_code)] // libc::kill probe — see SAFETY comment below
+fn pid_is_alive(pid: u32) -> bool {
+    if pid == 0 {
+        return false;
+    }
+    // SAFETY: `kill(pid, 0)` reads no memory and writes no signal; it
+    // only probes for the pid's existence. The libc binding is safe
+    // to call from any thread.
+    let rc = unsafe { libc::kill(pid as libc::pid_t, 0) };
+    if rc == 0 {
+        return true;
+    }
+    // EPERM: process exists but we lack permission. EINVAL: bad sig
+    // (won't happen with 0). ESRCH: no such process.
+    let errno = std::io::Error::last_os_error().raw_os_error().unwrap_or(0);
+    errno == libc::EPERM
+}
+
+/// Bridge `assistd_memory::PersistedRole` to `assistd_llm::HistoryRole`
+/// for resume-time history replay. Same identity mapping the daemon's
+/// branch-switch handler does, kept here so daemon startup doesn't
+/// reach into `assistd-core` internals.
+fn persisted_role_to_history_role(role: assistd_memory::PersistedRole) -> assistd_llm::HistoryRole {
+    match role {
+        assistd_memory::PersistedRole::System => assistd_llm::HistoryRole::System,
+        assistd_memory::PersistedRole::User => assistd_llm::HistoryRole::User,
+        assistd_memory::PersistedRole::Assistant => assistd_llm::HistoryRole::Assistant,
+        assistd_memory::PersistedRole::Tool => assistd_llm::HistoryRole::Tool,
+    }
 }
 
 fn build_transport_config(s: &McpServerConfig) -> TransportConfig {

--- a/crates/assistd/src/ptt.rs
+++ b/crates/assistd/src/ptt.rs
@@ -96,7 +96,11 @@ pub async fn run(action: PttAction) -> Result<()> {
             | Event::MemoryRow { .. }
             | Event::MemoryForgetResult { .. }
             | Event::ReindexProgress { .. }
-            | Event::Capabilities { .. } => {}
+            | Event::Capabilities { .. }
+            | Event::BranchInfo { .. }
+            | Event::BranchSwitched { .. }
+            | Event::HistoryEntry { .. }
+            | Event::UndoApplied { .. } => {}
             // `assistd ptt-stop` is one-shot non-interactive — same
             // story as `assistd query`. Daemon's gate denies on
             // disconnect; we just note and keep reading.

--- a/crates/assistd/src/query.rs
+++ b/crates/assistd/src/query.rs
@@ -144,7 +144,11 @@ pub async fn run(args: QueryArgs) -> Result<()> {
             | Event::MemoryRow { .. }
             | Event::MemoryForgetResult { .. }
             | Event::ReindexProgress { .. }
-            | Event::Capabilities { .. } => {}
+            | Event::Capabilities { .. }
+            | Event::BranchInfo { .. }
+            | Event::BranchSwitched { .. }
+            | Event::HistoryEntry { .. }
+            | Event::UndoApplied { .. } => {}
             // `assistd query` is one-shot non-interactive: it can't
             // answer a confirm prompt. The daemon-side gate denies
             // when the connection drops, so we just note the event


### PR DESCRIPTION
Implemented conversation branching with `/fork`, `/branches`, `/switch`, and `/undo` commands with cross-restart persistence