### PR TITLE
Image enabled broken for models lacking mmproj file

### DIFF
--- a/crates/assistd-core/src/lib.rs
+++ b/crates/assistd-core/src/lib.rs
@@ -275,6 +275,10 @@ pub struct VisionRevalidator {
     cached_model: tokio::sync::Mutex<Option<String>>,
     host: String,
     port: u16,
+    /// Configured model id (e.g. `unsloth/Qwen3.6-35B-A3B-GGUF:Q4_K_XL`).
+    /// Used to look up the live child server in router mode; see
+    /// [`assistd_llm::probe_capabilities_routed`].
+    model_name: String,
 }
 
 impl VisionRevalidator {
@@ -282,17 +286,21 @@ impl VisionRevalidator {
     ///
     /// `initial_model_id` is the model id known at startup; `None` means the
     /// first probe result will be accepted unconditionally as the baseline.
+    /// `model_name` is the configured model — required so router-mode
+    /// probes can find the corresponding child server.
     pub fn new(
         gate: Arc<assistd_tools::VisionGate>,
         initial_model_id: Option<String>,
         host: String,
         port: u16,
+        model_name: String,
     ) -> Arc<Self> {
         Arc::new(Self {
             gate,
             cached_model: tokio::sync::Mutex::new(initial_model_id),
             host,
             port,
+            model_name,
         })
     }
 
@@ -300,7 +308,20 @@ impl VisionRevalidator {
     /// gate. Tolerates probe failures silently; a transient HTTP
     /// blip should not flip vision off mid-session.
     pub async fn revalidate(&self) {
-        let probe = assistd_llm::probe_capabilities(&self.host, self.port).await;
+        let Ok(control) = assistd_llm::LlamaServerControl::new(&self.host, self.port) else {
+            tracing::warn!(
+                target: "assistd::vision",
+                "VisionRevalidator could not build control client; skipping probe"
+            );
+            return;
+        };
+        let probe = assistd_llm::probe_capabilities_routed(
+            &self.host,
+            self.port,
+            &self.model_name,
+            &control,
+        )
+        .await;
         self.apply_probe(probe).await;
     }
 
@@ -347,6 +368,7 @@ mod vision_revalidator_tests {
             // make a real revalidate() obviously fail loudly if anyone
             // accidentally points the test at it.
             0,
+            "test/model:Q4".to_string(),
         )
     }
 

--- a/crates/assistd-core/src/presence.rs
+++ b/crates/assistd-core/src/presence.rs
@@ -741,6 +741,32 @@ impl PresenceManager {
             PresenceState::Active => unreachable!("short-circuited above"),
         }
 
+        // `POST /models/load` returns 200 the moment the router accepts
+        // the spawn request — the child still needs to load weights and
+        // (for vision models) the mmproj. Without waiting here, the
+        // daemon's initial vision probe races the child startup and
+        // permanently reads `vision: off` even for vision-capable
+        // models. Poll `/models` until the entry flips to `loaded`.
+        const LOAD_POLL_INTERVAL: Duration = Duration::from_millis(200);
+        if let Err(e) = self
+            .control
+            .wait_for_loaded(&self.model.name, load_budget, LOAD_POLL_INTERVAL)
+            .await
+        {
+            warn!(
+                target: "assistd::presence",
+                model = %self.model.name,
+                timeout_secs = self.timeouts.presence_wake_load_secs,
+                "llama-server did not flip {} to loaded within budget: {e}",
+                self.model.name
+            );
+            return Err(anyhow!(
+                "llama-server did not finish loading {} within {}s during wake",
+                self.model.name,
+                self.timeouts.presence_wake_load_secs
+            ));
+        }
+
         *self.state.lock().unwrap_or_else(|e| e.into_inner()) = PresenceState::Active;
         let _ = self.state_tx.send(PresenceState::Active);
         info!(

--- a/crates/assistd-core/src/state.rs
+++ b/crates/assistd-core/src/state.rs
@@ -1869,11 +1869,33 @@ impl AppState {
         id: String,
         tx: mpsc::Sender<Event>,
     ) -> Result<()> {
-        let probe = assistd_llm::probe_capabilities(
+        // Router-aware probe: in router mode the configured host:port is
+        // just the router; the real /props (with `modalities`) lives on
+        // the child server. `probe_capabilities_routed` follows the
+        // indirection when present and degrades to the direct probe
+        // otherwise. Failure (e.g. transient client-build error) is
+        // surfaced as `vision: false` so the TUI shows the safe default.
+        let probe = match assistd_llm::LlamaServerControl::new(
             &self.config.llama_server.host,
             self.config.llama_server.port,
-        )
-        .await;
+        ) {
+            Ok(control) => {
+                assistd_llm::probe_capabilities_routed(
+                    &self.config.llama_server.host,
+                    self.config.llama_server.port,
+                    &self.config.model.name,
+                    &control,
+                )
+                .await
+            }
+            Err(e) => {
+                tracing::warn!(
+                    target: "assistd::vision",
+                    "GetCapabilities: failed to build control client: {e}"
+                );
+                assistd_llm::VisionState::default()
+            }
+        };
         // Match the TUI's old basename rendering: prefer the part after
         // the last `/` (e.g. `Qwen3-14B-GGUF:Q4_K_M` from
         // `bartowski/Qwen3-14B-GGUF:Q4_K_M`), fall back to the full

--- a/crates/assistd-llm/src/lib.rs
+++ b/crates/assistd-llm/src/lib.rs
@@ -22,7 +22,7 @@ pub use chat::conversation::ToolCallRecord;
 pub use chat::{ChatClientError, LlamaChatClient};
 pub use llama_server::{
     LlamaServerControl, LlamaServerError, LlamaService, ReadyState, VisionState,
-    detect_vision_support, probe_capabilities,
+    detect_vision_support, probe_capabilities, probe_capabilities_routed,
 };
 
 use assistd_tools::Attachment;

--- a/crates/assistd-llm/src/llama_server/capabilities.rs
+++ b/crates/assistd-llm/src/llama_server/capabilities.rs
@@ -1,11 +1,22 @@
 //! Capability probe for the running llama-server.
 //!
 //! After [`super::LlamaService::start`] reports the child as ready
-//! (`/health` = 200), call [`detect_vision_support`] to decide whether
-//! the loaded model has a multimodal projector (mmproj) bundled.
-//! llama.cpp auto-loads the projector when the HF repo carries one
-//! alongside the text weights; there is no separate config flag to
-//! opt in. The only way to know is to ask the server.
+//! (`/health` = 200), call [`probe_capabilities_routed`] (or
+//! [`detect_vision_support`] for the boolean-only variant) to decide
+//! whether the loaded model has a multimodal projector (mmproj)
+//! bundled. llama.cpp auto-loads the projector when the HF repo
+//! carries one alongside the text weights; there is no separate
+//! config flag to opt in. The only way to know is to ask the server.
+//!
+//! Router-mode awareness: when llama-server runs as a router, the
+//! daemon-managed port hosts only the router process, and `/props`
+//! there reports `role: "router"` with no model info — the real model
+//! (and the real `/props`, including `modalities`) lives in a child
+//! server spawned on a transient port. [`probe_capabilities_routed`]
+//! detects this by checking the `role` field, then consults
+//! [`super::LlamaServerControl::find_loaded_child_port`] to discover
+//! the child's port and re-probes `/props` there. Non-router setups
+//! see no detour: the first probe is the answer.
 //!
 //! The probe intentionally fails-closed: any HTTP error, parse
 //! failure, or absent capability field collapses to
@@ -15,16 +26,22 @@
 //! safer default than silently sending image bytes the model will drop.
 //!
 //! Field-name spread: across the multimodal-merge era llama.cpp has
-//! exposed the capability under several different keys. We tolerate
-//! the spread by checking a small union: any of `has_multimodal`,
-//! `has_vision`, `multimodal`, or
-//! `default_generation_settings.multimodal` set to `true` enables
-//! vision. New names can be added here without touching call sites.
+//! exposed the capability under several different keys. The current
+//! canonical shape is a structured `modalities` object
+//! (`{"modalities": {"vision": true}}`); legacy builds reported a
+//! flat boolean under `has_multimodal`, `has_vision`, `multimodal`,
+//! or `default_generation_settings.multimodal`. We tolerate the
+//! spread by checking the structured field first and falling back to
+//! the legacy union, so a server upgrade in either direction keeps
+//! vision detection working. New names can be added here without
+//! touching call sites.
 
 use std::time::Duration;
 
 use serde_json::Value;
 use tracing::{debug, warn};
+
+use super::control::LlamaServerControl;
 
 const PROBE_TIMEOUT: Duration = Duration::from_secs(2);
 
@@ -69,6 +86,91 @@ pub async fn probe_capabilities(host: &str, port: u16) -> VisionState {
 /// that don't need the model id.
 pub async fn detect_vision_support(host: &str, port: u16) -> bool {
     probe_capabilities(host, port).await.vision_supported
+}
+
+/// Probe the *effective* model's capabilities, transparently following
+/// router indirection when needed.
+///
+/// `host`/`port` identify the daemon-managed llama-server. `model` is
+/// the configured model id (e.g. `unsloth/Qwen3.6-35B-A3B-GGUF:Q4_K_XL`)
+/// — used to look up the right child when the server is in router
+/// mode. `control` is the same HTTP client the presence layer uses, so
+/// router-mode discovery reuses the configured base URL and connection
+/// pool.
+///
+/// Behaviour:
+/// - Direct mode: `/props` carries the model info → return it.
+/// - Router mode (`role == "router"` in `/props`): consult `/models`
+///   for the loaded child's port, then probe `/props` on that child.
+/// - Anything that fails along the way collapses to the default
+///   (vision off, no model id) so the gate fails closed.
+pub async fn probe_capabilities_routed(
+    host: &str,
+    port: u16,
+    model: &str,
+    control: &LlamaServerControl,
+) -> VisionState {
+    let body = match fetch_props(host, port).await {
+        Some(v) => v,
+        None => return VisionState::default(),
+    };
+
+    if !is_router_props(&body) {
+        return VisionState {
+            model_id: parse_model_id(&body),
+            vision_supported: parse_vision_supported(&body),
+        };
+    }
+
+    let child_port = match control.find_loaded_child_port(model).await {
+        Ok(Some(p)) if p != 0 => p,
+        Ok(Some(_)) => {
+            debug!(
+                target: "assistd::llama_server",
+                "router /models reports `--port 0` for {model}; child not yet bound — \
+                 reporting vision unsupported until the next probe"
+            );
+            return VisionState::default();
+        }
+        Ok(None) => {
+            debug!(
+                target: "assistd::llama_server",
+                "router /models has no loaded entry for {model}; reporting vision \
+                 unsupported until the next probe"
+            );
+            return VisionState::default();
+        }
+        Err(e) => {
+            warn!(
+                target: "assistd::llama_server",
+                "router /models lookup for {model} failed: {e}"
+            );
+            return VisionState::default();
+        }
+    };
+
+    let child_body = match fetch_props(host, child_port).await {
+        Some(v) => v,
+        None => return VisionState::default(),
+    };
+    let vision_supported = parse_vision_supported(&child_body);
+    // The child's /props sets `model` to null and only carries `model_path`;
+    // fall back to the configured name so the revalidator's swap detection
+    // has a stable identity to compare against.
+    let model_id = parse_model_id(&child_body).or_else(|| Some(model.to_string()));
+    debug!(
+        target: "assistd::llama_server",
+        "router child probe: model={model_id:?}, vision_supported={vision_supported}, \
+         child_port={child_port}"
+    );
+    VisionState {
+        model_id,
+        vision_supported,
+    }
+}
+
+fn is_router_props(body: &Value) -> bool {
+    body.get("role").and_then(Value::as_str) == Some("router")
 }
 
 async fn fetch_props(host: &str, port: u16) -> Option<Value> {
@@ -140,6 +242,11 @@ fn parse_model_id(body: &Value) -> Option<String> {
 /// multimodal/vision support. Tolerates the historical spread of
 /// field names in llama.cpp.
 fn parse_vision_supported(body: &Value) -> bool {
+    if let Some(modalities) = body.get("modalities")
+        && modalities.get("vision").and_then(Value::as_bool) == Some(true)
+    {
+        return true;
+    }
     const TOP_LEVEL_KEYS: &[&str] = &["has_multimodal", "has_vision", "multimodal"];
     for key in TOP_LEVEL_KEYS {
         if body.get(*key).and_then(Value::as_bool) == Some(true) {
@@ -158,6 +265,48 @@ fn parse_vision_supported(body: &Value) -> bool {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn detects_modalities_vision_true() {
+        let body = json!({"modalities": {"vision": true}, "total_slots": 1});
+        assert!(parse_vision_supported(&body));
+    }
+
+    #[test]
+    fn modalities_vision_false_does_not_promote_to_true() {
+        let body = json!({"modalities": {"vision": false}});
+        assert!(!parse_vision_supported(&body));
+    }
+
+    #[test]
+    fn modalities_vision_true_wins_over_legacy_false() {
+        // A server reporting the new structured field while still
+        // emitting a stale legacy `has_multimodal: false` must enable
+        // vision. The structured field is canonical.
+        let body = json!({
+            "modalities": {"vision": true},
+            "has_multimodal": false,
+        });
+        assert!(parse_vision_supported(&body));
+    }
+
+    #[test]
+    fn modalities_without_vision_key_falls_through_to_legacy() {
+        // Future-proof: if `modalities` exists but doesn't yet carry a
+        // `vision` key (e.g. audio-only build), we must not short-circuit
+        // — fall through and let the legacy union decide.
+        let body = json!({
+            "modalities": {"audio": true},
+            "has_vision": true,
+        });
+        assert!(parse_vision_supported(&body));
+    }
+
+    #[test]
+    fn ignores_non_bool_modalities_vision() {
+        let body = json!({"modalities": {"vision": "true"}});
+        assert!(!parse_vision_supported(&body));
+    }
 
     #[test]
     fn detects_top_level_has_multimodal_true() {
@@ -266,5 +415,25 @@ mod tests {
     fn ignores_non_string_model_value() {
         let body = json!({"model": 42});
         assert_eq!(parse_model_id(&body), None);
+    }
+
+    #[test]
+    fn detects_router_props_by_role_field() {
+        let body = json!({"role": "router", "max_instances": 4, "model_path": "none"});
+        assert!(is_router_props(&body));
+    }
+
+    #[test]
+    fn non_router_props_lack_router_role() {
+        // Real child-server /props: `model` may be null but `role` is absent.
+        let body = json!({"model": null, "model_path": "/some/model.gguf", "modalities": {"vision": true}});
+        assert!(!is_router_props(&body));
+    }
+
+    #[test]
+    fn non_router_props_with_unrelated_role_value() {
+        // Future-proof: only the literal "router" triggers the detour.
+        let body = json!({"role": "worker", "model_path": "/x.gguf"});
+        assert!(!is_router_props(&body));
     }
 }

--- a/crates/assistd-llm/src/llama_server/control.rs
+++ b/crates/assistd-llm/src/llama_server/control.rs
@@ -62,16 +62,68 @@ impl LlamaServerControl {
     /// Queries `GET /models` and looks for an entry matching `model` with
     /// a loaded status marker. Resilient to different response shapes:
     /// tolerates either a top-level `data`/`models` array and either a
-    /// `status: "loaded"` field or a boolean `loaded` field.
+    /// structured `status: {value: "loaded", args: [...]}` object, a flat
+    /// `status: "loaded"` string, or a boolean `loaded` field.
     pub async fn model_is_loaded(&self, model: &str) -> Result<bool, LlamaServerError> {
+        Ok(self.fetch_models().await?.contains_loaded(model))
+    }
+
+    /// Returns the child server's listening port for `model` if it is
+    /// currently loaded, or `None` otherwise.
+    ///
+    /// In router mode llama-server spawns a child per loaded model on a
+    /// transient port encoded in the per-model `status.args` array (the
+    /// value following `--port`). Callers need this port to reach the
+    /// model directly — `/props`, `/health`, etc. on the router itself
+    /// describe the router, not the loaded model.
+    ///
+    /// Returns `None` when the model is missing, marked unloaded, or
+    /// when the response shape doesn't carry the spawn args (e.g.
+    /// non-router-mode servers).
+    pub async fn find_loaded_child_port(
+        &self,
+        model: &str,
+    ) -> Result<Option<u16>, LlamaServerError> {
+        Ok(self.fetch_models().await?.find_loaded_child_port(model))
+    }
+
+    /// Polls `/models` until `model` reports `status.value == "loaded"`
+    /// or `deadline` elapses.
+    ///
+    /// `POST /models/load` on the router returns `200` the moment the
+    /// router accepts the spawn request — it does not block until the
+    /// child has actually finished loading weights + mmproj. Anything
+    /// that depends on the model being live (vision probe, first
+    /// chat request) needs to wait for this transition explicitly.
+    pub async fn wait_for_loaded(
+        &self,
+        model: &str,
+        deadline: Duration,
+        poll_interval: Duration,
+    ) -> Result<(), LlamaServerError> {
+        let start = tokio::time::Instant::now();
+        loop {
+            // Suppress transient errors during the poll — the router can
+            // briefly 5xx while spawning a child. Only the deadline is
+            // fatal.
+            if let Ok(true) = self.model_is_loaded(model).await {
+                return Ok(());
+            }
+            if start.elapsed() >= deadline {
+                return Err(LlamaServerError::HealthTimeout { timeout: deadline });
+            }
+            tokio::time::sleep(poll_interval).await;
+        }
+    }
+
+    async fn fetch_models(&self) -> Result<ModelsResponse, LlamaServerError> {
         let url = format!("{}/models", self.base_url);
         let resp = self.client.get(&url).send().await?;
         let status = resp.status();
         if !status.is_success() {
             return Err(control_http_error("GET", "/models", status));
         }
-        let body: ModelsResponse = resp.json().await?;
-        Ok(body.contains_loaded(model))
+        Ok(resp.json().await?)
     }
 
     async fn post_model_action(
@@ -117,11 +169,18 @@ struct ModelsResponse {
 }
 
 impl ModelsResponse {
+    fn entries(&self) -> impl Iterator<Item = &ModelEntry> {
+        self.data.iter().chain(self.models.iter())
+    }
+
     fn contains_loaded(&self, model: &str) -> bool {
-        self.data
-            .iter()
-            .chain(self.models.iter())
-            .any(|e| e.matches(model) && e.is_loaded())
+        self.entries().any(|e| e.matches(model) && e.is_loaded())
+    }
+
+    fn find_loaded_child_port(&self, model: &str) -> Option<u16> {
+        self.entries()
+            .find(|e| e.matches(model) && e.is_loaded())
+            .and_then(ModelEntry::child_port)
     }
 }
 
@@ -132,9 +191,48 @@ struct ModelEntry {
     #[serde(default)]
     name: Option<String>,
     #[serde(default)]
-    status: Option<String>,
+    status: Option<ModelStatus>,
     #[serde(default)]
     loaded: Option<bool>,
+}
+
+/// `/models` historically returned `status` as a flat string
+/// (`"loaded"` / `"unloaded"`); current router-mode builds return a
+/// structured object with the child's spawn args. We accept both via
+/// an untagged enum so an upgrade in either direction keeps parsing.
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum ModelStatus {
+    Structured {
+        value: String,
+        #[serde(default)]
+        args: Vec<String>,
+    },
+    Legacy(String),
+}
+
+impl ModelStatus {
+    fn is_loaded(&self) -> bool {
+        match self {
+            ModelStatus::Structured { value, .. } | ModelStatus::Legacy(value) => value == "loaded",
+        }
+    }
+
+    /// Extract the value following `--port` in the spawn args of a
+    /// structured status. Only present when the router actually spawned
+    /// a child for this model.
+    fn child_port(&self) -> Option<u16> {
+        let ModelStatus::Structured { args, .. } = self else {
+            return None;
+        };
+        let mut iter = args.iter();
+        while let Some(arg) = iter.next() {
+            if arg == "--port" {
+                return iter.next().and_then(|s| s.parse::<u16>().ok());
+            }
+        }
+        None
+    }
 }
 
 impl ModelEntry {
@@ -146,7 +244,11 @@ impl ModelEntry {
         if let Some(true) = self.loaded {
             return true;
         }
-        matches!(self.status.as_deref(), Some("loaded"))
+        self.status.as_ref().is_some_and(ModelStatus::is_loaded)
+    }
+
+    fn child_port(&self) -> Option<u16> {
+        self.status.as_ref().and_then(ModelStatus::child_port)
     }
 }
 
@@ -175,5 +277,80 @@ mod tests {
         let body = r#"{"data":[]}"#;
         let parsed: ModelsResponse = serde_json::from_str(body).unwrap();
         assert!(!parsed.contains_loaded("anything"));
+    }
+
+    #[test]
+    fn models_response_recognises_structured_status_loaded() {
+        // Shape the router currently returns: status is an object with
+        // `value` and `args` (the child's spawn command line).
+        let body = r#"{"data":[
+            {"id":"foo/bar:Q4","status":{"value":"loaded","args":["--host","127.0.0.1","--port","48881"]}},
+            {"id":"baz/qux:Q4","status":{"value":"unloaded","args":["--host","127.0.0.1","--port","0"]}}
+        ]}"#;
+        let parsed: ModelsResponse = serde_json::from_str(body).unwrap();
+        assert!(parsed.contains_loaded("foo/bar:Q4"));
+        assert!(!parsed.contains_loaded("baz/qux:Q4"));
+    }
+
+    #[test]
+    fn find_loaded_child_port_extracts_port_from_spawn_args() {
+        let body = r#"{"data":[
+            {"id":"foo/bar:Q4","status":{"value":"loaded","args":["--host","127.0.0.1","--port","48881","--alias","foo/bar:Q4"]}}
+        ]}"#;
+        let parsed: ModelsResponse = serde_json::from_str(body).unwrap();
+        assert_eq!(parsed.find_loaded_child_port("foo/bar:Q4"), Some(48881));
+    }
+
+    #[test]
+    fn find_loaded_child_port_returns_none_for_unloaded_model() {
+        // Even with a `--port` in args, an unloaded entry has no live
+        // child — surface None rather than a stale port.
+        let body = r#"{"data":[
+            {"id":"foo/bar:Q4","status":{"value":"unloaded","args":["--port","48881"]}}
+        ]}"#;
+        let parsed: ModelsResponse = serde_json::from_str(body).unwrap();
+        assert_eq!(parsed.find_loaded_child_port("foo/bar:Q4"), None);
+    }
+
+    #[test]
+    fn find_loaded_child_port_returns_none_when_args_missing() {
+        // Legacy/flat status carries no spawn args; vision detection
+        // falls back to direct probing in that case.
+        let body = r#"{"data":[{"id":"foo/bar:Q4","status":"loaded"}]}"#;
+        let parsed: ModelsResponse = serde_json::from_str(body).unwrap();
+        assert!(parsed.contains_loaded("foo/bar:Q4"));
+        assert_eq!(parsed.find_loaded_child_port("foo/bar:Q4"), None);
+    }
+
+    #[test]
+    fn find_loaded_child_port_returns_none_for_unknown_model() {
+        let body = r#"{"data":[
+            {"id":"foo/bar:Q4","status":{"value":"loaded","args":["--port","48881"]}}
+        ]}"#;
+        let parsed: ModelsResponse = serde_json::from_str(body).unwrap();
+        assert_eq!(parsed.find_loaded_child_port("other/model:Q4"), None);
+    }
+
+    #[test]
+    fn find_loaded_child_port_ignores_non_numeric_port() {
+        // Future-proof: if `--port` is followed by a non-numeric token,
+        // refuse to invent one rather than panicking.
+        let body = r#"{"data":[
+            {"id":"foo/bar:Q4","status":{"value":"loaded","args":["--port","auto"]}}
+        ]}"#;
+        let parsed: ModelsResponse = serde_json::from_str(body).unwrap();
+        assert_eq!(parsed.find_loaded_child_port("foo/bar:Q4"), None);
+    }
+
+    #[test]
+    fn find_loaded_child_port_handles_port_zero_as_unbound() {
+        // The router stores `--port 0` for entries it has never spawned;
+        // we parse it as 0 which callers should treat as "no live child."
+        // A real spawn replaces 0 with the actual bound port.
+        let body = r#"{"data":[
+            {"id":"foo/bar:Q4","status":{"value":"loaded","args":["--port","0"]}}
+        ]}"#;
+        let parsed: ModelsResponse = serde_json::from_str(body).unwrap();
+        assert_eq!(parsed.find_loaded_child_port("foo/bar:Q4"), Some(0));
     }
 }

--- a/crates/assistd-llm/src/llama_server/mod.rs
+++ b/crates/assistd-llm/src/llama_server/mod.rs
@@ -20,7 +20,9 @@ pub mod service;
 pub mod supervisor;
 
 pub use backoff::MAX_CONSECUTIVE_FAILURES;
-pub use capabilities::{VisionState, detect_vision_support, probe_capabilities};
+pub use capabilities::{
+    VisionState, detect_vision_support, probe_capabilities, probe_capabilities_routed,
+};
 pub use control::LlamaServerControl;
 pub use error::LlamaServerError;
 pub use service::{LlamaService, ReadyState};

--- a/crates/assistd/src/daemon.rs
+++ b/crates/assistd/src/daemon.rs
@@ -10,7 +10,7 @@
 //! [`AppState`] and retains the shutdown-relevant pieces in
 //! [`DaemonShutdown`] for ordered teardown.
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use assistd_core::{AppState, Config, PresenceManager};
 use assistd_llm::LlamaChatClient;
 use assistd_tools::{IpcConfirmationGate, MemoryOps};
@@ -97,8 +97,24 @@ pub async fn run(args: DaemonArgs) -> Result<()> {
 
     assistd_core::install_panic_hook(Arc::downgrade(&presence));
 
-    let initial_vision_state =
-        assistd_llm::probe_capabilities(&config.llama_server.host, config.llama_server.port).await;
+    // In router mode the daemon-managed port hosts only the router; the
+    // real /props (with `modalities`) lives on the child server's
+    // transient port. `probe_capabilities_routed` follows that indirection
+    // when present, and degrades to the direct path otherwise.
+    let initial_vision_state = {
+        let control = assistd_llm::LlamaServerControl::new(
+            &config.llama_server.host,
+            config.llama_server.port,
+        )
+        .context("failed to construct llama-server control client for vision probe")?;
+        assistd_llm::probe_capabilities_routed(
+            &config.llama_server.host,
+            config.llama_server.port,
+            &config.model.name,
+            &control,
+        )
+        .await
+    };
     if initial_vision_state.vision_supported {
         info!("vision: enabled (model has mmproj)");
     } else {
@@ -110,6 +126,7 @@ pub async fn run(args: DaemonArgs) -> Result<()> {
         initial_vision_state.model_id,
         config.llama_server.host.clone(),
         config.llama_server.port,
+        config.model.name.clone(),
     );
 
     let health_probe: std::sync::Arc<dyn assistd_llm::LlmHealthProbe> = std::sync::Arc::new(


### PR DESCRIPTION
Fixed check for image modality, stemming from querying the props endpoint on the router which wasn't scoped to the hosted model itself.