### PR TITLE
Arithmetic underflow in the llm supervisor

### DIFF
--- a/crates/assistd-llm/src/llama_server/supervisor.rs
+++ b/crates/assistd-llm/src/llama_server/supervisor.rs
@@ -99,6 +99,10 @@ impl Supervisor {
                 return;
             }
 
+            if consecutive_failures == 0 {
+                continue;
+            }
+
             let delay = backoff_delay(consecutive_failures - 1);
             warn!(
                 target: "assistd::llama_server",


### PR DESCRIPTION
added an early `continue` so healthy-crash restarts skip backoff.