### PR TITLE
CI doesn't use the pinned toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Rust toolchain (stable)
-        uses: dtolnay/rust-toolchain@stable
+      # Reads channel + components from rust-toolchain.toml so CI tracks
+      # the pinned toolchain instead of silently drifting to whatever
+      # "stable" resolves to on the runner.
+      - name: Install Rust toolchain (from rust-toolchain.toml)
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          components: clippy, rustfmt
+          cache: false
 
       # cpal links to libasound2 on Linux (ALSA backend) and pkg-config
       # is invoked by alsa-sys at build time. ubuntu-latest ships


### PR DESCRIPTION
- CI now installs whatever rust-toolchain.toml pins (currently stable + rustfmt, clippy), so an MSRV bump in that file flows through CI automatically.
- Dropped the duplicated components: clippy, rustfmt since the toml is now authoritative.