### PR TITLE
Mvp refinement

### DIFF
--- a/crates/assistd-core/src/agent.rs
+++ b/crates/assistd-core/src/agent.rs
@@ -122,11 +122,6 @@ impl Agent {
                 return Ok(());
             }
 
-            // Per-iteration replay budget: at most one restart-driven
-            // retry. The supervisor's own consecutive-failure cap (5) is
-            // the daemon-level circuit breaker; this keeps the user-visible
-            // latency bounded if the supervisor recovers but the model
-            // still crashes on the same prompt.
             let mut restart_attempted = false;
 
             let outcome = loop {
@@ -246,17 +241,10 @@ impl Agent {
                         }
                     }
                     Err(e) => {
-                        // Surface the typed error category to the model so
-                        // a transient HTTP hiccup doesn't read the same as
-                        // a persistent backend-unavailable state. The
-                        // human-readable Display is still the primary
-                        // signal in the user-facing delta.
                         let label = match &e {
                             LlmError::Chat(_) => "chat backend",
                             LlmError::ToolCallParse(_) => "tool-call parse",
                             LlmError::Unavailable(_) => "backend unavailable",
-                            // Already-attempted restart, or no probe wired.
-                            // Fall through as a terminal failure.
                             LlmError::ServerRestarting(_) => "llm restarting",
                         };
                         let _ = tx
@@ -286,9 +274,6 @@ impl Agent {
                                 cancelled = cancel.is_cancelled(),
                                 "stopping mid-call (client gone or explicit cancel) without dispatch"
                             );
-                            // Unwind: push synthetic errors for all pending calls
-                            // so conversation state isn't left with a dangling
-                            // assistant-with-tool_calls on the next turn.
                             results.push(ToolResultPayload {
                                 call_id: call.id,
                                 name: call.name,
@@ -311,9 +296,6 @@ impl Agent {
                         let (payload, raw_result) =
                             dispatch_tool_call(tools, &call, iteration).await;
 
-                        // Emit the result for downstream observers. Ignore
-                        // send errors; the next `tx.is_closed()` check will
-                        // catch the disconnect.
                         let _ = tx
                             .send(LlmEvent::ToolResult {
                                 id: payload.call_id.clone(),
@@ -347,15 +329,6 @@ impl Agent {
     }
 }
 
-/// Dispatch one tool call and produce both the LLM-facing payload and the
-/// raw JSON result (for event emission).
-///
-/// Error handling: failures at any level become synthetic tool results
-/// formatted with the Layer 2 navigational-hint convention
-/// (`[error] <cmd>: <what>. <Hint>: <recovery>`) so the model can
-/// self-correct on the next step. Only fundamental errors (like a
-/// `send` failure on `tx`) bubble up to the loop, and even those
-/// result in graceful shutdown, not a hung history.
 async fn dispatch_tool_call(
     tools: &ToolRegistry,
     call: &ToolCall,
@@ -474,8 +447,6 @@ async fn dispatch_tool_call(
     )
 }
 
-/// Decode one `attachments[i]` entry from a RunTool result. Currently
-/// only handles `{"type": "image", "mime": "...", "data": <base64>}`.
 fn parse_attachment(v: &Value) -> Option<Attachment> {
     let kind = v.get("type")?.as_str()?;
     if kind != "image" {
@@ -569,9 +540,6 @@ mod tests {
         ) -> assistd_llm::LlmResult<StepOutcome> {
             self.step_calls
                 .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            // Honour any configured slow-step delay BEFORE consuming
-            // an outcome; cancellation tests rely on this future
-            // being long-lived so the cancel signal can race it.
             let delay = *self.slow_step.lock();
             if let Some(d) = delay {
                 tokio::time::sleep(d).await;
@@ -585,8 +553,6 @@ mod tests {
                 }
             };
             if matches!(outcome, StepOutcome::Final) {
-                // Emulate a real step sending a text delta on Final so
-                // callers can observe streaming.
                 let _ = tx.send(LlmEvent::Delta { text: "ok".into() }).await;
             }
             Ok(outcome)
@@ -657,8 +623,6 @@ mod tests {
             .unwrap();
         let events = collect(&mut rx).await;
 
-        // Expected event sequence (intermixed with deltas):
-        // ToolCall, ToolResult, Delta("ok"), Done
         assert!(
             events
                 .iter()
@@ -671,8 +635,6 @@ mod tests {
         );
         assert!(matches!(events.last(), Some(LlmEvent::Done)));
 
-        // And the backend saw the echoed result pushed back before the
-        // second step.
         let pushed = backend.pushed_results.lock();
         assert_eq!(pushed.len(), 1);
         assert_eq!(pushed[0].len(), 1);
@@ -721,10 +683,6 @@ mod tests {
 
         let results = backend.pushed_results.lock();
         assert_eq!(results.len(), 1);
-        // `echo "alpha\nbeta\nalpha"` prints 1 line; grep alpha filters
-        // the full body; wc -l counts it. The exact count depends on
-        // how echo interprets \n, but the content should start with an
-        // integer and contain an [exit:0] footer.
         assert!(
             results[0][0].content.contains("[exit:0"),
             "expected success footer: {:?}",
@@ -765,8 +723,6 @@ mod tests {
 
     #[tokio::test]
     async fn unknown_tool_passes_error_to_next_step() {
-        // Model calls a non-existent tool; dispatch produces an error
-        // payload rather than aborting; next step sees it and goes Final.
         let backend = MockBackend::with(vec![
             StepOutcome::ToolCalls(vec![ToolCall {
                 id: "c-1".into(),
@@ -794,10 +750,6 @@ mod tests {
 
     #[tokio::test]
     async fn tool_invoke_err_becomes_synthetic_error_result() {
-        // A hand-written tool that errors at the Rust level (rather than
-        // via a non-zero exit code) triggers the dispatch `Err` path and
-        // must be converted into a synthetic tool-result payload so the
-        // next step can self-correct.
         struct ErrTool;
         #[async_trait]
         impl assistd_tools::Tool for ErrTool {
@@ -855,7 +807,6 @@ mod tests {
             .run_turn("go".into(), Vec::new(), tx, CancellationToken::new())
             .await
             .unwrap();
-        // With the receiver already dropped, no step was called.
         let pushed = backend.pushed_results.lock();
         assert!(
             pushed.is_empty(),
@@ -865,9 +816,6 @@ mod tests {
 
     #[tokio::test]
     async fn explicit_cancel_before_first_step_stops_loop_immediately() {
-        // The token is cancelled before the loop starts. The very
-        // first iteration's pre-step check sees `cancel.is_cancelled()`
-        // and bails; no step is ever called.
         let backend = MockBackend::with(vec![
             StepOutcome::Final,
             // If we get here the cancellation didn't take effect.
@@ -881,8 +829,6 @@ mod tests {
             .run_turn("go".into(), Vec::new(), tx, token)
             .await
             .unwrap();
-        // user push happened (it's the first thing in the loop), but
-        // no step ran.
         assert_eq!(backend.pushed_users.lock().len(), 1);
         assert_eq!(
             backend.step_calls.load(std::sync::atomic::Ordering::SeqCst),
@@ -931,8 +877,6 @@ mod tests {
         tools.register(RecallTool::new(no_embedder, no_semantic, String::new()));
         let tools = Arc::new(tools);
 
-        // Step 1: model calls remember(...). Step 2: model calls
-        // recall(...). Step 3: Final.
         let backend = MockBackend::with(vec![
             StepOutcome::ToolCalls(vec![ToolCall {
                 id: "c-1".into(),
@@ -972,19 +916,11 @@ mod tests {
             .collect();
         assert_eq!(names, vec!["remember", "recall"]);
 
-        // Save landed in the underlying SQLite store (the wire-level
-        // contract for `remember`).
         assert_eq!(
             mem.load("editor_preference").await.unwrap().as_deref(),
             Some("vim")
         );
 
-        // Recall's ToolResult and the second push_tool_results carry
-        // the no-memories sentinel; the embedder is disabled, so
-        // semantic search has nothing to return. The point of this
-        // assertion is that the recall result *was* round-tripped back
-        // to the model on the next step (proving the loop wiring), not
-        // that the data was actually retrievable.
         let recall_output = events
             .iter()
             .find_map(|e| match e {
@@ -1032,12 +968,6 @@ mod tests {
         }
     }
 
-    /// Acceptance: a turn that mixes an MCP-shaped tool call and a
-    /// native `run` call drives both through `dispatch_tool_call`,
-    /// emits a `ToolCall`/`ToolResult` pair for each, and pushes both
-    /// results back to the backend in order. This is the wire-level
-    /// proof that the agent loop is tool-source-agnostic: MCP tools
-    /// and native tools share the same dispatch/result/feedback path.
     #[tokio::test]
     async fn agent_loop_mixes_native_and_mcp_calls() {
         use assistd_tools::commands::EchoCommand;
@@ -1049,8 +979,6 @@ mod tests {
             &ToolsOutputConfig::default(),
             std::env::temp_dir().join(format!("assistd-agent-test-mix-{}", std::process::id())),
         ));
-        // Same envelope shape `McpToolAdapter::tool_result_to_json`
-        // produces for a `ToolResult::Text("calendar entries")`.
         tools.register(FakeMcpTool {
             name: "mcp__google_calendar__list_events".into(),
             result: serde_json::json!({
@@ -1127,9 +1055,6 @@ mod tests {
         let mut tools = ToolRegistry::new();
         tools.register(FakeMcpTool {
             name: "mcp__google_calendar__list_events".into(),
-            // Mirrors `error_envelope` in `assistd-mcp/src/lib.rs`;
-            // the line carries `Check:` which the model needs to see
-            // intact.
             result: serde_json::json!({
                 "type": "error",
                 "output": "[error] mcp__google_calendar__list_events: \
@@ -1186,16 +1111,11 @@ mod tests {
 
     #[tokio::test]
     async fn cancellation_during_slow_step_preempts_loop() {
-        // Fire a cancellation while the LLM step is still pending,
-        // and verify Agent::run_turn returns promptly via the
-        // tokio::select! against `cancel.cancelled()` rather than
-        // waiting for the step future to complete on its own.
         let backend = MockBackend::with(vec![StepOutcome::Final]).slow_step_ms(2_000);
         let tools = tools_with_echo();
         let (tx, _rx) = mpsc::channel::<LlmEvent>(16);
         let token = CancellationToken::new();
         let token_for_kicker = token.clone();
-        // Spawn a task that fires cancel after a short delay.
         tokio::spawn(async move {
             tokio::time::sleep(std::time::Duration::from_millis(20)).await;
             token_for_kicker.cancel();
@@ -1206,9 +1126,6 @@ mod tests {
             .await
             .unwrap();
         let elapsed = started.elapsed();
-        // The slow step is 2s; if cancellation didn't preempt we'd
-        // be waiting that long. Allow a generous 500ms buffer for
-        // CI scheduling variance.
         assert!(
             elapsed < std::time::Duration::from_millis(500),
             "cancellation did not preempt slow step (elapsed: {elapsed:?})"
@@ -1320,9 +1237,6 @@ mod tests {
         ) -> assistd_llm::LlmResult<StepOutcome> {
             self.step_calls
                 .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            // Errors first; once they're exhausted, fall through to
-            // outcomes. Lets a single test script "first attempt
-            // crashes, second attempt succeeds".
             let next_err = self.errors.lock().pop();
             if let Some(e) = next_err {
                 return Err(e);
@@ -1337,10 +1251,6 @@ mod tests {
 
     #[tokio::test]
     async fn replay_once_on_server_restarting() {
-        // First attempt: ServerRestarting. Probe says Ready returns Ok.
-        // Second attempt: Final.
-        // Expected: exactly one step retry; Status events for restarting
-        // and replaying; final Done; no terminal Error.
         let backend = ErrorInjectingBackend::new(
             vec![LlmError::ServerRestarting("boom".into())],
             vec![StepOutcome::Final],
@@ -1379,11 +1289,6 @@ mod tests {
 
     #[tokio::test]
     async fn replay_does_not_loop_on_repeated_server_restarting() {
-        // Two ServerRestarting in a row: the loop should retry once,
-        // see the second crash, and surface a terminal error rather
-        // than continue replaying. The supervisor's circuit-breaker
-        // (Degraded after 5 consecutive failures) is the daemon-level
-        // backstop; this test asserts the per-iteration cap.
         let backend = ErrorInjectingBackend::new(
             vec![
                 LlmError::ServerRestarting("second".into()),
@@ -1418,9 +1323,6 @@ mod tests {
 
     #[tokio::test]
     async fn replay_abandons_on_degraded_supervisor() {
-        // ServerRestarting once, but the probe reports Degraded.
-        // Expected: a `degraded` Status event followed by a terminal
-        // error. No second step call.
         let backend =
             ErrorInjectingBackend::new(vec![LlmError::ServerRestarting("dead".into())], vec![]);
         let probe = MockProbe::ready_with_wait_err(assistd_llm::HealthWaitError::Degraded);
@@ -1439,8 +1341,6 @@ mod tests {
             "expected a degraded Status event"
         );
         assert!(matches!(events.last(), Some(LlmEvent::Done)));
-        // Only one step call: wait_for_ready returned Err, so no
-        // replay step was attempted.
         assert_eq!(
             backend.step_calls.load(std::sync::atomic::Ordering::SeqCst),
             1

--- a/crates/assistd-core/src/lib.rs
+++ b/crates/assistd-core/src/lib.rs
@@ -66,7 +66,9 @@ pub use assistd_voice::{
 pub use assistd_wm::{NoWindowManager, WindowManager};
 
 pub use presence::{PresenceManager, RequestGuard};
-pub use state::{AppState, ConversationContext, MemoryStack, RuntimeState, Subsystems};
+pub use state::{
+    AppState, ConversationContext, McpStartupFailure, MemoryStack, RuntimeState, Subsystems,
+};
 
 use anyhow::{Context, Result};
 use assistd_embed::{EmbedJob, Embedder};

--- a/crates/assistd-core/src/lib.rs
+++ b/crates/assistd-core/src/lib.rs
@@ -175,8 +175,6 @@ pub fn build_tools(deps: BuildToolsDeps<'_>) -> Result<Arc<ToolRegistry>> {
     };
     let sandbox = probe_sandbox(sandbox_request, config.tools.bash.bwrap_extra_args.clone())?;
 
-    // Shlex-tokenize destructive patterns once so the hot path in
-    // `matches_destructive` doesn't re-parse them on every invocation.
     let destructive_patterns: Vec<Vec<String>> = config
         .tools
         .bash
@@ -191,8 +189,6 @@ pub fn build_tools(deps: BuildToolsDeps<'_>) -> Result<Arc<ToolRegistry>> {
         destructive_patterns,
     });
 
-    // Non-existent entries are dropped with a warning so a fresh install
-    // missing (say) `~/Documents` doesn't break the command entirely.
     let mut writable_paths: Vec<PathBuf> = Vec::new();
     for raw in &config.tools.write.writable_paths {
         let expanded = expand_config_tilde(raw);
@@ -252,8 +248,6 @@ pub fn build_tools(deps: BuildToolsDeps<'_>) -> Result<Arc<ToolRegistry>> {
     ));
     tools.register(ReminisceTool::new(embedder, semantic, embedding_model));
 
-    // MCP tools are registered last so a malicious server cannot shadow
-    // native tool names; the registry's linear lookup returns the first match.
     for t in mcp_tools {
         tools.register_boxed(t);
     }
@@ -331,8 +325,6 @@ impl VisionRevalidator {
     /// [`Self::revalidate`] so unit tests can drive the swap logic
     /// without standing up an HTTP server.
     pub async fn apply_probe(&self, probe: assistd_llm::VisionState) {
-        // No model id means the probe failed. Don't mutate the gate
-        // on a transient error; keep the last known good state.
         if probe.model_id.is_none() {
             return;
         }
@@ -366,9 +358,6 @@ mod vision_revalidator_tests {
             assistd_tools::VisionGate::new(gate_initial),
             cached_model.map(str::to_string),
             "127.0.0.1".to_string(),
-            // Port is unused in the apply_probe path; set to 0 to
-            // make a real revalidate() obviously fail loudly if anyone
-            // accidentally points the test at it.
             0,
             "test/model:Q4".to_string(),
         )
@@ -376,10 +365,6 @@ mod vision_revalidator_tests {
 
     #[tokio::test]
     async fn no_model_id_keeps_gate_unchanged() {
-        // Simulates a transient probe failure: probe_capabilities
-        // returns the default (None model id, false vision). The gate
-        // must stay where it was; flipping it on a network blip would
-        // disable vision mid-session.
         let rev = make_revalidator(true, Some("model-A"));
         rev.apply_probe(VisionState::default()).await;
         assert!(
@@ -393,8 +378,6 @@ mod vision_revalidator_tests {
         let rev = make_revalidator(true, Some("model-A"));
         rev.apply_probe(VisionState {
             model_id: Some("model-A".into()),
-            // Even if the new probe says false, no model swap means we
-            // don't disturb the gate; the same model can't lose vision.
             vision_supported: false,
         })
         .await;
@@ -425,9 +408,6 @@ mod vision_revalidator_tests {
 
     #[tokio::test]
     async fn fresh_revalidator_with_no_cached_model_still_picks_up_first_probe() {
-        // Daemon starts before the probe completes; the initial cache
-        // is None. When the first probe lands, we accept it as the
-        // baseline (None != Some) and update the gate to match.
         let rev = make_revalidator(false, None);
         rev.apply_probe(VisionState {
             model_id: Some("vision-model".into()),
@@ -438,9 +418,6 @@ mod vision_revalidator_tests {
     }
 }
 
-/// Expand a leading `~` / `~/` in a config-supplied path string using
-/// `$HOME`. Falls back to the literal path when `$HOME` is unset so the
-/// subsequent canonicalize call produces the diagnostic error.
 fn expand_config_tilde(raw: &str) -> PathBuf {
     if let Some(rest) = raw.strip_prefix("~/") {
         match std::env::var("HOME") {

--- a/crates/assistd-core/src/presence.rs
+++ b/crates/assistd-core/src/presence.rs
@@ -441,6 +441,41 @@ impl PresenceManager {
         bail!("failed to acquire active request guard after {MAX_RETRIES} retries")
     }
 
+    /// Variant of [`Self::acquire_request_guard`] that emits periodic
+    /// `Event::Status` updates while a wake transition is in progress.
+    ///
+    /// Without this, a cold-start wake (which can run for 30s+ while
+    /// llama-server loads weights) looks identical to a daemon hang
+    /// from the TUI's perspective. The progress emitter polls
+    /// [`Self::wake_in_progress`] every few seconds and sends an
+    /// `Event::Status` with the elapsed time so the user gets visible
+    /// feedback. Short wakes (those that complete before the first
+    /// tick) emit nothing, so the steady-state cost is zero.
+    pub async fn acquire_request_guard_with_progress(
+        self: &Arc<Self>,
+        request_id: String,
+        tx: tokio::sync::mpsc::Sender<assistd_ipc::Event>,
+    ) -> Result<RequestGuard> {
+        self.mark_activity();
+        const MAX_RETRIES: usize = 3;
+        for _ in 0..MAX_RETRIES {
+            let guard = self.inflight.clone().read_owned().await;
+            if self.state() == PresenceState::Active {
+                return Ok(RequestGuard { _guard: guard });
+            }
+            drop(guard);
+            let progress_task =
+                spawn_load_progress_emitter(Arc::clone(self), request_id.clone(), tx.clone());
+            let result = self.ensure_active().await;
+            progress_task.abort();
+            // Best-effort: wait for the abort to settle so we don't
+            // race with task drop. JoinError on Cancelled is expected.
+            let _ = progress_task.await;
+            result?;
+        }
+        bail!("failed to acquire active request guard after {MAX_RETRIES} retries")
+    }
+
     /// `Some(started_at)` if a wake transition is currently running;
     /// `None` otherwise. Used by the TUI to drive a "waking up"
     /// indicator during cold-start wakes (which can take tens of
@@ -770,6 +805,51 @@ impl PresenceManager {
         );
         Ok(())
     }
+}
+
+/// Period between model-load progress `Event::Status` emissions. Chosen so
+/// short wakes (already-Active fast path, sub-second drowse-to-active model
+/// reloads) emit nothing while a multi-minute cold-start gets ~1 update
+/// every 3s — enough for the TUI to update an elapsed-time indicator
+/// without flooding the channel.
+const LOAD_PROGRESS_INTERVAL: Duration = Duration::from_secs(3);
+
+/// Spawn a background task that emits `Event::Status` updates while
+/// `presence.wake_in_progress()` returns `Some(_)`. The task exits as
+/// soon as the wake completes (or is aborted by the caller); the first
+/// emission only happens after `LOAD_PROGRESS_INTERVAL`, so fast-path
+/// wakes incur no extra IPC traffic.
+fn spawn_load_progress_emitter(
+    presence: Arc<PresenceManager>,
+    request_id: String,
+    tx: tokio::sync::mpsc::Sender<assistd_ipc::Event>,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(LOAD_PROGRESS_INTERVAL);
+        // Skip the first immediate tick so sub-interval wakes stay quiet.
+        interval.tick().await;
+        loop {
+            interval.tick().await;
+            let Some(started) = presence.wake_in_progress() else {
+                return;
+            };
+            let elapsed_secs = started.elapsed().as_secs();
+            if tx
+                .send(assistd_ipc::Event::Status {
+                    id: request_id.clone(),
+                    severity: crate::recovery::RecoverySeverity::Info.as_str().to_string(),
+                    component: crate::recovery::Component::Llm.as_str().to_string(),
+                    event: "model_loading".to_string(),
+                    message: format!("loading model ({elapsed_secs}s elapsed)"),
+                })
+                .await
+                .is_err()
+            {
+                // Client disconnected; nothing left to report progress to.
+                return;
+            }
+        }
+    })
 }
 
 impl PresenceManager {

--- a/crates/assistd-core/src/presence.rs
+++ b/crates/assistd-core/src/presence.rs
@@ -206,22 +206,6 @@ impl PresenceManager {
         let current_inner_shutdown: Arc<StdMutex<Option<watch::Sender<bool>>>> =
             Arc::new(StdMutex::new(None));
 
-        // Forwarder: when daemon shutdown fires, flip whatever inner-shutdown
-        // sender is currently active. Lives for the daemon's lifetime.
-        //
-        // The `JoinHandle` is intentionally discarded: the task is bounded
-        // by the daemon-shutdown watch channel. It exits via one of two
-        // paths: `wait_for` returns `Ok` once shutdown fires (the normal
-        // case), or `Err` if every `watch::Sender` clone for daemon
-        // shutdown is dropped (which implies the daemon is already tearing
-        // down). `PresenceManager` also holds
-        // `daemon_shutdown_keepalive: watch::Receiver` below to keep
-        // the subscription valid for the manager's lifetime.
-        //
-        // Wrapped in `spawn_supervised` so a panic here (which would
-        // strand the daemon, since every inner shutdown lives off this
-        // forwarder) emits a structured recovery event instead of
-        // dying silently.
         {
             let mut daemon_rx = daemon_shutdown.clone();
             let current = Arc::clone(&current_inner_shutdown);
@@ -271,11 +255,6 @@ impl PresenceManager {
         *self.state.lock()
     }
 
-    /// Record that the user just interacted with the daemon. Called at
-    /// the top of every user-facing wrapper (`ensure_active`,
-    /// `set_presence`, `cycle`). Deliberately NOT called by the
-    /// low-level transition methods (`wake`/`drowse`/`sleep`) so that
-    /// automatic monitors (GPU, idle) don't defer their own progress.
     fn mark_activity(&self) {
         *self.last_activity.lock() = Instant::now();
     }
@@ -359,9 +338,6 @@ impl PresenceManager {
     /// to wait for the supervisor to bring the server back before
     /// re-running the LLM step.
     pub async fn wait_llama_ready(&self, budget: Duration) -> Result<(), HealthWaitError> {
-        // Snapshot the watch receiver under the async-mutex; we hold
-        // the lock only long enough to clone, then release so concurrent
-        // sleep/drowse can still take it.
         let mut rx = {
             let guard = self.llama.lock().await;
             match guard.as_ref() {
@@ -370,7 +346,6 @@ impl PresenceManager {
             }
         };
 
-        // Fast path: already Ready.
         if matches!(*rx.borrow(), ReadyState::Ready) {
             return Ok(());
         }
@@ -561,9 +536,6 @@ impl PresenceManager {
             return Ok(());
         }
 
-        // Wait for all in-flight requests to drop their read guards.
-        // Writer-preferring: new requests acquiring read guards after
-        // this point will block until the write guard is released.
         let _inflight = self.inflight.write().await;
 
         let started = Instant::now();
@@ -573,12 +545,6 @@ impl PresenceManager {
             let _ = tx.send(true);
         }
 
-        // Take the service out of its slot and join its supervisor task.
-        // Bound the join with `timeouts.presence_sleep_secs` so a wedged
-        // supervisor can't pin the transition lock indefinitely. On
-        // timeout we surface an error and rely on `kill_on_drop(true)`
-        // (set in process.rs::spawn) to send SIGKILL when the service
-        // handle drops with the original future.
         let service = self.llama.lock().await.take();
         if let Some(service) = service {
             let budget = Duration::from_secs(self.timeouts.presence_sleep_secs);
@@ -630,8 +596,6 @@ impl PresenceManager {
             PresenceState::Active => {}
         }
 
-        // Wait for all in-flight requests to drop their read guards
-        // before unloading model weights.
         let _inflight = self.inflight.write().await;
 
         let started = Instant::now();
@@ -681,9 +645,6 @@ impl PresenceManager {
             return Ok(());
         }
 
-        // Mark wake-in-progress for TUI. Placed *after* the short-circuit
-        // so idempotent wakes from Active don't briefly flicker the
-        // indicator.
         let _wake_marker = WakeMarker::new(Arc::clone(&self.wake_started));
 
         let started = Instant::now();
@@ -768,12 +729,6 @@ impl PresenceManager {
             PresenceState::Active => unreachable!("short-circuited above"),
         }
 
-        // `POST /models/load` returns 200 the moment the router accepts
-        // the spawn request — the child still needs to load weights and
-        // (for vision models) the mmproj. Without waiting here, the
-        // daemon's initial vision probe races the child startup and
-        // permanently reads `vision: off` even for vision-capable
-        // models. Poll `/models` until the entry flips to `loaded`.
         const LOAD_POLL_INTERVAL: Duration = Duration::from_millis(200);
         if let Err(e) = self
             .control
@@ -814,11 +769,6 @@ impl PresenceManager {
 /// without flooding the channel.
 const LOAD_PROGRESS_INTERVAL: Duration = Duration::from_secs(3);
 
-/// Spawn a background task that emits `Event::Status` updates while
-/// `presence.wake_in_progress()` returns `Some(_)`. The task exits as
-/// soon as the wake completes (or is aborted by the caller); the first
-/// emission only happens after `LOAD_PROGRESS_INTERVAL`, so fast-path
-/// wakes incur no extra IPC traffic.
 fn spawn_load_progress_emitter(
     presence: Arc<PresenceManager>,
     request_id: String,
@@ -980,11 +930,6 @@ mod tests {
 
     #[tokio::test]
     async fn cycle_from_sleeping_goes_to_active_logically() {
-        // `cycle` from Sleeping computes target=Active, then set_presence(Active)
-        // drives `wake`. With the stub, wake from Sleeping attempts a real
-        // cold-start and fails; we just assert the target selection by
-        // reading the next() helper directly here. Full cycle paths are
-        // exercised by integration with a live daemon.
         let start = PresenceState::Sleeping;
         assert_eq!(start.next(), PresenceState::Active);
     }
@@ -1013,17 +958,12 @@ mod tests {
         let m = PresenceManager::stub(PresenceState::Active);
         tokio::time::sleep(Duration::from_millis(50)).await;
         assert!(m.idle_duration() >= Duration::from_millis(40));
-        // set_presence(Active) from Active short-circuits in wake() but
-        // mark_activity still runs as the first line of set_presence.
         m.set_presence(PresenceState::Active).await.unwrap();
         assert!(m.idle_duration() < Duration::from_millis(20));
     }
 
     #[tokio::test]
     async fn cycle_resets_activity_timer() {
-        // Stub starts in Drowsy; cycle() computes target=Sleeping and
-        // calls set_presence(Sleeping) → sleep(), which is a pure
-        // local-state transition with no network I/O in the stub.
         let m = PresenceManager::stub(PresenceState::Drowsy);
         tokio::time::sleep(Duration::from_millis(50)).await;
         assert!(m.idle_duration() >= Duration::from_millis(40));
@@ -1033,10 +973,6 @@ mod tests {
 
     #[tokio::test]
     async fn wake_from_active_does_not_reset_activity_timer() {
-        // Low-level transition methods are called directly by automatic
-        // monitors (GPU, idle). They must NOT reset last_activity, or
-        // those automatic transitions would indefinitely defer their
-        // own forward progress.
         let m = PresenceManager::stub(PresenceState::Active);
         tokio::time::sleep(Duration::from_millis(50)).await;
         let before = m.idle_duration();
@@ -1124,10 +1060,6 @@ mod tests {
 
     #[tokio::test]
     async fn drowse_defers_for_inflight_request() {
-        // Same mechanism as sleep: the inflight write lock blocks
-        // drowse until all read guards drop. We only verify the block
-        // behaviour; the drowse itself will error on the dummy control
-        // client once it gets past the inflight wait, which is fine.
         let m = PresenceManager::stub(PresenceState::Active);
         let guard = m.acquire_request_guard().await.unwrap();
 
@@ -1141,8 +1073,6 @@ mod tests {
         );
 
         drop(guard);
-        // After drop, drowse completes (with Err from the dummy
-        // control client, since load/unload hit an unreachable port).
         let _ = tokio::time::timeout(Duration::from_secs(2), drowse_task)
             .await
             .expect("drowse did not unblock after guard dropped");
@@ -1200,10 +1130,6 @@ mod tests {
 
     #[tokio::test]
     async fn stream_guard_does_not_block_sleep() {
-        // Stream guards are a separate signal from the inflight RwLock;
-        // holding one must not prevent a concurrent sleep() from
-        // proceeding. sleep() will still block on a real RequestGuard
-        // via inflight, but that's a different path verified elsewhere.
         let m = PresenceManager::stub(PresenceState::Active);
         let _stream = m.acquire_stream_guard();
         let m2 = Arc::clone(&m);
@@ -1218,9 +1144,6 @@ mod tests {
 
     #[tokio::test]
     async fn wake_marker_cleared_on_error_path() {
-        // Wake from Drowsy calls `control.load_model`, which hits an
-        // unreachable port in the stub and returns Err. The RAII
-        // marker must still clear on the error path.
         let m = PresenceManager::stub(PresenceState::Drowsy);
         assert!(m.wake_in_progress().is_none());
         let err = m.wake().await;
@@ -1233,16 +1156,6 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn rapid_sleep_guard_loop_no_crash() {
-        // Stress the inflight RwLock + transition mutex interaction:
-        // many tasks take/release read guards while another loop calls
-        // sleep() and restores state via set_state_for_test. The stub
-        // can't cold-start wake, so the writer forces state back to
-        // Active after each sleep, which lets the retry loop in
-        // acquire_request_guard make progress. The point of the test
-        // is to confirm no deadlock or state corruption under churn,
-        // not to measure throughput. A generous wall-clock timeout
-        // wraps the whole workload. AC pin: 100 writer cycles complete
-        // without crash or deadlock.
         let m = PresenceManager::stub(PresenceState::Active);
 
         let mut readers = Vec::new();
@@ -1255,11 +1168,6 @@ mod tests {
                             tokio::task::yield_now().await;
                             drop(g);
                         }
-                        // Reader may observe Sleeping between writer's
-                        // sleep() completing and set_state_for_test(Active)
-                        // running; ensure_active() then fails in the
-                        // stub. Retry exhaustion is fine; just keep
-                        // going.
                         Err(_) => tokio::task::yield_now().await,
                     }
                 }
@@ -1275,8 +1183,6 @@ mod tests {
             }
         });
 
-        // Overall workload cap: if anything deadlocks, this trips and
-        // the test fails with a clear message rather than hanging.
         tokio::time::timeout(Duration::from_secs(30), async move {
             writer.await.expect("writer panicked");
             for r in readers {

--- a/crates/assistd-core/src/recovery.rs
+++ b/crates/assistd-core/src/recovery.rs
@@ -225,17 +225,17 @@ pub fn install_panic_hook(presence: Weak<PresenceManager>) {
             .as_ref()
             .and_then(|w| w.upgrade())
             .and_then(|p| p.llama_pid_blocking());
-        if let Some(pid) = pid_opt {
-            if let Some(pgid) = rustix::process::Pid::from_raw(pid as i32) {
-                let _ = rustix::process::kill_process_group(pgid, rustix::process::Signal::TERM);
-                recovery_event!(
-                    RecoverySeverity::Warning,
-                    Component::Llm,
-                    "panic_kill",
-                    pid = pid,
-                    "sent SIGTERM to llama-server process group from panic hook"
-                );
-            }
+        if let Some(pid) = pid_opt
+            && let Some(pgid) = rustix::process::Pid::from_raw(pid as i32)
+        {
+            let _ = rustix::process::kill_process_group(pgid, rustix::process::Signal::TERM);
+            recovery_event!(
+                RecoverySeverity::Warning,
+                Component::Llm,
+                "panic_kill",
+                pid = pid,
+                "sent SIGTERM to llama-server process group from panic hook"
+            );
         }
 
         previous(info);

--- a/crates/assistd-core/src/recovery.rs
+++ b/crates/assistd-core/src/recovery.rs
@@ -178,8 +178,6 @@ where
                 );
             }
             Err(join_err) if join_err.is_cancelled() => {
-                // Cancellation is normal during shutdown; do not
-                // promote to a recovery event.
                 ::tracing::debug!(
                     target: "assistd::recovery",
                     component = component.as_str(),
@@ -222,20 +220,12 @@ pub fn install_panic_hook(presence: Weak<PresenceManager>) {
             "daemon panic; killing llama-server before propagating"
         );
 
-        // Best-effort: try to SIGTERM the llama-server process group so
-        // the child doesn't outlive the daemon. We hold the lock only
-        // long enough to grab a strong ref + read the pid.
         let pid_opt = PRESENCE
             .lock()
             .as_ref()
             .and_then(|w| w.upgrade())
             .and_then(|p| p.llama_pid_blocking());
         if let Some(pid) = pid_opt {
-            // The child was started in its own session via `setsid`, so its
-            // pgid equals its pid. `kill_process_group` is the safe rustix
-            // wrapper around `killpg(2)`. We ignore the result: the child
-            // may have already exited between read and kill, and there is
-            // nothing actionable to do from a panic hook regardless.
             if let Some(pgid) = rustix::process::Pid::from_raw(pid as i32) {
                 let _ = rustix::process::kill_process_group(pgid, rustix::process::Signal::TERM);
                 recovery_event!(
@@ -285,18 +275,11 @@ mod tests {
         let handle = spawn_supervised("ok_task", Component::Daemon, async {
             tokio::task::yield_now().await;
         });
-        // The sentinel handle resolves once the inner task finishes.
-        // We don't assert any panic logging here; the absence of a
-        // panic event is the whole point.
         handle.await.expect("sentinel join");
     }
 
     #[tokio::test]
     async fn spawn_supervised_logs_on_panic() {
-        // We don't have a captured-subscriber harness wired here; the
-        // assertion is that the sentinel itself does not panic and
-        // resolves cleanly even when the inner task panicked. Visual
-        // verification via test-log output covers the message shape.
         let handle = spawn_supervised("panicker", Component::Llm, async {
             panic!("boom");
         });

--- a/crates/assistd-core/src/socket.rs
+++ b/crates/assistd-core/src/socket.rs
@@ -73,13 +73,6 @@ pub enum SocketError {
 /// as live to avoid clobbering it.
 const PROBE_TIMEOUT: Duration = Duration::from_secs(1);
 
-/// Decide what to do with an existing file at the would-be socket path.
-///
-/// Connect-probes the path: if the connect succeeds, a live daemon owns
-/// the socket and we must not unlink it. If the connect fails (refused,
-/// not-a-socket, etc.) the file is stale and we remove it. If the probe
-/// hangs past [`PROBE_TIMEOUT`] we assume "live" — better to refuse
-/// startup than rip an in-use socket out from under another process.
 async fn prepare_socket_path(path: &Path) -> Result<(), SocketError> {
     match path.try_exists() {
         Ok(false) => return Ok(()),
@@ -97,9 +90,6 @@ async fn prepare_socket_path(path: &Path) -> Result<(), SocketError> {
             path: path.to_path_buf(),
         }),
         Ok(Err(e)) => {
-            // ECONNREFUSED (no listener), ENOTSOCK (regular file at the
-            // path), or similar — all mean the file is leftover from a
-            // previous run and is safe to remove.
             warn!("removing stale socket file at {} ({})", path.display(), e);
             std::fs::remove_file(path).map_err(|source| SocketError::StaleCleanup {
                 path: path.to_path_buf(),
@@ -176,10 +166,6 @@ where
 {
     let grace = Duration::from_secs(state.config.daemon.shutdown_grace_secs);
     let mut connections: JoinSet<()> = JoinSet::new();
-    // Tracks whether the previous accept hit EMFILE/ENFILE so we log
-    // exactly once per incident (entry + recovery) instead of once per
-    // failed syscall — the latter floods the log channel and starves
-    // other tasks of the writer.
     let mut fd_exhausted = false;
 
     tokio::pin!(shutdown);
@@ -207,12 +193,6 @@ where
                         });
                     }
                     Err(e) if is_fd_exhaustion(&e) => {
-                        // Without a backoff this arm spins: the kernel
-                        // returns EMFILE synchronously every time we
-                        // call accept(), so the select! wakes again
-                        // immediately. Sleep gives reaping connections
-                        // a window to drop their FDs; suppress repeat
-                        // logs until accept() succeeds again.
                         if !fd_exhausted {
                             warn!(
                                 error = %e,
@@ -230,9 +210,6 @@ where
                     }
                 }
             }
-            // Reap finished connections eagerly so the set doesn't grow
-            // unbounded. `join_next` yields `None` when the set is empty,
-            // which would busy-loop; gate on `len()` to avoid that.
             Some(res) = connections.join_next(), if !connections.is_empty() => {
                 if let Err(e) = res
                     && e.is_panic()
@@ -243,9 +220,6 @@ where
         }
     }
 
-    // Stop accepting and drain in-flight handlers with bounded grace so
-    // streaming responses can emit their final `Done` event before the
-    // daemon exits.
     drop(listener);
 
     let in_flight = connections.len();
@@ -292,10 +266,6 @@ async fn handle_connection(stream: UnixStream, state: Arc<AppState>) -> Result<(
         debug!("client disconnected without sending a request");
         return Ok(());
     }
-    // `Take` signals "EOF" once the cap is hit, so a truncated frame
-    // arrives with no trailing newline. Reject it before we hand the
-    // partial bytes to serde_json (which would otherwise emit a
-    // misleading parse error).
     if !line.ends_with('\n') {
         let err = Event::Error {
             id: String::new(),
@@ -323,26 +293,10 @@ async fn handle_connection(stream: UnixStream, state: Arc<AppState>) -> Result<(
     let (tx, mut rx) = mpsc::channel::<Event>(EVENT_CHANNEL_CAPACITY);
     let dispatch_state = state.clone();
 
-    // Span carries the request id and kind so all child events emitted
-    // by `dispatch` (LLM stream, tool calls, TTS sentences) and by the
-    // forward loop are correlatable in `RUST_LOG=assistd=debug` output
-    // when several requests are in flight on different connections.
     let span = tracing::info_span!("ipc", id = %req.id(), req = req.kind());
 
-    // Per-connection router for mid-stream confirmation prompts. The
-    // `IpcConfirmationGate` (if installed in the daemon's tool registry)
-    // reads it from the `CONFIRM_ROUTER` task-local during dispatch;
-    // the read loop below routes inbound `Request::ConfirmResponse`
-    // lines to it. The wire channel is cloned so the router can emit
-    // its own `Event::ConfirmRequest` events into the same forward
-    // pipeline as dispatch.
     let router = ConfirmRouter::new(req.id().to_string(), tx.clone());
 
-    // Dispatch and event-forwarding run concurrently on this task rather
-    // than on a spawned child. If the task is cancelled (e.g. the outer
-    // accept loop hits its shutdown grace and calls `JoinSet::shutdown`),
-    // both halves are torn down together; the dispatcher can't be
-    // orphaned.
     let router_for_dispatch = router.clone();
     let dispatch_fut = async move {
         CONFIRM_ROUTER
@@ -356,14 +310,6 @@ async fn handle_connection(stream: UnixStream, state: Arc<AppState>) -> Result<(
         Ok::<_, SocketError>(write_half)
     };
 
-    // Read loop: drains additional client lines (mostly
-    // `Request::ConfirmResponse`, possibly nothing if the client is a
-    // legacy CLI that shut down its write half). Exits on EOF or
-    // I/O error so the connection can finish even if the client
-    // disconnects mid-stream. Every dispatched response routes
-    // through the router; unknown additional Requests are logged
-    // and ignored (we don't surface them to the client because
-    // doing so would muddle the streaming Event protocol).
     let router_for_reader = router.clone();
     let read_fut = async move {
         let mut buf = String::new();
@@ -386,9 +332,6 @@ async fn handle_connection(stream: UnixStream, state: Arc<AppState>) -> Result<(
                 }
             }
             if !buf.ends_with('\n') {
-                // `Take` hit its cap before the frame terminated.
-                // Stop reading further client input rather than try
-                // to resync mid-stream; dispatch continues to drain.
                 warn!(
                     bytes = buf.len(),
                     "mid-stream request exceeded {MAX_REQUEST_BYTES}-byte limit; closing read \
@@ -422,18 +365,10 @@ async fn handle_connection(stream: UnixStream, state: Arc<AppState>) -> Result<(
         }
     };
 
-    // Run dispatch + forward + read concurrently. When dispatch
-    // returns, drop the router so any still-pending oneshots resolve
-    // to "deny" (see `ConfirmRouter::ask`). The forward future then
-    // sees `rx.recv()` return None once both `tx` clones are dropped.
     let (dispatch_res, forward_res, _) = async {
         let read_handle = tokio::spawn(read_fut);
         let (d, f) = tokio::join!(dispatch_fut, forward_fut);
-        // dispatch is done; drop the router clone we held outside
-        // the task so the read loop's clone is the only remaining
-        // reference (we'll abort it next).
         drop(router);
-        // Stop reading more client input; dispatch is over.
         read_handle.abort();
         let _ = read_handle.await;
         (d, f, ())
@@ -470,10 +405,6 @@ mod tests {
 
     #[test]
     fn fd_exhaustion_predicate_matches_emfile_and_enfile() {
-        // Pinning the predicate is the load-bearing piece of the
-        // EMFILE-spin fix: misclassifying these as "Other" would
-        // route them through the silent `error!` arm and the loop
-        // would spin again with no backoff.
         let emfile = std::io::Error::from_raw_os_error(libc::EMFILE);
         let enfile = std::io::Error::from_raw_os_error(libc::ENFILE);
         assert!(
@@ -518,8 +449,6 @@ mod tests {
         panic!("listener at {} did not become ready", path.display());
     }
 
-    /// Send a raw request line and collect every event the daemon emits
-    /// until the stream terminates.
     async fn send_request_collect_events(path: &Path, body: &str) -> Vec<Event> {
         let stream = UnixStream::connect(path).await.unwrap();
         let (read, mut write) = stream.into_split();
@@ -623,16 +552,10 @@ mod tests {
 
     #[tokio::test]
     async fn oversize_request_is_rejected_without_oom() {
-        // A request larger than MAX_REQUEST_BYTES must be rejected
-        // with an Error event rather than buffered in full. We send
-        // MAX_REQUEST_BYTES + 1 bytes (no newline) so the daemon's
-        // `.take()` cap fires before any newline arrives.
         with_server(test_state(), |path| async move {
             let stream = UnixStream::connect(&path).await.unwrap();
             let (read, mut write) = stream.into_split();
 
-            // Send the cap + 1 bytes in chunks so we don't allocate
-            // the whole payload up front in the test process.
             let chunk = vec![b'a'; 1024 * 1024];
             let mut remaining = MAX_REQUEST_BYTES as usize + 1;
             while remaining > 0 {
@@ -644,7 +567,6 @@ mod tests {
                 }
                 remaining -= n;
             }
-            // Best-effort shutdown; daemon may already be closing.
             let _ = write.shutdown().await;
 
             let mut reader = BufReader::new(read);
@@ -724,11 +646,6 @@ mod tests {
 
     #[tokio::test]
     async fn listen_start_errors_with_no_continuous_listener_stub() {
-        // The default `test_state` builds with a `NoContinuousListener`
-        // whose `start()` is a hard error; this asserts the error
-        // propagation path. A real MicContinuousListener has different
-        // semantics (it actually starts) but needs cpal + whisper to
-        // exercise end-to-end.
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("assistd.sock");
         let (tx, rx) = oneshot::channel::<()>();
@@ -756,10 +673,6 @@ mod tests {
 
     #[tokio::test]
     async fn second_serve_refuses_to_clobber_live_socket() {
-        // Regression test for the socket-clobbering hazard: a live
-        // listener on the path must not have its socket ripped out by
-        // a second `serve_at` call. The second call must error with
-        // `AlreadyRunning`, and the first must keep serving requests.
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("assistd.sock");
         let (tx, rx) = oneshot::channel::<()>();
@@ -774,8 +687,6 @@ mod tests {
         });
         wait_for_listener(&path).await;
 
-        // Second attempt at the same path: must refuse, and must not
-        // unlink the live socket.
         let second_state = test_state();
         let err = serve_at(&path, second_state, std::future::pending::<()>())
             .await
@@ -789,7 +700,6 @@ mod tests {
             "live socket must remain after a refused second-bind attempt"
         );
 
-        // The first daemon is still healthy and serving requests.
         let events =
             send_request_collect_events(&path, r#"{"type":"query","id":"q","text":"ok"}"#).await;
         assert!(matches!(events.last(), Some(Event::Done { .. })));
@@ -901,8 +811,6 @@ mod tests {
                     text: "stuck".into(),
                 })
                 .await;
-            // Park forever; this future is cancelled when the parent
-            // task is aborted via JoinSet::shutdown.
             std::future::pending::<()>().await;
             Ok(())
         }
@@ -997,9 +905,6 @@ mod tests {
 
         tx.send(()).unwrap();
 
-        // All remaining Deltas and the terminal Done must still arrive
-        // before the stream closes, because grace (5s) comfortably
-        // exceeds the remaining ~100ms of backend work.
         let mut seen_delta = 1;
         let mut seen_done = false;
         loop {
@@ -1059,27 +964,12 @@ mod tests {
 
         tx.send(()).unwrap();
 
-        // Server task must exit promptly: the grace is 0, so the
-        // connection is aborted as soon as shutdown fires. Bound with
-        // a 2s timeout so a regression doesn't hang the test forever.
         tokio::time::timeout(std::time::Duration::from_secs(2), server)
             .await
             .expect("server did not exit within 2s of shutdown")
             .unwrap();
     }
 
-    // ---------------------------------------------------------------
-    // Wire-protocol contract tests: one happy (or expected-failure)
-    // path per `assistd_ipc::Request` variant. Each variant must
-    // produce a sensible event sequence terminated by `Done` or
-    // `Error`. Adding/renaming a variant should fail at least one of
-    // these tests, so a protocol regression is caught at CI time
-    // rather than at runtime in a TUI session.
-    // ---------------------------------------------------------------
-
-    /// Spin up `serve_at` against the given state, hand the socket
-    /// path to the body, then trigger shutdown and join the server.
-    /// Removes the boilerplate from per-variant tests below.
     async fn with_server<F, Fut, R>(state: Arc<AppState>, body: F) -> R
     where
         F: FnOnce(PathBuf) -> Fut,
@@ -1105,9 +995,6 @@ mod tests {
 
     #[tokio::test]
     async fn set_presence_to_sleeping_returns_presence_then_done() {
-        // Active → Sleeping is the stub-friendly path: it drops the
-        // (None) llama service and flips the state field. drowse()
-        // and Drowsy-bound wake() require a live HTTP server.
         with_server(test_state(), |path| async move {
             let events = send_request_collect_events(
                 &path,
@@ -1159,11 +1046,6 @@ mod tests {
 
     #[tokio::test]
     async fn cycle_from_active_attempts_drowse_and_errors_on_stub() {
-        // Cycle Active → Drowsy invokes `drowse()`, which calls
-        // `control.unload_model()` against the stub's bogus
-        // 127.0.0.1:1 endpoint. We don't care about the exact error
-        // text, only that the IPC layer surfaces it as an `Error`
-        // event with the matching id.
         with_server(test_state(), |path| async move {
             let events =
                 send_request_collect_events(&path, r#"{"type":"cycle","id":"cy-1"}"#).await;
@@ -1200,8 +1082,6 @@ mod tests {
         with_server(test_state(), |path| async move {
             let events =
                 send_request_collect_events(&path, r#"{"type":"ptt_stop","id":"ptt-2"}"#).await;
-            // ptt_stop emits VoiceState::Transcribing first, then
-            // surfaces the NoVoiceInput error.
             assert!(
                 matches!(
                     events.last(),
@@ -1215,9 +1095,6 @@ mod tests {
 
     #[tokio::test]
     async fn listen_stop_when_inactive_returns_listenstate_then_done() {
-        // NoContinuousListener::stop is idempotent: the daemon
-        // emits ListenState{active:false} + Done even when nothing
-        // was running.
         with_server(test_state(), |path| async move {
             let events =
                 send_request_collect_events(&path, r#"{"type":"listen_stop","id":"ls-stop"}"#)
@@ -1236,9 +1113,6 @@ mod tests {
 
     #[tokio::test]
     async fn listen_toggle_from_inactive_attempts_start_and_errors_on_stub() {
-        // Toggle delegates to start/stop based on `is_active()`. With
-        // NoContinuousListener inactive, toggle routes to start,
-        // which then errors with "not enabled".
         with_server(test_state(), |path| async move {
             let events =
                 send_request_collect_events(&path, r#"{"type":"listen_toggle","id":"lt-1"}"#).await;
@@ -1290,10 +1164,6 @@ mod tests {
         .await;
     }
 
-    /// Sending a `ConfirmResponse` as the *initial* request is a
-    /// protocol error: there's no in-flight prompt to satisfy. The
-    /// daemon surfaces it as `Event::Error` so a buggy client gets
-    /// a clear signal instead of a hang.
     #[tokio::test]
     async fn confirm_response_as_initial_request_returns_error() {
         with_server(test_state(), |path| async move {
@@ -1314,9 +1184,6 @@ mod tests {
         .await;
     }
 
-    /// A mid-stream `ConfirmResponse` whose `confirm_id` doesn't match
-    /// any pending prompt is logged + ignored; the daemon doesn't
-    /// crash and the original stream still terminates cleanly.
     #[tokio::test]
     async fn unmatched_mid_stream_confirm_response_does_not_crash() {
         let dir = tempfile::tempdir().unwrap();
@@ -1333,10 +1200,6 @@ mod tests {
         });
         wait_for_listener(&path).await;
 
-        // Open a Query connection without shutting the write half;
-        // the EchoBackend's stream is so fast that we may already see
-        // Done before our second write lands. That's fine; the test
-        // is "doesn't crash."
         let stream = UnixStream::connect(&path).await.unwrap();
         let (read, mut write) = stream.into_split();
         write
@@ -1344,9 +1207,6 @@ mod tests {
             .await
             .unwrap();
         write.write_all(b"\n").await.unwrap();
-        // Now send an unmatched ConfirmResponse: there is no
-        // in-flight prompt because the EchoBackend doesn't trigger
-        // tools.
         write
             .write_all(
                 br#"{"type":"confirm_response","id":"cr-x","confirm_id":"missing","allow":false}"#,
@@ -1371,8 +1231,6 @@ mod tests {
                 break;
             }
         }
-        // The Query still gets its Delta + Done. The unmatched
-        // ConfirmResponse is silently discarded by the read loop.
         assert!(
             matches!(events.last(), Some(Event::Done { id }) if id == "q1"),
             "got {events:?}"
@@ -1410,11 +1268,6 @@ mod tests {
 
     #[tokio::test]
     async fn concurrent_set_presence_to_sleeping_is_idempotent_under_fanout() {
-        // 32 connections each ask the daemon to enter Sleeping. The
-        // first one transitions Active → Sleeping; the rest hit the
-        // idempotency fast path and still receive Presence{Sleeping}
-        // + Done. Pins the invariant that the transition mutex
-        // serializes correctly under a connection storm.
         with_server(test_state(), |path| async move {
             let mut handles = Vec::new();
             for i in 0..32 {
@@ -1451,13 +1304,6 @@ mod tests {
 
     #[tokio::test]
     async fn mixed_query_and_set_presence_does_not_drop_events() {
-        // Half the connections issue Queries against SlowBackend (3
-        // deltas × 50ms ≈ 150ms); the other half issue idempotent
-        // SetPresence{Active} calls. Queries hold the inflight RwLock
-        // as readers; SetPresence takes the transition mutex. The
-        // target is Active (the stub's starting state) so auto-wake
-        // doesn't fire (the stub can't cold-start a llama-server).
-        // No connection should see an Error or miss its terminal Done.
         let state = state_with_backend_and_grace(
             Arc::new(SlowBackend {
                 deltas: 3,
@@ -1496,10 +1342,6 @@ mod tests {
 
     #[tokio::test]
     async fn duplicate_request_id_across_connections_does_not_leak_events() {
-        // Four connections each fire a Query with the literal id
-        // "shared". Per-connection event isolation means each socket
-        // sees Delta + Done with id="shared" and no extras from
-        // sibling connections. EchoBackend echoes text as one delta.
         with_server(test_state(), |path| async move {
             let mut handles = Vec::new();
             for i in 0..4 {
@@ -1535,10 +1377,6 @@ mod tests {
 
     #[tokio::test]
     async fn query_without_version_field_is_treated_as_legacy_v1() {
-        // Pre-versioning clients send Query without the optional
-        // `version` field. The daemon must accept it and stream a
-        // normal Delta + Done. This pins the additive-evolution
-        // contract for the protocol.
         with_server(test_state(), |path| async move {
             let events =
                 send_request_collect_events(&path, r#"{"type":"query","id":"legacy","text":"hi"}"#)
@@ -1554,10 +1392,6 @@ mod tests {
 
     #[tokio::test]
     async fn query_with_future_protocol_version_is_warned_but_accepted() {
-        // A client claiming a higher protocol version than the daemon
-        // knows about must still get a normal stream (additive
-        // evolution invariant). The daemon logs a warn (not asserted
-        // here) and proceeds.
         with_server(test_state(), |path| async move {
             let events = send_request_collect_events(
                 &path,

--- a/crates/assistd-core/src/socket.rs
+++ b/crates/assistd-core/src/socket.rs
@@ -321,8 +321,8 @@ async fn handle_connection(stream: UnixStream, state: Arc<AppState>) -> Result<(
                 .await
             {
                 Ok(0) => {
-                    // Half-close from the client (the legacy CLI
-                    // pattern). Exit cleanly.
+                    // Half-close from the client (one-shot CLI pattern).
+                    // Exit cleanly.
                     break;
                 }
                 Ok(_) => {}
@@ -1376,26 +1376,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn query_without_version_field_is_treated_as_legacy_v1() {
-        with_server(test_state(), |path| async move {
-            let events =
-                send_request_collect_events(&path, r#"{"type":"query","id":"legacy","text":"hi"}"#)
-                    .await;
-            assert!(
-                matches!(events.first(), Some(Event::Delta { id, .. }) if id == "legacy"),
-                "expected Delta, got {events:?}"
-            );
-            assert!(matches!(events.last(), Some(Event::Done { id }) if id == "legacy"));
-        })
-        .await;
-    }
-
-    #[tokio::test]
-    async fn query_with_future_protocol_version_is_warned_but_accepted() {
+    async fn query_ignores_unknown_top_level_fields() {
+        // Extra unrecognized fields on a Query payload (forward-compat
+        // hook for future additive evolution) must not break parsing.
         with_server(test_state(), |path| async move {
             let events = send_request_collect_events(
                 &path,
-                r#"{"type":"query","id":"future","text":"hi","version":99}"#,
+                r#"{"type":"query","id":"future","text":"hi","extra":"ignored"}"#,
             )
             .await;
             assert!(

--- a/crates/assistd-core/src/state/branches.rs
+++ b/crates/assistd-core/src/state/branches.rs
@@ -56,9 +56,6 @@ impl AppState {
                 .await;
             return Ok(());
         }
-        // Lock first, then drain; order matters: holding the lock
-        // prevents new persistence tasks from being spawned, then we
-        // wait for already-spawned ones to finish.
         let _agent_guard = self.runtime.agent_turn_lock.clone().lock_owned().await;
         self.drain_persistence_inflight().await;
 
@@ -145,8 +142,6 @@ impl AppState {
             }
         };
         let (active_session, _) = self.runtime.conversation_ctx.current().await;
-        // Active-session-first ordering: keep the original list_branches
-        // sort but pull active-session branches to the top.
         let mut active = Vec::new();
         let mut other = Vec::new();
         for b in branches {
@@ -283,9 +278,6 @@ impl AppState {
         };
         let (target_session, target_branch) = resolved;
 
-        // Update DB pointer first; if the daemon crashes between this
-        // and the in-memory swap, the next startup resumes the *new*
-        // active branch (consistent), not the old one.
         if let Err(e) = self
             .memory
             .conversations
@@ -403,10 +395,6 @@ impl AppState {
             }
         };
         if outcome.removed_messages > 0 {
-            // Mirror the deletion in the in-memory conversation. We
-            // call `truncate_to_last_real_user` rather than recompute
-            // from the DB because the DB is now authoritative; the
-            // backend's job is just to align.
             if let Err(e) = self.subsystems.llm.truncate_to_last_real_user().await {
                 tracing::warn!(
                     target: "assistd::state",
@@ -450,8 +438,6 @@ impl AppState {
             .await
             .ok()
             .flatten();
-        // Keep the current branch when it's either empty (nothing to
-        // stale-out) or its latest message landed within the window.
         let keep_current = match latest.as_deref() {
             None => true,
             Some(s) => chrono::DateTime::parse_from_rfc3339(s)

--- a/crates/assistd-core/src/state/branches.rs
+++ b/crates/assistd-core/src/state/branches.rs
@@ -394,14 +394,14 @@ impl AppState {
                 return Ok(());
             }
         };
-        if outcome.removed_messages > 0 {
-            if let Err(e) = self.subsystems.llm.truncate_to_last_real_user().await {
-                tracing::warn!(
-                    target: "assistd::state",
-                    error = %e,
-                    "truncate_to_last_real_user failed (non-fatal)"
-                );
-            }
+        if outcome.removed_messages > 0
+            && let Err(e) = self.subsystems.llm.truncate_to_last_real_user().await
+        {
+            tracing::warn!(
+                target: "assistd::state",
+                error = %e,
+                "truncate_to_last_real_user failed (non-fatal)"
+            );
         }
         let _ = tx
             .send(Event::UndoApplied {

--- a/crates/assistd-core/src/state/capabilities.rs
+++ b/crates/assistd-core/src/state/capabilities.rs
@@ -19,12 +19,6 @@ impl AppState {
         id: String,
         tx: mpsc::Sender<Event>,
     ) -> Result<()> {
-        // Surface any MCP-server startup failures as non-terminal Status
-        // events. Without this, a misconfigured server (typo'd binary
-        // path, missing dep) fails silently at boot and the user only
-        // discovers the problem when the model tries to invoke a tool.
-        // GetCapabilities is the TUI's on-connect probe, so warnings
-        // landing here hit the user during the first render.
         for failure in &self.subsystems.mcp_startup_failures {
             let _ = tx
                 .send(Event::Status {
@@ -40,12 +34,6 @@ impl AppState {
                 .await;
         }
 
-        // Router-aware probe: in router mode the configured host:port is
-        // just the router; the real /props (with `modalities`) lives on
-        // the child server. `probe_capabilities_routed` follows the
-        // indirection when present and degrades to the direct probe
-        // otherwise. Failure (e.g. transient client-build error) is
-        // surfaced as `vision: false` so the TUI shows the safe default.
         let probe = match assistd_llm::LlamaServerControl::new(
             &self.config.llama_server.host,
             self.config.llama_server.port,
@@ -67,10 +55,6 @@ impl AppState {
                 assistd_llm::VisionState::default()
             }
         };
-        // Match the TUI's old basename rendering: prefer the part after
-        // the last `/` (e.g. `Qwen3-14B-GGUF:Q4_K_M` from
-        // `bartowski/Qwen3-14B-GGUF:Q4_K_M`), fall back to the full
-        // string when there's no `/`.
         let model_name = self
             .config
             .model

--- a/crates/assistd-core/src/state/capabilities.rs
+++ b/crates/assistd-core/src/state/capabilities.rs
@@ -2,6 +2,7 @@
 //! reports vision support + model name.
 
 use super::AppState;
+use crate::recovery::{Component, RecoverySeverity};
 use anyhow::Result;
 use assistd_ipc::Event;
 use std::sync::Arc;
@@ -18,6 +19,27 @@ impl AppState {
         id: String,
         tx: mpsc::Sender<Event>,
     ) -> Result<()> {
+        // Surface any MCP-server startup failures as non-terminal Status
+        // events. Without this, a misconfigured server (typo'd binary
+        // path, missing dep) fails silently at boot and the user only
+        // discovers the problem when the model tries to invoke a tool.
+        // GetCapabilities is the TUI's on-connect probe, so warnings
+        // landing here hit the user during the first render.
+        for failure in &self.subsystems.mcp_startup_failures {
+            let _ = tx
+                .send(Event::Status {
+                    id: id.clone(),
+                    severity: RecoverySeverity::Warning.as_str().to_string(),
+                    component: Component::Mcp.as_str().to_string(),
+                    event: "startup_failed".to_string(),
+                    message: format!(
+                        "MCP server '{}' is not available: {}",
+                        failure.server_name, failure.reason
+                    ),
+                })
+                .await;
+        }
+
         // Router-aware probe: in router mode the configured host:port is
         // just the router; the real /props (with `modalities`) lives on
         // the child server. `probe_capabilities_routed` follows the

--- a/crates/assistd-core/src/state/context.rs
+++ b/crates/assistd-core/src/state/context.rs
@@ -31,16 +31,12 @@ impl AppState {
     /// Best-effort: errors propagate but the caller treats every failure
     /// (embedder down, dim mismatch, …) as "skip injection".
     pub(super) async fn build_semantic_context(&self, query: &str) -> Result<Option<String>> {
-        // Skip very short queries: no useful semantic signal in 1-2
-        // chars, and the cost of a wasted embed call is non-zero.
         if query.trim().chars().count() < 3 {
             return Ok(None);
         }
         let vec = self.memory.embedder.embed(query.to_string()).await?;
         let model = self.memory.embedder.model().to_string();
         if model.is_empty() {
-            // NoEmbedder path: model() == "" → never matches stored
-            // rows. Bail without a write.
             return Ok(None);
         }
         let top_k = self.memory.embedding_cfg.top_k as usize;
@@ -122,9 +118,6 @@ pub(super) fn format_window_context_block(
     let kind = if is_term { "terminal" } else { "non-terminal" };
     block.push_str(&format!("The user is interacting with a {kind} window."));
     if is_term {
-        // Bias the LLM toward in-place execution. Phrasing references
-        // the actual `run` tool's sub-command names so the model maps
-        // the hint cleanly onto its tool schema.
         block.push_str(
             " If the user asks to run a command, build, or test, prefer calling `run` \
              with `command: \"bash\"` (executing the command in this terminal context) over \

--- a/crates/assistd-core/src/state/memory_handlers.rs
+++ b/crates/assistd-core/src/state/memory_handlers.rs
@@ -16,8 +16,6 @@ impl AppState {
     ) -> Result<()> {
         let model = self.memory.embedder.model().to_string();
         if model.is_empty() {
-            // Embedding subsystem disabled: emit Done with no hits so
-            // the CLI sees a clean empty stream, not an error.
             let _ = tx.send(Event::Done { id }).await;
             return Ok(());
         }
@@ -82,10 +80,6 @@ impl AppState {
         tx: mpsc::Sender<Event>,
     ) -> Result<()> {
         match self.memory.memory_ops.save(&key, value).await {
-            // The IPC `MemorySave` handler doesn't surface the row id;
-            // its only callers are the `assistd memory save` CLI which
-            // just wants confirmation. Discard the id; the LLM tool
-            // (`RememberTool`) is the one that consumes it directly.
             Ok(_id) => {
                 let _ = tx.send(Event::Done { id }).await;
                 Ok(())
@@ -193,10 +187,6 @@ impl AppState {
     ) -> Result<()> {
         match self.memory.memory_ops.list_full(&prefix).await {
             Ok(rows) => {
-                // `limit = 0` means no cap (matches the wire convention
-                // used by other search-style memory variants). Otherwise
-                // truncate after the SQL has already ordered
-                // lexicographically by key.
                 let cap = if limit == 0 {
                     rows.len()
                 } else {
@@ -313,9 +303,6 @@ impl AppState {
         let chunks_total = chunks.len() as u32;
         let memories_total = memories.len() as u32;
 
-        // Always emit a kickoff progress for each kind so a client that
-        // only sees `(0, 0)` still learns the totals before receiving
-        // `Done`; useful when the run has nothing to do.
         let _ = tx
             .send(Event::ReindexProgress {
                 id: id.clone(),

--- a/crates/assistd-core/src/state/memory_stack.rs
+++ b/crates/assistd-core/src/state/memory_stack.rs
@@ -34,9 +34,6 @@ impl MemoryStack {
         let memory: Arc<dyn MemoryStore> = Arc::new(NoMemoryStore);
         let conversations: Arc<dyn ConversationStore> = Arc::new(NoConversationStore);
         let memory_ops = Arc::new(MemoryOps::new(memory.clone(), conversations.clone()));
-        // Closed channel: every `try_send` fails immediately so the
-        // persistence hook degrades to chunk-only behaviour when nothing
-        // else wires a real embedder task in.
         let (embed_tx, embed_rx) = mpsc::channel::<EmbedJob>(1);
         drop(embed_rx);
         Self {
@@ -102,11 +99,6 @@ mod tests {
 
     #[tokio::test]
     async fn with_memory_then_conversations_keeps_both_fields() {
-        // Cross-update invariant: chaining both builders in either order
-        // must leave the final stack with the supplied handles on the
-        // matching fields. This test pins that ordering doesn't drop
-        // either store; the `memory_ops` rebuild path is observed
-        // indirectly via the Arc::ptr_eq assertions.
         let m1: Arc<dyn MemoryStore> = Arc::new(NoMemoryStore);
         let c1: Arc<dyn ConversationStore> = Arc::new(NoConversationStore);
         let stack = MemoryStack::disabled(EmbeddingConfig::default())
@@ -118,9 +110,6 @@ mod tests {
 
     #[tokio::test]
     async fn with_conversations_before_memory_keeps_both_fields() {
-        // Same invariant, reverse order. Documents that the rebuild of
-        // `memory_ops` happens in BOTH `with_*` methods so the last one
-        // sees consistent inputs regardless of chain direction.
         let m1: Arc<dyn MemoryStore> = Arc::new(NoMemoryStore);
         let c1: Arc<dyn ConversationStore> = Arc::new(NoConversationStore);
         let stack = MemoryStack::disabled(EmbeddingConfig::default())

--- a/crates/assistd-core/src/state/mod.rs
+++ b/crates/assistd-core/src/state/mod.rs
@@ -169,12 +169,6 @@ impl AppState {
                 self.handle_resume_or_new(id, recency_secs, tx).await
             }
             Request::NewSession { id } => self.handle_new_session(id, tx).await,
-            // ConfirmResponse is intercepted by the connection-level
-            // read loop (see `assistd-core/src/socket.rs`) and routed to
-            // the active confirmation gate's pending oneshot. If we see
-            // it as the *initial* request on a fresh connection there
-            // is no in-flight prompt to satisfy; surface as an error
-            // so a buggy client gets a clear signal instead of timing out.
             Request::ConfirmResponse { id, confirm_id, .. } => {
                 let _ = tx
                     .send(Event::Error {
@@ -278,9 +272,6 @@ mod tests {
 
     #[tokio::test]
     async fn persistence_tracker_drains_in_flight_tasks() {
-        // AppState's persistence tracker must wait for spawned tasks to
-        // complete on shutdown drain. Spawn a slow task through the
-        // tracker; close+wait must block until that task finishes.
         let state = test_state(Arc::new(EchoBackend::new()), PresenceState::Active);
         let tracker = state.runtime.persistence_tracker_handle();
         let counter = Arc::new(AtomicUsize::new(0));
@@ -324,9 +315,6 @@ mod tests {
 
     #[tokio::test]
     async fn dispatch_set_presence_emits_presence_and_done() {
-        // Active → Sleeping avoids hitting the stub's non-existent
-        // control-plane endpoint while still exercising the transition
-        // path end-to-end.
         let state = test_state(Arc::new(EchoBackend::new()), PresenceState::Active);
         let (tx, rx) = mpsc::channel::<Event>(8);
         let req = Request::SetPresence {
@@ -367,9 +355,6 @@ mod tests {
 
     #[tokio::test]
     async fn dispatch_cycle_advances_to_next_state() {
-        // Drowsy → Sleeping: the Drowsy→Sleeping branch of `sleep()` is
-        // network-free when `llama` is None (as in the stub), so this
-        // exercises the full cycle path without a live server.
         let state = test_state(Arc::new(EchoBackend::new()), PresenceState::Drowsy);
         let (tx, rx) = mpsc::channel::<Event>(8);
         let req = Request::Cycle { id: "c1".into() };
@@ -486,9 +471,6 @@ mod tests {
 
     #[tokio::test]
     async fn dispatch_query_forwards_tool_call_and_result_events() {
-        // One tool call, then Final. We expect the forwarder to map
-        // LlmEvent::ToolCall → Event::ToolCall (with the request id),
-        // LlmEvent::ToolResult → Event::ToolResult, then Done.
         let backend = Arc::new(ScriptedBackend {
             outcomes: parking_lot::Mutex::new(vec![
                 StepOutcome::ToolCalls(vec![ToolCall {
@@ -638,9 +620,6 @@ mod tests {
 
     #[tokio::test]
     async fn dispatch_ptt_stop_with_text_runs_query() {
-        // Non-empty transcription should: emit Transcribing → Idle →
-        // Transcription(text), then dispatch as a Query (EchoBackend
-        // echoes the text), then terminal Done.
         let voice = Arc::new(MockVoice::new(Ok(()), Ok("hello world".into())));
         let state = state_with_voice(Arc::new(EchoBackend::new()), voice);
         let (tx, rx) = mpsc::channel::<Event>(16);
@@ -984,11 +963,6 @@ mod tests {
 
     #[tokio::test]
     async fn dispatch_query_speaks_sentences_in_order() {
-        // EchoBackend emits the input as a single Delta. SentenceBuffer
-        // pushes that into 4 sentences (3 from push, 1 from finish).
-        // The new per-query speech worker MUST consume them in arrival
-        // order; the previous fire-and-forget tokio::spawn pattern
-        // could scramble them based on synthesis time.
         let recorder = MockSpeechRecorder::new();
         let state = state_with_speech_recorder(
             Arc::new(EchoBackend::new()),
@@ -1095,12 +1069,6 @@ mod tests {
 
     #[tokio::test]
     async fn dispatch_query_partial_flush_after_idle() {
-        // Backend emits a partial sentence ("Half a sente"), then
-        // *stalls* for >partial_flush_ms, then completes ("nce. End.").
-        // With the idle flush enabled the partial cuts at the last
-        // whitespace ("Half a") and is spoken during the stall;
-        // "sentence." then completes naturally on resume; "End." on
-        // finish.
         let recorder = MockSpeechRecorder::new();
         let backend = StreamingDeltaBackend::new(vec![
             DeltaScript::Text("Half a sente"),
@@ -1138,9 +1106,6 @@ mod tests {
 
     #[tokio::test]
     async fn dispatch_query_partial_flush_zero_disables() {
-        // Same backend, same stall, but partial_flush_ms = 0 means no
-        // idle flush. Only the completed sentence and the final tail
-        // are spoken.
         let recorder = MockSpeechRecorder::new();
         let backend = StreamingDeltaBackend::new(vec![
             DeltaScript::Text("Half a sente"),
@@ -1227,8 +1192,6 @@ mod tests {
                     q.remove(0)
                 }
             };
-            // Emit pre-delta on the FIRST step (when ToolCalls is queued)
-            // and post-delta on Final.
             match &outcome {
                 StepOutcome::ToolCalls(_) => {
                     tx.send(LlmEvent::Delta {
@@ -1280,12 +1243,6 @@ mod tests {
 
     #[tokio::test]
     async fn dispatch_query_tool_call_inhibits_idle_flush() {
-        // Stream: Delta("Half a ") → ToolCall(sleep 300ms) →
-        //          ToolResult → Delta("done.") → Done.
-        // partial_flush_ms = 50 would fire 6+ times during the
-        // 300ms tool dispatch if not inhibited. With proper
-        // `awaiting_tool_result` tracking, only the final tail is
-        // spoken: "Half a done."
         let recorder = MockSpeechRecorder::new();
         let backend = ToolCallBackend::new(
             "Half a ",
@@ -1341,8 +1298,6 @@ mod tests {
 
     #[tokio::test]
     async fn dispatch_query_speech_worker_drains_before_return() {
-        // The worker's wait_idle() must be awaited before handle_query
-        // returns; otherwise daemon shutdown could cut off audio.
         let recorder = MockSpeechRecorder::new();
         let state = state_with_speech_recorder(
             Arc::new(EchoBackend::new()),
@@ -1372,8 +1327,6 @@ mod tests {
         title: Option<&str>,
         ws: Option<&str>,
     ) -> assistd_wm::FocusedWindowContext {
-        // PR 3b adds an `id: Option<WindowId>` field; the prompt
-        // formatter doesn't render it, so the helper leaves it None.
         assistd_wm::FocusedWindowContext {
             id: None,
             class: class.map(str::to_string),
@@ -1394,7 +1347,6 @@ mod tests {
         assert!(block.contains("- Focused window: Alacritty - nvim ~ src/main.rs\n"));
         assert!(block.contains("- Workspace: 2\n"));
         assert!(block.contains("interacting with a terminal window."));
-        // AC#3: hint references the actual `run` sub-command names.
         assert!(block.contains("`command: \"bash\"`"));
         assert!(block.contains("`command: \"wm\"`"));
     }
@@ -1414,7 +1366,6 @@ mod tests {
 
     #[test]
     fn format_window_context_block_omits_missing_fields() {
-        // Class only: no title bar, no workspace line.
         let block = format_window_context_block(&ctx(Some("Alacritty"), None, None)).expect("Some");
         assert!(block.contains("- Focused window: Alacritty\n"));
         assert!(!block.contains(" - "));
@@ -1444,8 +1395,6 @@ mod tests {
             Some("Current desktop context:\n- bar".into()),
         )
         .expect("Some");
-        // Trailing newline of semantic block trimmed; blank line inserted
-        // between the two blocks so the LLM sees clean separation.
         assert_eq!(
             merged,
             "Relevant past context:\n- foo\nCurrent desktop context:\n- bar"

--- a/crates/assistd-core/src/state/mod.rs
+++ b/crates/assistd-core/src/state/mod.rs
@@ -23,7 +23,7 @@ pub(crate) mod wire;
 
 pub use self::memory_stack::MemoryStack;
 pub use self::runtime::{ConversationContext, RuntimeState};
-pub use self::subsystems::Subsystems;
+pub use self::subsystems::{McpStartupFailure, Subsystems};
 
 /// Shared, long-lived daemon state handed to every request handler.
 ///

--- a/crates/assistd-core/src/state/mod.rs
+++ b/crates/assistd-core/src/state/mod.rs
@@ -115,22 +115,7 @@ impl AppState {
                 id,
                 text,
                 attachments,
-                version,
-            } => {
-                if let Some(v) = version {
-                    if v > assistd_ipc::PROTOCOL_VERSION {
-                        tracing::warn!(
-                            client = v,
-                            server = assistd_ipc::PROTOCOL_VERSION,
-                            "client sent newer protocol version than daemon understands; \
-                             extra fields will be ignored"
-                        );
-                    }
-                } else {
-                    tracing::debug!("client did not send protocol version; treating as legacy v1");
-                }
-                self.handle_query(id, text, attachments, tx).await
-            }
+            } => self.handle_query(id, text, attachments, tx).await,
             Request::SetPresence { id, target } => self.handle_set_presence(id, target, tx).await,
             Request::GetPresence { id } => self.handle_get_presence(id, tx).await,
             Request::Cycle { id } => self.handle_cycle(id, tx).await,
@@ -299,7 +284,6 @@ mod tests {
             id: "q1".into(),
             text: "hello".into(),
             attachments: Vec::new(),
-            version: None,
         };
 
         state.dispatch(req, tx).await.unwrap();
@@ -380,7 +364,6 @@ mod tests {
             id: "q-err".into(),
             text: "boom".into(),
             attachments: Vec::new(),
-            version: None,
         };
 
         let err = state.dispatch(req, tx).await.unwrap_err();
@@ -487,7 +470,6 @@ mod tests {
             id: "req-42".into(),
             text: "go".into(),
             attachments: Vec::new(),
-            version: None,
         };
         state.dispatch(req, tx).await.unwrap();
 
@@ -976,7 +958,6 @@ mod tests {
                     id: "ord".into(),
                     text: "First. Second. Third. End.".into(),
                     attachments: Vec::new(),
-                    version: None,
                 },
                 tx,
             )
@@ -1084,7 +1065,6 @@ mod tests {
                     id: "pf".into(),
                     text: "go".into(),
                     attachments: Vec::new(),
-                    version: None,
                 },
                 tx,
             )
@@ -1121,7 +1101,6 @@ mod tests {
                     id: "pf0".into(),
                     text: "go".into(),
                     attachments: Vec::new(),
-                    version: None,
                 },
                 tx,
             )
@@ -1276,7 +1255,6 @@ mod tests {
                     id: "tc".into(),
                     text: "go".into(),
                     attachments: Vec::new(),
-                    version: None,
                 },
                 tx,
             )
@@ -1311,7 +1289,6 @@ mod tests {
                     id: "drain".into(),
                     text: "Hello world.".into(),
                     attachments: Vec::new(),
-                    version: None,
                 },
                 tx,
             )

--- a/crates/assistd-core/src/state/persistence.rs
+++ b/crates/assistd-core/src/state/persistence.rs
@@ -37,10 +37,6 @@ impl AppState {
             chunk_chars: self.memory.embedding_cfg.chunk_chars,
             overlap_chars: self.memory.embedding_cfg.chunk_overlap_chars,
         };
-        // Snapshot what we need for chunking *before* moving `msg` into
-        // append_message. Tool-call assistant rows and tool-result rows
-        // skip chunking: the former have empty content, the latter are
-        // JSON-y noise that pollutes semantic search.
         let should_embed = embedding_enabled
             && chunks_handle.is_some()
             && matches!(msg.role, PersistedRole::User | PersistedRole::Assistant)
@@ -116,11 +112,6 @@ impl AppState {
     /// task has landed. Held inside `agent_turn_lock` so no new tasks
     /// can spawn during the wait.
     pub(super) async fn drain_persistence_inflight(&self) {
-        // `TaskTracker::wait()` on a *closed* tracker is permanent; we
-        // don't want to close it. Instead we just wait briefly via a
-        // probe; there's no public "wait for current tasks" API on
-        // the tracker. As a workaround, sample with a fixed budget:
-        // most persistence tasks finish in microseconds (one DB hop).
         let deadline = std::time::Instant::now() + std::time::Duration::from_millis(500);
         while !self.runtime.persistence_tracker.is_empty() && std::time::Instant::now() < deadline {
             tokio::time::sleep(std::time::Duration::from_millis(5)).await;

--- a/crates/assistd-core/src/state/query.rs
+++ b/crates/assistd-core/src/state/query.rs
@@ -164,7 +164,12 @@ impl AppState {
         id: &str,
         tx: &mpsc::Sender<Event>,
     ) -> Result<Option<QueryGuards>> {
-        let request = match self.subsystems.presence.acquire_request_guard().await {
+        let request = match self
+            .subsystems
+            .presence
+            .acquire_request_guard_with_progress(id.to_string(), tx.clone())
+            .await
+        {
             Ok(g) => g,
             Err(e) => {
                 let _ = tx

--- a/crates/assistd-core/src/state/query.rs
+++ b/crates/assistd-core/src/state/query.rs
@@ -51,39 +51,23 @@ impl AppState {
             .await?
         {
             Some(a) => a,
-            // prepare_attachments only returns Ok(None) for an
-            // explicitly-handled "decline" path that isn't reachable
-            // today; collapse to Ok so the dispatch loop sees a clean
-            // terminal Done.
             None => return Ok(()),
         };
         let Some(_session_guards) = self.acquire_query_guards(&id, &tx).await? else {
             return Ok(());
         };
-        // Serialize agent turns. Concurrent queries each wait here so
-        // one turn's assistant/tool_calls/tool_result triplet lands in
-        // conversation state atomically.
         let _agent_guard = self.runtime.agent_turn_lock.clone().lock_owned().await;
 
         let (current_session, turn_id) = self.open_persistence_turn(&text).await;
         self.assemble_transient_context(&text).await;
 
-        // Cancellation token: wired to the agent loop so a slow LLM
-        // step or tool dispatch can be preempted promptly. Drop guard
-        // fires the token when this function returns for any reason.
         let cancel = tokio_util::sync::CancellationToken::new();
         let _cancel_on_return = cancel.clone().drop_guard();
 
-        // Snapshot the user's prompt so the post-turn title-generation
-        // hook (Done arm in `drive_event_loop`) can summarise without
-        // racing `run_turn`, which moves `text`.
         let title_user_text = text.clone();
         let (llm_tx, llm_rx) = mpsc::channel::<LlmEvent>(32);
         let generator = self.spawn_agent_task(text, attachments, llm_tx, cancel.clone());
 
-        // Sentence buffer + speech worker. Each completed sentence is
-        // sent to a per-query worker task that calls voice_output.speak
-        // serially. Buffer = 32 ≈ 2 minutes of queued speech.
         let synthesis = &self.config.voice.synthesis;
         let sentence_buf = SentenceBuffer::new_with_mode(
             synthesis.max_sentence_chars as usize,
@@ -98,10 +82,6 @@ impl AppState {
         let start_epoch = self.subsystems.voice_output.current_epoch();
         let speech_handle = self.spawn_speech_worker(start_epoch, speech_rx);
 
-        // Drive the LlmEvent → Event loop. This both forwards wire
-        // events and feeds the speech worker; speech_tx is dropped
-        // inside the helper at end of stream so the worker drains
-        // remaining audio before exiting.
         self.clone()
             .drive_event_loop(
                 id.clone(),
@@ -116,8 +96,6 @@ impl AppState {
             )
             .await;
 
-        // The agent_turn_lock can be released as soon as the turn ends;
-        // concurrent queries shouldn't wait for audio playback to finish.
         let gen_result = generator.await;
         drop(_agent_guard);
 
@@ -125,11 +103,6 @@ impl AppState {
             .await
     }
 
-    /// Phase 1: revalidate vision support and decode wire attachments.
-    /// Always called on every turn (the probe is a single local HTTP
-    /// `GET /props` with a 2s timeout, mutating the gate only on
-    /// model swap). Returns `Err` on a bad attachment payload so the
-    /// caller fails before the GPU round-trip.
     async fn prepare_attachments(
         &self,
         id: &str,
@@ -153,12 +126,6 @@ impl AppState {
         }
     }
 
-    /// Phase 2: take the request + stream guards that keep presence
-    /// `Active` for the lifetime of the turn (including post-Done
-    /// audio). The agent-turn lock is acquired by the caller because
-    /// its drop timing differs (released early, after the LLM stream
-    /// ends). Returns `Ok(None)` only if the wake fails after an
-    /// `Event::Error` has already been emitted.
     async fn acquire_query_guards(
         &self,
         id: &str,
@@ -188,9 +155,6 @@ impl AppState {
         }))
     }
 
-    /// Phase 3: open a persistence turn and fire-and-forget the user
-    /// message. Returns `(session, turn_id)`. `turn_id` is `None`
-    /// when persistence is disabled (`NoConversationStore`).
     async fn open_persistence_turn(&self, text: &str) -> (Arc<SessionId>, Option<TurnId>) {
         let (current_session, _current_branch) = self.runtime.conversation_ctx.current().await;
         let turn_id: Option<TurnId> = match self
@@ -200,8 +164,6 @@ impl AppState {
             .await
         {
             Ok(t) if t.0 != 0 => Some(t),
-            // NoConversationStore returns TurnId(0); treat that as "no
-            // persistence configured" without logging.
             Ok(_) => None,
             Err(e) => {
                 tracing::warn!(
@@ -212,17 +174,10 @@ impl AppState {
                 None
             }
         };
-        // Mirror the user's prompt into the conversations table on the
-        // way to the LLM; fire-and-forget so the dispatch loop never
-        // waits on disk.
         self.persist_message_fire_and_forget(turn_id, PersistedMessage::user(text.to_string()));
         (current_session, turn_id)
     }
 
-    /// Phase 4: build the LLM's per-turn transient system message from
-    /// semantic recall + focused-window context, then push it. Both
-    /// sources are best-effort: any failure debug-logs and continues
-    /// (so a flaky compositor or embedder never blocks a turn).
     async fn assemble_transient_context(&self, text: &str) {
         let semantic = if self.memory.embedding_cfg.enabled && self.memory.embedding_cfg.auto_inject
         {
@@ -252,10 +207,6 @@ impl AppState {
         }
     }
 
-    /// Phase 5: spawn the agent task. Returns the join handle so the
-    /// orchestrator can await completion after the event loop drains.
-    /// The agent owns its own LLM and tool handles (cloned `Arc`s) so
-    /// the spawn doesn't borrow from `self`.
     fn spawn_agent_task(
         &self,
         text: String,
@@ -276,12 +227,6 @@ impl AppState {
         )
     }
 
-    /// Phase 6: spawn the per-query speech worker. The worker drains
-    /// the bounded `speech_rx` channel, honoring `should_speak` so a
-    /// later `skip()` / `interrupt()` drops every remaining sentence
-    /// for THIS query without affecting future ones. On channel close
-    /// it calls `wait_idle()` so the daemon doesn't tear down audio
-    /// mid-playback.
     fn spawn_speech_worker(
         &self,
         start_epoch: u64,
@@ -293,8 +238,6 @@ impl AppState {
                 while let Some(sentence) = speech_rx.recv().await {
                     match ctrl.should_speak(start_epoch) {
                         SpeakDecision::Speak => {
-                            // Truncate the snippet for logging; a long
-                            // sentence in the log line clutters the journal.
                             let preview: String = sentence.chars().take(60).collect();
                             if let Err(e) = ctrl.inner().speak(sentence).await {
                                 tracing::warn!(
@@ -323,13 +266,6 @@ impl AppState {
         )
     }
 
-    /// Phase 7: the `LlmEvent` → `Event` translation loop. Consumes
-    /// `llm_rx`, forwards wire events to the IPC `tx`, feeds completed
-    /// sentences into `speech_tx`, accumulates assistant text for
-    /// persistence boundaries, and inhibits the idle flush during a
-    /// tool call. `speech_tx` is moved by value so it drops at end of
-    /// this function — that signals the speech worker to wait_idle
-    /// and exit.
     #[allow(clippy::too_many_arguments)]
     async fn drive_event_loop(
         self: Arc<Self>,
@@ -343,14 +279,8 @@ impl AppState {
         title_user_text: String,
         current_session: Arc<SessionId>,
     ) {
-        // Tool calls inhibit the idle-flush: the LLM is waiting on a
-        // tool, not stalled mid-prose. Without this, a long-running
-        // bash command would trigger spurious mid-sentence flushes.
         let mut awaiting_tool_result = false;
 
-        // Persistence accumulator: tee every `LlmEvent::Delta` into
-        // this string so the assistant's full reply gets written as
-        // one row at end-of-turn. Cleared on each Tool/Done flush.
         let mut assistant_accum = String::new();
 
         let mut client_alive = true;
@@ -381,8 +311,6 @@ impl AppState {
                 },
             };
 
-            // Wire events are forwarded before speech_tx.send so client
-            // display latency stays independent of TTS backpressure.
             let (wire_event, sentences_to_speak): (Event, Vec<String>) = match llm_event {
                 LlmEvent::Delta { text } => {
                     let sentences = sentence_buf.push(&text);
@@ -412,9 +340,6 @@ impl AppState {
                     arguments,
                 } => {
                     awaiting_tool_result = true;
-                    // Flush any narration we'd accumulated so the
-                    // pre-tool-call assistant text doesn't get glued
-                    // onto the tool result downstream.
                     if !assistant_accum.is_empty() {
                         let pre_text = std::mem::take(&mut assistant_accum);
                         self.persist_message_fire_and_forget(
@@ -470,9 +395,6 @@ impl AppState {
                     event,
                     message,
                 } => {
-                    // On a recoverable restart, drop any partial
-                    // accumulator state so a successful replay isn't
-                    // persisted as `<partial><replay>` concatenated.
                     if event == "restarting" {
                         assistant_accum.clear();
                         let _ = sentence_buf.finish();
@@ -498,9 +420,6 @@ impl AppState {
                             PersistedMessage::assistant_text(final_text),
                         );
                     }
-                    // Kick off LLM title summarisation in the background.
-                    // The helper short-circuits when a title is already
-                    // set, so this is cheap on every-turn-but-the-first.
                     self.clone().spawn_session_title_generation(
                         current_session.clone(),
                         title_user_text.clone(),
@@ -532,21 +451,11 @@ impl AppState {
             }
 
             if !client_alive {
-                // Stop pulling from llm_rx so the agent loop's
-                // `tx.is_closed()` check fires at its next iteration
-                // boundary. The speech worker keeps draining queued
-                // audio (speech_tx still alive until function return).
                 break;
             }
         }
-        // speech_tx drops here, signalling the worker to wait_idle()
-        // and exit; playback finishes naturally.
     }
 
-    /// Phase 8: end the persisted turn (if any), await the speech
-    /// worker so audio playback completes inside the still-active
-    /// presence guards, and translate the agent's `JoinHandle` result
-    /// into the dispatch loop's `Result`.
     async fn finalize_turn(
         &self,
         turn_id: Option<TurnId>,
@@ -569,8 +478,6 @@ impl AppState {
             });
         }
 
-        // _session_guards (held by caller) are still alive so presence
-        // stays Active through playback.
         let _ = speech_handle.await;
 
         match gen_result {

--- a/crates/assistd-core/src/state/subsystems.rs
+++ b/crates/assistd-core/src/state/subsystems.rs
@@ -12,6 +12,19 @@ use assistd_voice::{ContinuousListener, VoiceInput, VoiceOutputController};
 use assistd_wm::{NoWindowManager, WindowManager};
 use std::sync::Arc;
 
+/// One MCP server that failed to start or complete tool discovery during
+/// daemon boot. Retained on [`Subsystems`] so the daemon can surface the
+/// failure to connected clients via `Event::Status` instead of leaving
+/// users to discover broken servers only when the model invokes a tool.
+#[derive(Debug, Clone)]
+pub struct McpStartupFailure {
+    /// Configured server name (matches `mcp.servers[].name`).
+    pub server_name: String,
+    /// Human-readable reason for the failure, suitable for the TUI to
+    /// render verbatim (e.g. `"binary not found at /usr/bin/foo-mcp"`).
+    pub reason: String,
+}
+
 pub struct Subsystems {
     pub llm: Arc<dyn LlmBackend>,
     pub presence: Arc<PresenceManager>,
@@ -21,6 +34,8 @@ pub struct Subsystems {
     pub voice_output: Arc<VoiceOutputController>,
     pub window_manager: Arc<dyn WindowManager>,
     pub vision_revalidator: Option<Arc<crate::VisionRevalidator>>,
+    /// MCP servers that failed at boot. Empty in the happy path.
+    pub mcp_startup_failures: Vec<McpStartupFailure>,
 }
 
 impl Subsystems {
@@ -45,6 +60,7 @@ impl Subsystems {
             voice_output,
             window_manager: Arc::new(NoWindowManager),
             vision_revalidator: None,
+            mcp_startup_failures: Vec::new(),
         }
     }
 
@@ -55,6 +71,11 @@ impl Subsystems {
 
     pub fn with_vision_revalidator(mut self, r: Arc<crate::VisionRevalidator>) -> Self {
         self.vision_revalidator = Some(r);
+        self
+    }
+
+    pub fn with_mcp_startup_failures(mut self, failures: Vec<McpStartupFailure>) -> Self {
+        self.mcp_startup_failures = failures;
         self
     }
 }

--- a/crates/assistd-core/src/state/voice_handlers.rs
+++ b/crates/assistd-core/src/state/voice_handlers.rs
@@ -19,9 +19,6 @@ impl AppState {
         id: String,
         tx: mpsc::Sender<Event>,
     ) -> Result<()> {
-        // Barge-in: stop any in-flight TTS playback before opening the
-        // mic. Fire unconditionally; even if recording is rejected
-        // below, the user signaled "shut up", which we should honor.
         self.subsystems.voice_output.interrupt().await;
         if self.subsystems.listener.is_active() {
             let _ = tx
@@ -34,10 +31,6 @@ impl AppState {
         }
         match self.subsystems.voice.start_recording().await {
             Ok(()) => {
-                // Kick off the presence wake in parallel with capture so a
-                // Drowsy → Active model load runs during Whisper inference.
-                // `ensure_active` is idempotent; the second call from
-                // `acquire_request_guard` short-circuits to a single RwLock read.
                 let presence = self.subsystems.presence.clone();
                 let warm =
                     tokio::spawn(async move { presence.ensure_active().await }.in_current_span());
@@ -242,10 +235,6 @@ impl AppState {
             })
             .await;
 
-        // The warmup was spawned at PTT-start; joining it concurrently with
-        // Whisper means a Drowsy → Active model load runs during transcription
-        // rather than serially after it. A failed warmup is non-fatal; the
-        // request guard in `handle_query` will retry the wake.
         let warmup = self.runtime.warmup_handle.lock().await.take();
         let (text_res, warm_res) =
             tokio::join!(self.subsystems.voice.stop_and_transcribe(), async {

--- a/crates/assistd-embed/src/client.rs
+++ b/crates/assistd-embed/src/client.rs
@@ -69,8 +69,6 @@ impl LlamaEmbedder {
             .context("build embed reqwest client")?;
         let base_url = format!("http://{host}:{port}");
 
-        // Probe dim with a one-token request. Any failure here is fatal;
-        // the daemon's try-warn-fallback path will swap in NoEmbedder.
         let probe = embed_raw(&client, &base_url, &model, "x").await?;
         let dim = probe.len();
         if dim == 0 {

--- a/crates/assistd-embed/src/embedder_task.rs
+++ b/crates/assistd-embed/src/embedder_task.rs
@@ -152,7 +152,6 @@ mod tests {
     use async_trait::async_trait;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
-    /// Mock that returns a fixed vector and counts calls.
     struct MockEmbedder {
         calls: AtomicUsize,
         vec: Vec<f32>,
@@ -208,7 +207,6 @@ mod tests {
             _ => panic!("expected StoreChunkEmbedding"),
         }
 
-        // Shutdown so the task exits cleanly.
         sd_tx.send(true).unwrap();
         drop(job_tx);
         let _ = tokio::time::timeout(std::time::Duration::from_secs(2), task).await;
@@ -256,7 +254,6 @@ mod tests {
         let (job_tx, job_rx) = mpsc::channel::<EmbedJob>(8);
         let (sd_tx, sd_rx) = watch::channel(false);
 
-        // Pre-load 3 jobs before the worker starts.
         for i in 0..3 {
             job_tx
                 .send(EmbedJob::Chunk {
@@ -272,7 +269,6 @@ mod tests {
         sd_tx.send(true).unwrap();
         drop(job_tx);
 
-        // Collect 3 writes, ack each.
         for _ in 0..3 {
             let op = tokio::time::timeout(std::time::Duration::from_secs(2), write_rx.recv())
                 .await

--- a/crates/assistd-embed/src/server/process.rs
+++ b/crates/assistd-embed/src/server/process.rs
@@ -88,10 +88,10 @@ impl ChildProcess {
     /// `term_timeout`, then SIGKILL if still running.
     pub async fn shutdown(mut self, term_timeout: Duration) -> Result<(), EmbedServerError> {
         #[cfg(unix)]
-        if let Some(pid) = self.child.id() {
-            if let Some(pgid) = rustix::process::Pid::from_raw(pid as i32) {
-                let _ = rustix::process::kill_process_group(pgid, rustix::process::Signal::TERM);
-            }
+        if let Some(pid) = self.child.id()
+            && let Some(pgid) = rustix::process::Pid::from_raw(pid as i32)
+        {
+            let _ = rustix::process::kill_process_group(pgid, rustix::process::Signal::TERM);
         }
 
         match tokio::time::timeout(term_timeout, self.child.wait()).await {

--- a/crates/assistd-embed/src/server/process.rs
+++ b/crates/assistd-embed/src/server/process.rs
@@ -23,15 +23,6 @@ impl ChildProcess {
     ///
     /// Returns [`EmbedServerError::Spawn`] if the process cannot be started.
     pub fn spawn(cfg: &EmbeddingConfig) -> Result<Self, EmbedServerError> {
-        // The embedding server is NOT in router mode. We pass `--hf-repo`
-        // directly so the model is downloaded once and held resident for
-        // the daemon's lifetime, so embedding requests should be cheap.
-        // `--embedding` enables the `/v1/embeddings` endpoint.
-        //
-        // We also pass `--pooling mean` to make the endpoint match the
-        // OpenAI-compatible response shape that nomic / bge models use.
-        // (Without it, llama.cpp returns per-token vectors instead of one
-        // sentence vector.)
         let mut cmd = Command::new("llama-server");
         cmd.arg("--embedding")
             .arg("--pooling")
@@ -52,7 +43,6 @@ impl ChildProcess {
 
         #[cfg(unix)]
         {
-            // Process group so SIGTERM to -pid takes down any grandchildren.
             cmd.process_group(0);
         }
 
@@ -99,10 +89,6 @@ impl ChildProcess {
     pub async fn shutdown(mut self, term_timeout: Duration) -> Result<(), EmbedServerError> {
         #[cfg(unix)]
         if let Some(pid) = self.child.id() {
-            // Child was spawned with `process_group(0)`, so its pgid equals
-            // its pid. `kill_process_group` is the safe rustix wrapper
-            // around `killpg(2)`; we ignore the result because the child
-            // may have already exited.
             if let Some(pgid) = rustix::process::Pid::from_raw(pid as i32) {
                 let _ = rustix::process::kill_process_group(pgid, rustix::process::Signal::TERM);
             }

--- a/crates/assistd-ipc/src/client.rs
+++ b/crates/assistd-ipc/src/client.rs
@@ -7,9 +7,9 @@
 //!
 //! Two connection shapes are supported:
 //!
-//! - [`IpcClient::one_shot`]: legacy "send one Request, shutdown write
-//!   half, read until terminal Event". The vast majority of CLI calls
-//!   take this path.
+//! - [`IpcClient::one_shot`]: "send one Request, shutdown write half,
+//!   read until terminal Event". The vast majority of CLI calls take
+//!   this path.
 //! - [`IpcClient::open_dialog`]: bidirectional. The connection stays
 //!   write-open after the initial Request so the client can answer
 //!   mid-stream prompts (e.g. [`Request::ConfirmResponse`]) on the same

--- a/crates/assistd-ipc/src/client.rs
+++ b/crates/assistd-ipc/src/client.rs
@@ -233,9 +233,6 @@ mod tests {
     /// JoinHandle the test should await once it's done.
     async fn mock_server(responses: Vec<Event>) -> (PathBuf, tokio::task::JoinHandle<()>) {
         let dir = tempfile::tempdir().unwrap();
-        // Leak the tempdir so the socket file survives until process
-        // exit; tests don't bother to clean up explicitly and this
-        // avoids the dir being dropped before the connection completes.
         let path = dir.path().join("mock.sock");
         std::mem::forget(dir);
 
@@ -253,15 +250,10 @@ mod tests {
                 write.write_all(out.as_bytes()).await.unwrap();
             }
             write.flush().await.unwrap();
-            // Half-close so the client's read returns Ok(None) instead
-            // of "connection reset by peer" on the next poll.
             write.shutdown().await.unwrap();
             drop(listener);
         });
 
-        // Yield once so the spawned task gets a chance to bind+accept.
-        // The path already exists from `bind`; an explicit connect
-        // would consume the only `accept()` on this listener.
         tokio::task::yield_now().await;
         (path, h)
     }
@@ -302,7 +294,6 @@ mod tests {
 
     #[tokio::test]
     async fn collect_errors_on_premature_close() {
-        // Server sends one delta and closes; no terminal event.
         let (path, _h) = mock_server(vec![Event::Delta {
             id: "r".into(),
             text: "incomplete".into(),
@@ -316,8 +307,6 @@ mod tests {
 
     #[tokio::test]
     async fn dialog_can_send_after_initial_request() {
-        // Server: read initial request, send a ConfirmRequest event,
-        // then read a ConfirmResponse and echo Done.
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("dialog.sock");
         let listener = UnixListener::bind(&path).unwrap();
@@ -325,12 +314,11 @@ mod tests {
             let (stream, _) = listener.accept().await.unwrap();
             let (read, mut write) = stream.into_split();
             let mut reader = BufReader::new(read);
-            // Read initial Request::Query.
+
             let mut first = String::new();
             reader.read_line(&mut first).await.unwrap();
             let _: Request = serde_json::from_str(first.trim()).unwrap();
 
-            // Emit a ConfirmRequest event.
             let cr = Event::ConfirmRequest {
                 id: "r".into(),
                 confirm_id: "c1".into(),
@@ -343,20 +331,17 @@ mod tests {
             write.write_all(out.as_bytes()).await.unwrap();
             write.flush().await.unwrap();
 
-            // Read the client's ConfirmResponse.
             let mut second = String::new();
             reader.read_line(&mut second).await.unwrap();
             let req: Request = serde_json::from_str(second.trim()).unwrap();
             assert!(matches!(req, Request::ConfirmResponse { allow: true, .. }));
 
-            // Emit Done.
             let mut done = serde_json::to_string(&Event::Done { id: "r".into() }).unwrap();
             done.push('\n');
             write.write_all(done.as_bytes()).await.unwrap();
             write.flush().await.unwrap();
         });
 
-        // Yield so the spawned listener task starts before we connect.
         tokio::task::yield_now().await;
 
         let client = IpcClient::with_path(&path);

--- a/crates/assistd-ipc/src/lib.rs
+++ b/crates/assistd-ipc/src/lib.rs
@@ -653,8 +653,6 @@ pub fn socket_path() -> PathBuf {
     )
 }
 
-/// Pure resolver: env reads happen at the boundary so this can be tested
-/// without mutating process-global state.
 fn socket_path_for(xdg_runtime_dir: Option<OsString>, user: Option<OsString>) -> PathBuf {
     if let Some(dir) = xdg_runtime_dir {
         let mut p = PathBuf::from(dir);
@@ -673,9 +671,6 @@ mod tests {
 
     #[test]
     fn request_roundtrip() {
-        // Legacy struct-literal form: empty attachments + no version are
-        // both skipped on serialize so the wire shape is unchanged from
-        // pre-multimodality clients.
         let req = Request::Query {
             id: "req-1".into(),
             text: "ping".into(),
@@ -714,9 +709,6 @@ mod tests {
 
     #[test]
     fn legacy_query_payload_deserializes_with_default_attachments() {
-        // A pre-multimodality client emits the original two-field shape.
-        // Older daemons keep accepting it: attachments defaults to empty,
-        // version defaults to None.
         let json = r#"{"type":"query","id":"req-4","text":"hello"}"#;
         let parsed: Request = serde_json::from_str(json).unwrap();
         match parsed {
@@ -950,9 +942,6 @@ mod tests {
 
     #[test]
     fn memory_list_all_request_omits_optional_fields() {
-        // Both `prefix` and `limit` use `#[serde(default)]`, so a
-        // pre-feature client that only sends `id` should still parse
-        // (additive evolution).
         let json = r#"{"type":"memory_list_all","id":"r"}"#;
         let parsed: Request = serde_json::from_str(json).unwrap();
         match parsed {

--- a/crates/assistd-ipc/src/lib.rs
+++ b/crates/assistd-ipc/src/lib.rs
@@ -34,12 +34,6 @@ pub mod client;
 #[cfg(feature = "client")]
 pub use client::{DialogConnection, EventStream, IpcClient, IpcClientError};
 
-/// Wire-protocol version. Bumped when an existing field's semantics
-/// change in a non-additive way; new optional fields don't bump this.
-/// Servers log a warning and continue when they see a version they
-/// don't understand, so additive evolution stays compatible.
-pub const PROTOCOL_VERSION: u32 = 1;
-
 /// An image attachment carried over the wire alongside a [`Request::Query`].
 /// `data_base64` is standard base64 (with padding); the daemon decodes
 /// it back into raw bytes before handing it to the LLM. `mime` is one of
@@ -123,15 +117,9 @@ pub enum Request {
         id: String,
         text: String,
         /// Image attachments to surface as vision inputs on this turn.
-        /// Empty for text-only queries; deserializes from missing fields
-        /// for backward compat.
+        /// Empty for text-only queries.
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         attachments: Vec<ImageAttachment>,
-        /// Wire-protocol version the client speaks. None means a
-        /// legacy client (pre-versioning); the daemon accepts these
-        /// for now but logs a warning.
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        version: Option<u32>,
     },
     /// Drive the daemon to a specific presence state.
     SetPresence { id: String, target: PresenceState },
@@ -288,21 +276,16 @@ pub enum Request {
 }
 
 impl Request {
-    /// Build a text-only [`Request::Query`] tagged with the current
-    /// [`PROTOCOL_VERSION`]. Use this in clients to keep call sites
-    /// short; legacy struct-literal construction still works for
-    /// callers that need to set `attachments` explicitly.
+    /// Build a text-only [`Request::Query`].
     pub fn query(id: impl Into<String>, text: impl Into<String>) -> Self {
         Request::Query {
             id: id.into(),
             text: text.into(),
             attachments: Vec::new(),
-            version: Some(PROTOCOL_VERSION),
         }
     }
 
-    /// Build a [`Request::Query`] with one or more image attachments,
-    /// tagged with the current [`PROTOCOL_VERSION`].
+    /// Build a [`Request::Query`] with one or more image attachments.
     pub fn query_with_attachments(
         id: impl Into<String>,
         text: impl Into<String>,
@@ -312,7 +295,6 @@ impl Request {
             id: id.into(),
             text: text.into(),
             attachments,
-            version: Some(PROTOCOL_VERSION),
         }
     }
 
@@ -675,7 +657,6 @@ mod tests {
             id: "req-1".into(),
             text: "ping".into(),
             attachments: Vec::new(),
-            version: None,
         };
         let json = serde_json::to_string(&req).unwrap();
         assert_eq!(json, r#"{"type":"query","id":"req-1","text":"ping"}"#);
@@ -684,7 +665,7 @@ mod tests {
     }
 
     #[test]
-    fn request_query_with_version_and_attachments_roundtrip() {
+    fn request_query_with_attachments_roundtrip() {
         let req = Request::query_with_attachments(
             "req-2",
             "describe this",
@@ -694,37 +675,15 @@ mod tests {
             )],
         );
         let json = serde_json::to_string(&req).unwrap();
-        assert!(json.contains(r#""version":1"#));
         assert!(json.contains(r#""data_base64":"3q2+7w==""#));
         let parsed: Request = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed, req);
     }
 
     #[test]
-    fn request_query_helper_emits_current_version() {
-        let req = Request::query("req-3", "hi");
-        let json = serde_json::to_string(&req).unwrap();
-        assert!(json.contains(&format!(r#""version":{PROTOCOL_VERSION}"#)));
-    }
-
-    #[test]
-    fn legacy_query_payload_deserializes_with_default_attachments() {
-        let json = r#"{"type":"query","id":"req-4","text":"hello"}"#;
-        let parsed: Request = serde_json::from_str(json).unwrap();
-        match parsed {
-            Request::Query {
-                id,
-                text,
-                attachments,
-                version,
-            } => {
-                assert_eq!(id, "req-4");
-                assert_eq!(text, "hello");
-                assert!(attachments.is_empty());
-                assert_eq!(version, None);
-            }
-            _ => panic!("expected Query"),
-        }
+    fn text_only_query_omits_attachments_on_the_wire() {
+        let json = serde_json::to_string(&Request::query("req-3", "hi")).unwrap();
+        assert_eq!(json, r#"{"type":"query","id":"req-3","text":"hi"}"#);
     }
 
     #[test]

--- a/crates/assistd-llm/src/bin/fake_llama_server.rs
+++ b/crates/assistd-llm/src/bin/fake_llama_server.rs
@@ -96,11 +96,10 @@ fn parse_args() -> Args {
                 mode = parse_mode(&argv[i + 1]).expect("invalid --mode");
                 i += 2;
             }
-            // Ignore llama-server args we don't implement. `--hf-repo` is no
-            // longer passed in router mode, but accept it anyway for forward
-            // compat in case an old test path invokes us that way.
+            // Ignore llama-server args we don't implement but real
+            // router-mode spawns pass through.
             "--jinja" => i += 1,
-            "--hf-repo" | "-ngl" | "-c" => i += 2,
+            "-ngl" | "-c" => i += 2,
             _ => i += 1,
         }
     }

--- a/crates/assistd-llm/src/bin/fake_llama_server.rs
+++ b/crates/assistd-llm/src/bin/fake_llama_server.rs
@@ -389,7 +389,7 @@ async fn list_models_response(
     let s = state.lock().await;
     let body = match &s.loaded_model {
         Some(name) => format!(
-            "{{\"data\":[{{\"id\":\"{}\",\"status\":\"loaded\"}}]}}",
+            "{{\"data\":[{{\"id\":\"{}\",\"status\":{{\"value\":\"loaded\",\"args\":[]}}}}]}}",
             escape_json(name)
         ),
         None => "{\"data\":[]}".to_string(),

--- a/crates/assistd-llm/src/chat/client.rs
+++ b/crates/assistd-llm/src/chat/client.rs
@@ -427,9 +427,9 @@ impl LlmBackend for LlamaChatClient {
                 Err(LlmError::Chat(e))
             }
             StreamOutcome::ServerRestart { .. } => {
-                // `generate` is the legacy single-turn API; callers cannot
-                // replay. Leave the user message in place; a follow-up call
-                // would re-push, and double-pushing would duplicate.
+                // `generate` is single-turn; callers cannot replay. Leave
+                // the user message in place; a follow-up call would
+                // re-push, and double-pushing would duplicate.
                 Err(LlmError::ServerRestarting(
                     "llama-server crashed during generate".into(),
                 ))

--- a/crates/assistd-llm/src/lib.rs
+++ b/crates/assistd-llm/src/lib.rs
@@ -310,13 +310,9 @@ pub trait LlmBackend: Send + Sync + 'static {
         Ok(0)
     }
 
-    /// One-shot completion that does NOT touch the in-memory
-    /// conversation. Used by the daemon's title-generation hook so the
+    /// Used by the daemon's title-generation hook so the
     /// summarisation prompt cannot leak into the user's chat history.
     /// Returns the model's final text concatenated.
-    ///
-    /// Default impl reports unavailable; backends that can run a
-    /// stateless completion override it.
     async fn complete_oneshot(&self, _prompt: String) -> LlmResult<String> {
         Err(LlmError::Unavailable(
             "complete_oneshot not supported by this backend".into(),

--- a/crates/assistd-llm/src/lib.rs
+++ b/crates/assistd-llm/src/lib.rs
@@ -249,8 +249,8 @@ pub trait LlmBackend: Send + Sync + 'static {
     /// `mpsc`; if `send` fails it means the consumer has disconnected and
     /// the implementation should stop generating and return `Ok(())`.
     ///
-    /// This is the legacy single-turn API used by code paths that don't
-    /// want the agent loop's tool-dispatch machinery.
+    /// Single-turn API used by code paths that don't want the agent
+    /// loop's tool-dispatch machinery.
     async fn generate(&self, prompt: String, tx: mpsc::Sender<LlmEvent>) -> LlmResult<()>;
 
     /// Append a user message to the conversation. Does not invoke the

--- a/crates/assistd-llm/src/llama_server/backoff.rs
+++ b/crates/assistd-llm/src/llama_server/backoff.rs
@@ -4,6 +4,17 @@ use std::time::Duration;
 /// up and enters [`crate::llama_server::ReadyState::Degraded`].
 pub const MAX_CONSECUTIVE_FAILURES: u32 = 5;
 
+/// Rolling-window cap on *any* restart (startup or crash-after-ready). Without
+/// this, a child that stays up for at least [`super::supervisor::MIN_HEALTHY_SECONDS`]
+/// before each crash would reset the consecutive-failure counter and restart
+/// forever — paying the multi-second weight-load cost every cycle. Hitting
+/// this cap forces [`crate::llama_server::ReadyState::Degraded`] regardless
+/// of how long any individual child lived.
+pub const MAX_RESTARTS_PER_WINDOW: usize = 10;
+
+/// Width of the rolling window used by [`MAX_RESTARTS_PER_WINDOW`].
+pub const RESTART_WINDOW: Duration = Duration::from_secs(600);
+
 /// Exponential backoff schedule: `2^attempt` seconds, capped at 60s.
 ///
 /// `attempt` starts at 0, yielding the sequence

--- a/crates/assistd-llm/src/llama_server/capabilities.rs
+++ b/crates/assistd-llm/src/llama_server/capabilities.rs
@@ -154,9 +154,7 @@ pub async fn probe_capabilities_routed(
         None => return VisionState::default(),
     };
     let vision_supported = parse_vision_supported(&child_body);
-    // The child's /props sets `model` to null and only carries `model_path`;
-    // fall back to the configured name so the revalidator's swap detection
-    // has a stable identity to compare against.
+
     let model_id = parse_model_id(&child_body).or_else(|| Some(model.to_string()));
     debug!(
         target: "assistd::llama_server",
@@ -219,10 +217,6 @@ async fn fetch_props(host: &str, port: u16) -> Option<Value> {
     }
 }
 
-/// Pull a model identifier from a `/props` body. llama.cpp has reported
-/// this under a few different keys (`model`, `model_path`,
-/// `default_generation_settings.model`), so try them in order. Returns
-/// `None` if no recognizable field is present.
 fn parse_model_id(body: &Value) -> Option<String> {
     const TOP_LEVEL_KEYS: &[&str] = &["model", "model_path", "model_name"];
     for key in TOP_LEVEL_KEYS {
@@ -238,9 +232,6 @@ fn parse_model_id(body: &Value) -> Option<String> {
     None
 }
 
-/// Inspect a parsed `/props` body for any field that signals
-/// multimodal/vision support. Tolerates the historical spread of
-/// field names in llama.cpp.
 fn parse_vision_supported(body: &Value) -> bool {
     if let Some(modalities) = body.get("modalities")
         && modalities.get("vision").and_then(Value::as_bool) == Some(true)
@@ -280,9 +271,6 @@ mod tests {
 
     #[test]
     fn modalities_vision_true_wins_over_legacy_false() {
-        // A server reporting the new structured field while still
-        // emitting a stale legacy `has_multimodal: false` must enable
-        // vision. The structured field is canonical.
         let body = json!({
             "modalities": {"vision": true},
             "has_multimodal": false,
@@ -292,9 +280,6 @@ mod tests {
 
     #[test]
     fn modalities_without_vision_key_falls_through_to_legacy() {
-        // Future-proof: if `modalities` exists but doesn't yet carry a
-        // `vision` key (e.g. audio-only build), we must not short-circuit
-        // — fall through and let the legacy union decide.
         let body = json!({
             "modalities": {"audio": true},
             "has_vision": true,
@@ -356,9 +341,6 @@ mod tests {
 
     #[test]
     fn ignores_non_bool_field_value() {
-        // Future-proofing: a string "true" must NOT count. We require
-        // a JSON boolean to avoid accidentally enabling vision based on
-        // an unrelated string field that happens to share a name.
         let body = json!({"has_multimodal": "true"});
         assert!(!parse_vision_supported(&body));
     }
@@ -425,14 +407,12 @@ mod tests {
 
     #[test]
     fn non_router_props_lack_router_role() {
-        // Real child-server /props: `model` may be null but `role` is absent.
         let body = json!({"model": null, "model_path": "/some/model.gguf", "modalities": {"vision": true}});
         assert!(!is_router_props(&body));
     }
 
     #[test]
     fn non_router_props_with_unrelated_role_value() {
-        // Future-proof: only the literal "router" triggers the detour.
         let body = json!({"role": "worker", "model_path": "/x.gguf"});
         assert!(!is_router_props(&body));
     }

--- a/crates/assistd-llm/src/llama_server/capabilities.rs
+++ b/crates/assistd-llm/src/llama_server/capabilities.rs
@@ -25,16 +25,8 @@
 //! `[error] …: vision not available …` line in that case, which is a
 //! safer default than silently sending image bytes the model will drop.
 //!
-//! Field-name spread: across the multimodal-merge era llama.cpp has
-//! exposed the capability under several different keys. The current
-//! canonical shape is a structured `modalities` object
-//! (`{"modalities": {"vision": true}}`); legacy builds reported a
-//! flat boolean under `has_multimodal`, `has_vision`, `multimodal`,
-//! or `default_generation_settings.multimodal`. We tolerate the
-//! spread by checking the structured field first and falling back to
-//! the legacy union, so a server upgrade in either direction keeps
-//! vision detection working. New names can be added here without
-//! touching call sites.
+//! We read the capability from llama.cpp's canonical structured
+//! `modalities` object (`{"modalities": {"vision": true}}`).
 
 use std::time::Duration;
 
@@ -233,23 +225,10 @@ fn parse_model_id(body: &Value) -> Option<String> {
 }
 
 fn parse_vision_supported(body: &Value) -> bool {
-    if let Some(modalities) = body.get("modalities")
-        && modalities.get("vision").and_then(Value::as_bool) == Some(true)
-    {
-        return true;
-    }
-    const TOP_LEVEL_KEYS: &[&str] = &["has_multimodal", "has_vision", "multimodal"];
-    for key in TOP_LEVEL_KEYS {
-        if body.get(*key).and_then(Value::as_bool) == Some(true) {
-            return true;
-        }
-    }
-    if let Some(settings) = body.get("default_generation_settings")
-        && settings.get("multimodal").and_then(Value::as_bool) == Some(true)
-    {
-        return true;
-    }
-    false
+    body.get("modalities")
+        .and_then(|m| m.get("vision"))
+        .and_then(Value::as_bool)
+        == Some(true)
 }
 
 #[cfg(test)]
@@ -270,78 +249,20 @@ mod tests {
     }
 
     #[test]
-    fn modalities_vision_true_wins_over_legacy_false() {
-        let body = json!({
-            "modalities": {"vision": true},
-            "has_multimodal": false,
-        });
-        assert!(parse_vision_supported(&body));
-    }
-
-    #[test]
-    fn modalities_without_vision_key_falls_through_to_legacy() {
-        let body = json!({
-            "modalities": {"audio": true},
-            "has_vision": true,
-        });
-        assert!(parse_vision_supported(&body));
-    }
-
-    #[test]
     fn ignores_non_bool_modalities_vision() {
         let body = json!({"modalities": {"vision": "true"}});
         assert!(!parse_vision_supported(&body));
     }
 
     #[test]
-    fn detects_top_level_has_multimodal_true() {
-        let body = json!({"has_multimodal": true, "total_slots": 1});
-        assert!(parse_vision_supported(&body));
-    }
-
-    #[test]
-    fn detects_top_level_has_vision_true() {
-        let body = json!({"has_vision": true});
-        assert!(parse_vision_supported(&body));
-    }
-
-    #[test]
-    fn detects_top_level_multimodal_true() {
-        let body = json!({"multimodal": true});
-        assert!(parse_vision_supported(&body));
-    }
-
-    #[test]
-    fn detects_nested_multimodal_under_default_generation_settings() {
-        let body = json!({
-            "default_generation_settings": {"multimodal": true, "temperature": 0.7},
-        });
-        assert!(parse_vision_supported(&body));
-    }
-
-    #[test]
-    fn ignores_field_when_explicitly_false() {
-        let body = json!({"has_multimodal": false, "has_vision": false});
-        assert!(!parse_vision_supported(&body));
-    }
-
-    #[test]
-    fn defaults_false_when_no_field_present() {
+    fn defaults_false_when_modalities_absent() {
         let body = json!({"total_slots": 1, "model_path": "/some/model.gguf"});
         assert!(!parse_vision_supported(&body));
     }
 
     #[test]
-    fn nested_false_does_not_promote_to_true() {
-        let body = json!({
-            "default_generation_settings": {"multimodal": false},
-        });
-        assert!(!parse_vision_supported(&body));
-    }
-
-    #[test]
-    fn ignores_non_bool_field_value() {
-        let body = json!({"has_multimodal": "true"});
+    fn defaults_false_when_modalities_lacks_vision_key() {
+        let body = json!({"modalities": {"audio": true}});
         assert!(!parse_vision_supported(&body));
     }
 
@@ -349,16 +270,6 @@ mod tests {
     fn empty_object_is_not_vision_supported() {
         let body = json!({});
         assert!(!parse_vision_supported(&body));
-    }
-
-    #[test]
-    fn any_truthy_field_wins_even_if_others_false() {
-        let body = json!({
-            "has_multimodal": false,
-            "has_vision": true,
-            "multimodal": false,
-        });
-        assert!(parse_vision_supported(&body));
     }
 
     #[test]

--- a/crates/assistd-llm/src/llama_server/control.rs
+++ b/crates/assistd-llm/src/llama_server/control.rs
@@ -59,11 +59,9 @@ impl LlamaServerControl {
 
     /// Best-effort check for whether `model` is currently loaded.
     ///
-    /// Queries `GET /models` and looks for an entry matching `model` with
-    /// a loaded status marker. Resilient to different response shapes:
-    /// tolerates either a top-level `data`/`models` array and either a
-    /// structured `status: {value: "loaded", args: [...]}` object, a flat
-    /// `status: "loaded"` string, or a boolean `loaded` field.
+    /// Queries `GET /models` and looks for an entry matching `model`
+    /// with a structured `status: {value: "loaded", args: [...]}` field
+    /// (the router-mode response shape).
     pub async fn model_is_loaded(&self, model: &str) -> Result<bool, LlamaServerError> {
         Ok(self.fetch_models().await?.contains_loaded(model))
     }
@@ -161,21 +159,16 @@ struct ModelActionRequest<'a> {
 struct ModelsResponse {
     #[serde(default)]
     data: Vec<ModelEntry>,
-    #[serde(default)]
-    models: Vec<ModelEntry>,
 }
 
 impl ModelsResponse {
-    fn entries(&self) -> impl Iterator<Item = &ModelEntry> {
-        self.data.iter().chain(self.models.iter())
-    }
-
     fn contains_loaded(&self, model: &str) -> bool {
-        self.entries().any(|e| e.matches(model) && e.is_loaded())
+        self.data.iter().any(|e| e.matches(model) && e.is_loaded())
     }
 
     fn find_loaded_child_port(&self, model: &str) -> Option<u16> {
-        self.entries()
+        self.data
+            .iter()
             .find(|e| e.matches(model) && e.is_loaded())
             .and_then(ModelEntry::child_port)
     }
@@ -186,43 +179,25 @@ struct ModelEntry {
     #[serde(default)]
     id: Option<String>,
     #[serde(default)]
-    name: Option<String>,
-    #[serde(default)]
     status: Option<ModelStatus>,
-    #[serde(default)]
-    loaded: Option<bool>,
 }
 
-/// `/models` historically returned `status` as a flat string
-/// (`"loaded"` / `"unloaded"`); current router-mode builds return a
-/// structured object with the child's spawn args. We accept both via
-/// an untagged enum so an upgrade in either direction keeps parsing.
 #[derive(Deserialize)]
-#[serde(untagged)]
-enum ModelStatus {
-    Structured {
-        value: String,
-        #[serde(default)]
-        args: Vec<String>,
-    },
-    Legacy(String),
+struct ModelStatus {
+    value: String,
+    #[serde(default)]
+    args: Vec<String>,
 }
 
 impl ModelStatus {
     fn is_loaded(&self) -> bool {
-        match self {
-            ModelStatus::Structured { value, .. } | ModelStatus::Legacy(value) => value == "loaded",
-        }
+        self.value == "loaded"
     }
 
-    /// Extract the value following `--port` in the spawn args of a
-    /// structured status. Only present when the router actually spawned
-    /// a child for this model.
+    /// Extract the value following `--port` in the spawn args. Only
+    /// present when the router actually spawned a child for this model.
     fn child_port(&self) -> Option<u16> {
-        let ModelStatus::Structured { args, .. } = self else {
-            return None;
-        };
-        let mut iter = args.iter();
+        let mut iter = self.args.iter();
         while let Some(arg) = iter.next() {
             if arg == "--port" {
                 return iter.next().and_then(|s| s.parse::<u16>().ok());
@@ -234,13 +209,10 @@ impl ModelStatus {
 
 impl ModelEntry {
     fn matches(&self, model: &str) -> bool {
-        self.id.as_deref() == Some(model) || self.name.as_deref() == Some(model)
+        self.id.as_deref() == Some(model)
     }
 
     fn is_loaded(&self) -> bool {
-        if let Some(true) = self.loaded {
-            return true;
-        }
         self.status.as_ref().is_some_and(ModelStatus::is_loaded)
     }
 
@@ -252,22 +224,6 @@ impl ModelEntry {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn models_response_recognises_loaded_status_field() {
-        let body = r#"{"data":[{"id":"a","status":"loaded"},{"id":"b","status":"unloaded"}]}"#;
-        let parsed: ModelsResponse = serde_json::from_str(body).unwrap();
-        assert!(parsed.contains_loaded("a"));
-        assert!(!parsed.contains_loaded("b"));
-        assert!(!parsed.contains_loaded("c"));
-    }
-
-    #[test]
-    fn models_response_recognises_loaded_bool_field() {
-        let body = r#"{"models":[{"name":"x","loaded":true}]}"#;
-        let parsed: ModelsResponse = serde_json::from_str(body).unwrap();
-        assert!(parsed.contains_loaded("x"));
-    }
 
     #[test]
     fn models_response_empty_is_not_loaded() {
@@ -285,6 +241,7 @@ mod tests {
         let parsed: ModelsResponse = serde_json::from_str(body).unwrap();
         assert!(parsed.contains_loaded("foo/bar:Q4"));
         assert!(!parsed.contains_loaded("baz/qux:Q4"));
+        assert!(!parsed.contains_loaded("c"));
     }
 
     #[test]
@@ -302,14 +259,6 @@ mod tests {
             {"id":"foo/bar:Q4","status":{"value":"unloaded","args":["--port","48881"]}}
         ]}"#;
         let parsed: ModelsResponse = serde_json::from_str(body).unwrap();
-        assert_eq!(parsed.find_loaded_child_port("foo/bar:Q4"), None);
-    }
-
-    #[test]
-    fn find_loaded_child_port_returns_none_when_args_missing() {
-        let body = r#"{"data":[{"id":"foo/bar:Q4","status":"loaded"}]}"#;
-        let parsed: ModelsResponse = serde_json::from_str(body).unwrap();
-        assert!(parsed.contains_loaded("foo/bar:Q4"));
         assert_eq!(parsed.find_loaded_child_port("foo/bar:Q4"), None);
     }
 

--- a/crates/assistd-llm/src/llama_server/control.rs
+++ b/crates/assistd-llm/src/llama_server/control.rs
@@ -103,9 +103,6 @@ impl LlamaServerControl {
     ) -> Result<(), LlamaServerError> {
         let start = tokio::time::Instant::now();
         loop {
-            // Suppress transient errors during the poll — the router can
-            // briefly 5xx while spawning a child. Only the deadline is
-            // fatal.
             if let Ok(true) = self.model_is_loaded(model).await {
                 return Ok(());
             }
@@ -281,8 +278,6 @@ mod tests {
 
     #[test]
     fn models_response_recognises_structured_status_loaded() {
-        // Shape the router currently returns: status is an object with
-        // `value` and `args` (the child's spawn command line).
         let body = r#"{"data":[
             {"id":"foo/bar:Q4","status":{"value":"loaded","args":["--host","127.0.0.1","--port","48881"]}},
             {"id":"baz/qux:Q4","status":{"value":"unloaded","args":["--host","127.0.0.1","--port","0"]}}
@@ -303,8 +298,6 @@ mod tests {
 
     #[test]
     fn find_loaded_child_port_returns_none_for_unloaded_model() {
-        // Even with a `--port` in args, an unloaded entry has no live
-        // child — surface None rather than a stale port.
         let body = r#"{"data":[
             {"id":"foo/bar:Q4","status":{"value":"unloaded","args":["--port","48881"]}}
         ]}"#;
@@ -314,8 +307,6 @@ mod tests {
 
     #[test]
     fn find_loaded_child_port_returns_none_when_args_missing() {
-        // Legacy/flat status carries no spawn args; vision detection
-        // falls back to direct probing in that case.
         let body = r#"{"data":[{"id":"foo/bar:Q4","status":"loaded"}]}"#;
         let parsed: ModelsResponse = serde_json::from_str(body).unwrap();
         assert!(parsed.contains_loaded("foo/bar:Q4"));
@@ -333,8 +324,6 @@ mod tests {
 
     #[test]
     fn find_loaded_child_port_ignores_non_numeric_port() {
-        // Future-proof: if `--port` is followed by a non-numeric token,
-        // refuse to invent one rather than panicking.
         let body = r#"{"data":[
             {"id":"foo/bar:Q4","status":{"value":"loaded","args":["--port","auto"]}}
         ]}"#;
@@ -344,9 +333,6 @@ mod tests {
 
     #[test]
     fn find_loaded_child_port_handles_port_zero_as_unbound() {
-        // The router stores `--port 0` for entries it has never spawned;
-        // we parse it as 0 which callers should treat as "no live child."
-        // A real spawn replaces 0 with the actual bound port.
         let body = r#"{"data":[
             {"id":"foo/bar:Q4","status":{"value":"loaded","args":["--port","0"]}}
         ]}"#;

--- a/crates/assistd-llm/src/llama_server/service.rs
+++ b/crates/assistd-llm/src/llama_server/service.rs
@@ -75,9 +75,6 @@ impl LlamaService {
                             });
                         }
                         ReadyState::Degraded => {
-                            // Supervisor is parked waiting for shutdown. We
-                            // don't own the shutdown sender here, so abort
-                            // the task rather than `await` it.
                             task.abort();
                             return Err(LlamaServerError::StartupFailed {
                                 attempts: MAX_CONSECUTIVE_FAILURES,

--- a/crates/assistd-llm/src/llama_server/supervisor.rs
+++ b/crates/assistd-llm/src/llama_server/supervisor.rs
@@ -50,10 +50,7 @@ impl Supervisor {
     /// [`RESTART_WINDOW`]. Intended to be spawned as a Tokio task.
     pub async fn run(mut self) {
         let mut consecutive_failures: u32 = 0;
-        // Rolling window of restart timestamps. Catches the crash-loop case
-        // where each child runs for ≥ MIN_HEALTHY_SECONDS (resetting
-        // consecutive_failures) but the process keeps dying in a short
-        // wall-clock window.
+
         let mut restart_history: VecDeque<Instant> = VecDeque::new();
 
         loop {
@@ -64,9 +61,6 @@ impl Supervisor {
 
             let outcome = self.supervise_once().await;
 
-            // Record any non-shutdown outcome in the rolling window before
-            // updating consecutive_failures, so the cap is enforced even when
-            // the per-cycle counter keeps resetting.
             let recorded_restart = !matches!(outcome, Ok(CycleResult::ShutdownRequested));
             if recorded_restart {
                 let now = Instant::now();
@@ -129,9 +123,7 @@ impl Supervisor {
                     );
                 }
                 let _ = self.ready_tx.send(ReadyState::Degraded);
-                // Park until the daemon tells us to stop. Keeping the task
-                // alive means the daemon process doesn't crash, and the
-                // LlamaService::shutdown() path still works.
+
                 let _ = self.shutdown_rx.wait_for(|v| *v).await;
                 return;
             }
@@ -159,7 +151,6 @@ impl Supervisor {
         }
     }
 
-    /// Spawns the child, waits for it to become healthy, then watches for exit or shutdown.
     async fn supervise_once(&mut self) -> Result<CycleResult, LlamaServerError> {
         let mut child = ChildProcess::spawn(&self.cfg, &self.model)?;
         *self.pid.lock() = child.pid();

--- a/crates/assistd-llm/src/llama_server/supervisor.rs
+++ b/crates/assistd-llm/src/llama_server/supervisor.rs
@@ -1,10 +1,13 @@
-use super::backoff::{MAX_CONSECUTIVE_FAILURES, backoff_delay};
+use super::backoff::{
+    MAX_CONSECUTIVE_FAILURES, MAX_RESTARTS_PER_WINDOW, RESTART_WINDOW, backoff_delay,
+};
 use super::error::LlamaServerError;
 use super::health::HealthChecker;
 use super::process::ChildProcess;
 use super::service::ReadyState;
 use assistd_config::{LlamaServerConfig, ModelConfig};
 use parking_lot::Mutex;
+use std::collections::VecDeque;
 use std::process::ExitStatus;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -14,7 +17,7 @@ use tracing::{error, info, warn};
 /// Seconds a child must stay healthy after reaching Ready before a subsequent
 /// exit is treated as a runtime crash (counter reset) rather than a startup
 /// flap (counter increment).
-const MIN_HEALTHY_SECONDS: u64 = 30;
+pub(crate) const MIN_HEALTHY_SECONDS: u64 = 30;
 
 /// Graceful shutdown budget per child; fits under systemd's 15s stop budget.
 const TERM_TIMEOUT: Duration = Duration::from_secs(10);
@@ -42,10 +45,16 @@ pub struct Supervisor {
 }
 
 impl Supervisor {
-    /// Runs the supervisor loop until shutdown is requested or [`MAX_CONSECUTIVE_FAILURES`]
-    /// is reached. Intended to be spawned as a Tokio task.
+    /// Runs the supervisor loop until shutdown is requested, [`MAX_CONSECUTIVE_FAILURES`]
+    /// is reached, or [`MAX_RESTARTS_PER_WINDOW`] is exceeded inside
+    /// [`RESTART_WINDOW`]. Intended to be spawned as a Tokio task.
     pub async fn run(mut self) {
         let mut consecutive_failures: u32 = 0;
+        // Rolling window of restart timestamps. Catches the crash-loop case
+        // where each child runs for ≥ MIN_HEALTHY_SECONDS (resetting
+        // consecutive_failures) but the process keeps dying in a short
+        // wall-clock window.
+        let mut restart_history: VecDeque<Instant> = VecDeque::new();
 
         loop {
             if *self.shutdown_rx.borrow() {
@@ -54,6 +63,22 @@ impl Supervisor {
             let _ = self.ready_tx.send(ReadyState::Starting);
 
             let outcome = self.supervise_once().await;
+
+            // Record any non-shutdown outcome in the rolling window before
+            // updating consecutive_failures, so the cap is enforced even when
+            // the per-cycle counter keeps resetting.
+            let recorded_restart = !matches!(outcome, Ok(CycleResult::ShutdownRequested));
+            if recorded_restart {
+                let now = Instant::now();
+                while let Some(&oldest) = restart_history.front() {
+                    if now.duration_since(oldest) > RESTART_WINDOW {
+                        restart_history.pop_front();
+                    } else {
+                        break;
+                    }
+                }
+                restart_history.push_back(now);
+            }
 
             match outcome {
                 Ok(CycleResult::ShutdownRequested) => {
@@ -87,11 +112,22 @@ impl Supervisor {
                 }
             }
 
-            if consecutive_failures >= MAX_CONSECUTIVE_FAILURES {
-                error!(
-                    target: "assistd::llama_server",
-                    "{MAX_CONSECUTIVE_FAILURES} consecutive failures; entering degraded state"
-                );
+            let consecutive_tripped = consecutive_failures >= MAX_CONSECUTIVE_FAILURES;
+            let window_tripped = restart_history.len() >= MAX_RESTARTS_PER_WINDOW;
+            if consecutive_tripped || window_tripped {
+                if window_tripped {
+                    error!(
+                        target: "assistd::llama_server",
+                        restarts = restart_history.len(),
+                        window_secs = RESTART_WINDOW.as_secs(),
+                        "llama-server hit {MAX_RESTARTS_PER_WINDOW} restarts in rolling window; entering degraded state"
+                    );
+                } else {
+                    error!(
+                        target: "assistd::llama_server",
+                        "{MAX_CONSECUTIVE_FAILURES} consecutive failures; entering degraded state"
+                    );
+                }
                 let _ = self.ready_tx.send(ReadyState::Degraded);
                 // Park until the daemon tells us to stop. Keeping the task
                 // alive means the daemon process doesn't crash, and the

--- a/crates/assistd-llm/tests/presence.rs
+++ b/crates/assistd-llm/tests/presence.rs
@@ -350,7 +350,6 @@ async fn query_during_sleeping_triggers_auto_wake() {
         id: "q1".into(),
         text: "hello".into(),
         attachments: Vec::new(),
-        version: None,
     };
     let stream = UnixStream::connect(&sock_path).await.unwrap();
     let (read, mut write) = stream.into_split();
@@ -513,7 +512,6 @@ async fn sleep_defers_until_inflight_query_done() {
         id: "q1".into(),
         text: "hello".into(),
         attachments: Vec::new(),
-        version: None,
     };
     let sock_for_client = sock_path.clone();
     let client_task = tokio::spawn(async move { connect_and_send(&sock_for_client, &req).await });
@@ -612,7 +610,6 @@ async fn multiple_queries_during_wake_complete_in_order() {
             id: id.clone(),
             text: text.clone(),
             attachments: Vec::new(),
-            version: None,
         };
         handles.push((
             id,

--- a/crates/assistd-llm/tests/presence_stress.rs
+++ b/crates/assistd-llm/tests/presence_stress.rs
@@ -249,7 +249,6 @@ async fn sleep_defers_until_inflight_real_chat_stream_done() {
         id: "q-stream".into(),
         text: "hello".into(),
         attachments: Vec::new(),
-        version: None,
     };
     let mut body = serde_json::to_string(&req).unwrap();
     body.push('\n');

--- a/crates/assistd-llm/tests/wake_latency.rs
+++ b/crates/assistd-llm/tests/wake_latency.rs
@@ -179,7 +179,6 @@ async fn measure_query_latency(sock_path: &std::path::Path, id: &str) -> (Durati
         id: id.to_string(),
         text: "ping".into(),
         attachments: Vec::new(),
-        version: None,
     };
     let mut body = serde_json::to_string(&req).unwrap();
     body.push('\n');

--- a/crates/assistd-mcp/src/backoff.rs
+++ b/crates/assistd-mcp/src/backoff.rs
@@ -1,8 +1,8 @@
 use std::time::Duration;
 
 /// Cap on consecutive transport-startup failures before a server's
-/// supervisor parks itself in `HealthState::Unhealthy` permanently.
-/// Matches the embed-server budget at
+/// supervisor backs off to a slow-cadence retry loop in
+/// `HealthState::Unhealthy`. Matches the embed-server budget at
 /// `assistd_embed::server::backoff::MAX_CONSECUTIVE_FAILURES`.
 pub const MAX_CONSECUTIVE_FAILURES: u32 = 5;
 
@@ -13,6 +13,13 @@ pub const MIN_HEALTHY_SECONDS: u64 = 30;
 
 /// Cap on the SSE reconnection delay (also reused for stdio restarts).
 pub const RECONNECT_MAX_SECS: u64 = 60;
+
+/// Once a supervisor has hit `MAX_CONSECUTIVE_FAILURES`, it transitions
+/// to `HealthState::Unhealthy` and sleeps this long between further
+/// spawn attempts. Picked so a misconfigured server the user has just
+/// fixed (typo'd binary path, etc.) self-heals within minutes without
+/// the daemon thrashing if the underlying problem persists.
+pub const UNHEALTHY_RETRY_INTERVAL: Duration = Duration::from_secs(300);
 
 /// Exponential backoff: 1s, 2s, 4s, 8s, 16s, 32s, 60s (capped).
 pub fn backoff_delay(attempt: u32) -> Duration {

--- a/crates/assistd-mcp/src/handle.rs
+++ b/crates/assistd-mcp/src/handle.rs
@@ -264,13 +264,6 @@ impl Supervisor {
         let mut session_start = Instant::now();
 
         loop {
-            // If we had a live transport, wait for it to die or for a
-            // shutdown signal. On crash, flip to Restarting so direct
-            // consumers see ServerDown rather than calling a dead
-            // transport. When we re-enter the loop after a failed
-            // respawn, current_lifeline is None and we leave the health
-            // state alone (Restarting or Unhealthy as appropriate) to
-            // avoid flapping the watch channel.
             if let Some(mut lifeline) = current_lifeline.take() {
                 tokio::select! {
                     _ = lifeline.wait() => {

--- a/crates/assistd-mcp/src/handle.rs
+++ b/crates/assistd-mcp/src/handle.rs
@@ -21,7 +21,9 @@ use tokio::sync::{RwLock, watch};
 use tokio::task::JoinHandle;
 use tracing::{error, info, warn};
 
-use crate::backoff::{MAX_CONSECUTIVE_FAILURES, MIN_HEALTHY_SECONDS, backoff_delay};
+use crate::backoff::{
+    MAX_CONSECUTIVE_FAILURES, MIN_HEALTHY_SECONDS, UNHEALTHY_RETRY_INTERVAL, backoff_delay,
+};
 use crate::error::McpError;
 use crate::sse::{SseConfig, SseLifeline, SseMcpClient};
 use crate::stdio::{ChildLifeline, StdioConfig, StdioMcpClient};
@@ -262,6 +264,13 @@ impl Supervisor {
         let mut session_start = Instant::now();
 
         loop {
+            // If we had a live transport, wait for it to die or for a
+            // shutdown signal. On crash, flip to Restarting so direct
+            // consumers see ServerDown rather than calling a dead
+            // transport. When we re-enter the loop after a failed
+            // respawn, current_lifeline is None and we leave the health
+            // state alone (Restarting or Unhealthy as appropriate) to
+            // avoid flapping the watch channel.
             if let Some(mut lifeline) = current_lifeline.take() {
                 tokio::select! {
                     _ = lifeline.wait() => {
@@ -276,6 +285,8 @@ impl Supervisor {
                         if ran_for >= Duration::from_secs(MIN_HEALTHY_SECONDS) {
                             consecutive_failures = 0;
                         }
+                        let _ = health_tx.send(HealthState::Restarting);
+                        switch.swap(None).await;
                     }
                     _ = supervisor_shutdown_rx.changed() => {
                         if *supervisor_shutdown_rx.borrow() {
@@ -296,35 +307,28 @@ impl Supervisor {
                 }
             }
 
-            // Swap the switching client to None so direct consumers see
-            // ServerDown rather than calling a dead transport.
-            let _ = health_tx.send(HealthState::Restarting);
-            switch.swap(None).await;
-
-            if consecutive_failures >= MAX_CONSECUTIVE_FAILURES {
+            let unhealthy = consecutive_failures >= MAX_CONSECUTIVE_FAILURES;
+            let delay = if unhealthy {
                 error!(
                     target: "assistd::mcp",
                     server = %name,
                     attempts = consecutive_failures,
-                    "MCP server reached {MAX_CONSECUTIVE_FAILURES} consecutive failures; marking permanently unhealthy",
+                    retry_secs = UNHEALTHY_RETRY_INTERVAL.as_secs(),
+                    "MCP server reached {MAX_CONSECUTIVE_FAILURES} consecutive failures; marking unhealthy and retrying at slow cadence",
                 );
                 let _ = health_tx.send(HealthState::Unhealthy);
-                // Park awaiting any shutdown signal.
-                tokio::select! {
-                    _ = supervisor_shutdown_rx.changed() => {}
-                    _ = external_shutdown_rx.changed() => {}
-                }
-                return;
-            }
-
-            let delay = backoff_delay(consecutive_failures);
-            warn!(
-                target: "assistd::mcp",
-                server = %name,
-                attempt = consecutive_failures + 1,
-                cap = MAX_CONSECUTIVE_FAILURES,
-                "restarting MCP server in {delay:?}",
-            );
+                UNHEALTHY_RETRY_INTERVAL
+            } else {
+                let d = backoff_delay(consecutive_failures);
+                warn!(
+                    target: "assistd::mcp",
+                    server = %name,
+                    attempt = consecutive_failures + 1,
+                    cap = MAX_CONSECUTIVE_FAILURES,
+                    "restarting MCP server in {d:?}",
+                );
+                d
+            };
             tokio::select! {
                 _ = tokio::time::sleep(delay) => {}
                 _ = supervisor_shutdown_rx.changed() => return,

--- a/crates/assistd-mcp/src/health_route.rs
+++ b/crates/assistd-mcp/src/health_route.rs
@@ -124,8 +124,7 @@ mod tests {
     async fn forwards_when_healthy() {
         let (tool, _tx) = make_tool(HealthState::Healthy);
         let result = tool.invoke(json!({})).await.unwrap();
-        // McpToolAdapter renders Text results into the dispatch envelope
-        // shape (`output` field, not the old `text` field).
+
         assert_eq!(result["type"], "text");
         assert!(result["output"].as_str().unwrap().contains("search"));
     }
@@ -137,12 +136,10 @@ mod tests {
         assert_eq!(result["type"], "error");
         assert_eq!(result["exit_code"], -1);
         assert_eq!(result["truncated"], false);
-        // Server name carried out-of-band on a separate field so the
-        // message body itself can stay convention-compliant without
-        // having to embed the supervisor's identifier mid-sentence.
+
         assert_eq!(result["server_name"], "web");
         let output = result["output"].as_str().unwrap();
-        // Convention-compliant line: `[error] <tool>: <what>. <Hint>: <recovery>\n`
+
         assert!(output.starts_with("[error] mcp__web__search: "), "{output}");
         assert!(
             output.contains("Try:") || output.contains("Check:"),

--- a/crates/assistd-mcp/src/jsonrpc.rs
+++ b/crates/assistd-mcp/src/jsonrpc.rs
@@ -111,9 +111,6 @@ impl Correlator {
     /// when an in-flight reply arrives just after the supervisor swap.
     pub fn deliver(&self, response: Response) {
         let Some(id) = response.id else {
-            // Server sent a notification or a malformed response without id.
-            // Notifications other than the initial handshake are ignored
-            // by this v1 client.
             return;
         };
         let tx = {

--- a/crates/assistd-mcp/src/lib.rs
+++ b/crates/assistd-mcp/src/lib.rs
@@ -430,11 +430,7 @@ mod tests {
         assert_eq!(attachments.len(), 1);
         assert_eq!(attachments[0]["type"], "image");
         assert_eq!(attachments[0]["mime"], "image/png");
-        // Matches the agent loop's `parse_attachment`, which decodes
-        // `attachments[i]["data"]` (NOT `bytes_base64`).
         assert_eq!(attachments[0]["data"], "3q2+7w==");
-        // Body should describe the image so the model has something to
-        // anchor its next turn against.
         let output = v["output"].as_str().unwrap();
         assert!(output.contains("image/png"));
         assert!(output.contains("4 bytes"));

--- a/crates/assistd-mcp/src/sse.rs
+++ b/crates/assistd-mcp/src/sse.rs
@@ -95,9 +95,6 @@ impl SseMcpClient {
             headers.insert(name, value);
         }
 
-        // We deliberately set `read_timeout` (per-read) rather than
-        // `timeout` (whole-request); the SSE GET is meant to be long-lived,
-        // so the per-read deadline is what catches a frozen server.
         let http = reqwest::Client::builder()
             .read_timeout(cfg.read_timeout)
             .timeout(cfg.request_timeout)
@@ -132,9 +129,6 @@ impl SseMcpClient {
         };
         let stream_task = tokio::spawn(reader.run());
 
-        // Wait briefly for the optional `endpoint` discovery event. If
-        // we don't get one in 5s, fall back to assuming POSTs go to the
-        // base URL. Many MCP SSE servers omit the event.
         let _ = tokio::time::timeout(Duration::from_secs(5), endpoint_ready_rx).await;
         if post_url.read().await.is_none() {
             *post_url.write().await = Some(base_url.clone());
@@ -157,11 +151,6 @@ impl SseMcpClient {
             return Err(e);
         }
 
-        // Periodic ping task, separate from the SSE stream so a server
-        // that holds the SSE connection open while wedged still gets
-        // detected. On ping failure, we flip the cancel watch which the
-        // read loop selects on; that closes the transport and trips the
-        // supervisor's restart path.
         let ping_task = tokio::spawn(ping_loop(
             client.clone(),
             cfg.ping_interval,
@@ -491,11 +480,6 @@ async fn handle_event(
 ) {
     match event.event_type.as_str() {
         "endpoint" => {
-            // Server tells us where to POST. Spec allows either an
-            // absolute URL or a path relative to the base. We treat
-            // anything that doesn't parse as an absolute URL as a
-            // missed event for now; the daemon falls back to the base
-            // URL after a 5s timeout in `connect`.
             let resolved = Url::parse(&event.data).ok();
             if let Some(url) = resolved {
                 debug!(
@@ -558,8 +542,6 @@ async fn ping_loop(
                         debug!(target: "assistd::mcp", server = %label, "ping ok");
                     }
                     Err(McpError::RpcError { code: -32601, message, .. }) => {
-                        // Server doesn't implement `ping`. Treat as healthy;
-                        // the SSE stream itself will tell us about death.
                         debug!(
                             target: "assistd::mcp",
                             server = %label,
@@ -650,7 +632,6 @@ impl EventParser {
             };
             let (field, value) = match line_str.split_once(':') {
                 Some((f, v)) => {
-                    // Strip a single leading space from value, per spec.
                     let v = v.strip_prefix(' ').unwrap_or(v);
                     (f, v)
                 }

--- a/crates/assistd-mcp/src/stdio.rs
+++ b/crates/assistd-mcp/src/stdio.rs
@@ -81,8 +81,6 @@ impl StdioMcpClient {
 
         #[cfg(unix)]
         {
-            // Process group so SIGTERM to -pid takes down any grandchildren
-            // (e.g., npx → node → server-filesystem).
             cmd.process_group(0);
         }
 
@@ -104,9 +102,6 @@ impl StdioMcpClient {
         let (client, transport_handles) =
             Self::from_streams(stdout, stdin, cfg.label.clone(), cfg.request_timeout).await?;
 
-        // Initialize handshake. Failure here brings down the whole transport
-        // since a server that won't agree on the protocol version cannot
-        // serve tools/list / tools/call.
         if let Err(e) = client.initialize().await {
             warn!(
                 target: "assistd::mcp",
@@ -189,9 +184,6 @@ impl StdioMcpClient {
         });
         let result = self.call("initialize", params).await?;
 
-        // Some servers return their negotiated protocolVersion; we don't
-        // hard-fail on mismatch because servers commonly advertise multiple
-        // versions and tools/call still works. We log it for the operator.
         if let Some(server_pv) = result.get("protocolVersion").and_then(Value::as_str)
             && server_pv != PROTOCOL_VERSION
         {
@@ -278,13 +270,6 @@ impl McpClient for StdioMcpClient {
         let params = json!({ "name": name, "arguments": arguments });
         let result = self.call("tools/call", params).await?;
 
-        // The MCP spec says tools/call returns:
-        //   { "content": [{"type":"text","text":...}|{"type":"image",...}|...],
-        //     "isError": bool }
-        // We map the first content entry into our ToolResult shape. Multiple
-        // content entries are uncommon enough in practice that taking the
-        // first is the right v1 trade-off; downstream code can still surface
-        // a helpful message.
         let content_arr = result
             .get("content")
             .and_then(Value::as_array)
@@ -302,9 +287,6 @@ impl McpClient for StdioMcpClient {
         };
 
         if is_error {
-            // Wrap text errors so the model sees the failure mode in the
-            // result body. Image errors keep their image; the model can
-            // still react.
             let parsed = match parsed {
                 ToolResult::Text(t) => ToolResult::Text(format!("[mcp tool error] {t}")),
                 other => other,

--- a/crates/assistd-memory/src/chunking.rs
+++ b/crates/assistd-memory/src/chunking.rs
@@ -112,9 +112,6 @@ mod tests {
 
     #[test]
     fn long_input_splits_with_overlap() {
-        // 100 chars, chunk=40, overlap=10 → step=30 → starts at 0, 30, 60.
-        // Window 2 (start=60) reaches end=100 and the loop breaks, so the
-        // last chunk is exactly chunk_chars wide; no separate tail.
         let s: String = (0..100).map(|i| (b'a' + (i % 26) as u8) as char).collect();
         let r = chunk_message(&s, &cfg(40, 10));
         assert_eq!(
@@ -170,8 +167,6 @@ mod tests {
         let s: String = (0..30).map(|_| '世').collect();
         let r = chunk_message(&s, &cfg(10, 2));
         for c in &r {
-            // Every chunk must be a valid UTF-8 string (Rust guarantees) and
-            // contain only whole `世` characters (no boundary splits).
             assert!(c.chars().all(|ch| ch == '世'));
         }
         assert!(r.len() >= 3);
@@ -179,8 +174,6 @@ mod tests {
 
     #[test]
     fn pure_whitespace_chunk_is_dropped() {
-        // 30 chars of spaces. Whole thing becomes a single chunk; trim
-        // detects it as whitespace and the function returns empty.
         let s = " ".repeat(30);
         let r = chunk_message(&s, &cfg(10, 2));
         assert!(r.is_empty());
@@ -188,8 +181,6 @@ mod tests {
 
     #[test]
     fn defensive_against_overlap_geq_chunk() {
-        // Validation should prevent this, but if it slips through we
-        // return one chunk rather than loop forever.
         let s = "a".repeat(50);
         let r = chunk_message(&s, &cfg(10, 10));
         assert_eq!(r, vec![s]);

--- a/crates/assistd-memory/src/migrations.rs
+++ b/crates/assistd-memory/src/migrations.rs
@@ -14,16 +14,29 @@
 use rusqlite::Connection;
 use rusqlite_migration::{M, Migrations};
 
-/// V1: initial schema. Tables in order:
+/// V1: full MVP schema. Tables in order:
 /// - `schema_migrations` - version log for future upgrades.
-/// - `sessions` - one row per daemon process (uuid PK).
-/// - `turns` - logical user-prompt-to-final-assistant grouping inside a session.
+/// - `sessions` - one row per daemon process (uuid PK), carries a
+///   nullable `title` (filled asynchronously by an LLM-summarisation
+///   task after the first agent response) and a `current_branch_id`
+///   pointer into `branches`.
+/// - `turns` - logical user-prompt-to-final-assistant grouping inside
+///   a session.
 /// - `conversations` - one row per `Message`. Tool results are
 ///   `role='tool'` rows with `tool_call_id` / `tool_name` set.
 /// - `conversations_fts` - FTS5 mirror, kept in sync via triggers.
 /// - `memories` - flat KV with provenance (source_conversation_id).
-/// - `conversation_chunks` + `embeddings` - schema only this milestone;
-///   populated by a follow-up that wires the embedder.
+/// - `memory_embeddings` - sibling to `embeddings`, indexes the KV
+///   rows for semantic recall. `UNIQUE(memory_id)` powers the
+///   `INSERT ... ON CONFLICT(memory_id) DO UPDATE` upsert path so
+///   re-saving an existing key overwrites the embedding in place and
+///   no stale vector survives a value change.
+/// - `branches` + `branch_messages` - named branches per session plus
+///   a join table mapping `(branch_id, branch-local seq)` to
+///   `conversation_id`. Forks share `conversations` rows across
+///   branches via separate `branch_messages` entries; no row duplication.
+/// - `conversation_chunks` + `embeddings` - chunked conversation text
+///   with one embedding per chunk for semantic search.
 const V1_SQL: &str = r#"
 CREATE TABLE schema_migrations (
     version    INTEGER PRIMARY KEY,
@@ -31,10 +44,12 @@ CREATE TABLE schema_migrations (
 );
 
 CREATE TABLE sessions (
-    id          TEXT PRIMARY KEY,
-    started_at  TEXT NOT NULL,
-    ended_at    TEXT,
-    daemon_pid  INTEGER NOT NULL
+    id                 TEXT PRIMARY KEY,
+    started_at         TEXT NOT NULL,
+    ended_at           TEXT,
+    daemon_pid         INTEGER NOT NULL,
+    title              TEXT,
+    current_branch_id  INTEGER
 );
 
 CREATE TABLE turns (
@@ -87,6 +102,36 @@ CREATE TABLE memories (
 );
 CREATE INDEX idx_memories_key ON memories(key);
 
+CREATE TABLE memory_embeddings (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    memory_id   INTEGER NOT NULL UNIQUE REFERENCES memories(id) ON DELETE CASCADE,
+    model       TEXT NOT NULL,
+    dim         INTEGER NOT NULL,
+    vector      BLOB NOT NULL,
+    created_at  TEXT NOT NULL
+);
+CREATE INDEX idx_memory_embeddings_model ON memory_embeddings(model);
+
+CREATE TABLE branches (
+    id                INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id        TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    name              TEXT NOT NULL,
+    parent_branch_id  INTEGER REFERENCES branches(id) ON DELETE SET NULL,
+    fork_point_seq    INTEGER,
+    created_at        TEXT NOT NULL,
+    UNIQUE(session_id, name)
+);
+CREATE INDEX idx_branches_session ON branches(session_id);
+
+CREATE TABLE branch_messages (
+    branch_id       INTEGER NOT NULL REFERENCES branches(id) ON DELETE CASCADE,
+    seq             INTEGER NOT NULL,
+    conversation_id INTEGER NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+    PRIMARY KEY (branch_id, seq)
+);
+CREATE INDEX idx_branch_messages_branch_seq ON branch_messages(branch_id, seq);
+CREATE INDEX idx_branch_messages_conv ON branch_messages(conversation_id);
+
 CREATE TABLE conversation_chunks (
     id              INTEGER PRIMARY KEY AUTOINCREMENT,
     conversation_id INTEGER NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
@@ -108,105 +153,10 @@ CREATE TABLE embeddings (
 CREATE INDEX idx_embeddings_model ON embeddings(model);
 "#;
 
-/// V3: conversation branching.
-///
-/// Adds named branches per session plus a `branch_messages` join table
-/// that maps `(branch_id, branch-local seq) -> conversation_id`. We
-/// deliberately do NOT duplicate `conversations` rows on fork; a single
-/// conversation row can be reachable from multiple branches at
-/// different (or the same) seq via separate `branch_messages` entries.
-/// This avoids FTS5 trigger-driven duplication and keeps
-/// `conversation_chunks` / `embeddings` referentially clean.
-///
-/// `sessions` gains `current_branch_id` (NULL on legacy rows; backfilled
-/// to the freshly-inserted "main" branch in this migration). The
-/// existing `conversations.seq` column stays as the session-wide insert
-/// order used by FTS5 ranking; branch-local order lives in
-/// `branch_messages.seq`.
-const V3_SQL: &str = r#"
-CREATE TABLE branches (
-    id                INTEGER PRIMARY KEY AUTOINCREMENT,
-    session_id        TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
-    name              TEXT NOT NULL,
-    parent_branch_id  INTEGER REFERENCES branches(id) ON DELETE SET NULL,
-    fork_point_seq    INTEGER,
-    created_at        TEXT NOT NULL,
-    UNIQUE(session_id, name)
-);
-CREATE INDEX idx_branches_session ON branches(session_id);
-
-CREATE TABLE branch_messages (
-    branch_id       INTEGER NOT NULL REFERENCES branches(id) ON DELETE CASCADE,
-    seq             INTEGER NOT NULL,
-    conversation_id INTEGER NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
-    PRIMARY KEY (branch_id, seq)
-);
-CREATE INDEX idx_branch_messages_branch_seq ON branch_messages(branch_id, seq);
-CREATE INDEX idx_branch_messages_conv ON branch_messages(conversation_id);
-
-ALTER TABLE sessions ADD COLUMN current_branch_id INTEGER REFERENCES branches(id);
-
-INSERT INTO branches (session_id, name, parent_branch_id, fork_point_seq, created_at)
-    SELECT id, 'main', NULL, NULL, started_at FROM sessions;
-
-INSERT INTO branch_messages (branch_id, seq, conversation_id)
-    SELECT b.id, c.seq, c.id
-    FROM conversations c
-    JOIN branches b ON b.session_id = c.session_id AND b.name = 'main';
-
-UPDATE sessions
-    SET current_branch_id = (
-        SELECT id FROM branches
-        WHERE branches.session_id = sessions.id AND name = 'main'
-    );
-"#;
-
-/// V2: per-memory embeddings.
-///
-/// Adds a sibling table to `embeddings` that indexes the `memories` KV
-/// rows for semantic recall. Kept separate from `embeddings` (which is
-/// chunk-keyed) because (a) the data sources are independent (chunks
-/// are unstructured conversation text, memories are key/value facts),
-/// and (b) `ON DELETE CASCADE` on each FK gives free cleanup when the
-/// parent row is deleted, with no nullable FKs or CHECK constraints.
-///
-/// `UNIQUE(memory_id)` is what makes the
-/// `INSERT ... ON CONFLICT(memory_id) DO UPDATE` upsert work: re-saving
-/// the same memory key (which keeps its row id) overwrites the embedding
-/// in place, so a stale vector never survives a value change.
-const V2_SQL: &str = r#"
-CREATE TABLE memory_embeddings (
-    id          INTEGER PRIMARY KEY AUTOINCREMENT,
-    memory_id   INTEGER NOT NULL UNIQUE REFERENCES memories(id) ON DELETE CASCADE,
-    model       TEXT NOT NULL,
-    dim         INTEGER NOT NULL,
-    vector      BLOB NOT NULL,
-    created_at  TEXT NOT NULL
-);
-CREATE INDEX idx_memory_embeddings_model ON memory_embeddings(model);
-"#;
-
-/// V4: per-session human-readable title.
-///
-/// Adds a nullable `title` column to `sessions`, populated asynchronously
-/// after the first agent response in a session by an LLM-summarisation
-/// task in the daemon. The TUI's `/resume` picker prefers this title
-/// over the raw session UUID prefix when listing branches; legacy rows
-/// (and rows whose title generation hasn't completed yet) keep showing
-/// the UUID prefix as a fallback.
-const V4_SQL: &str = r#"
-ALTER TABLE sessions ADD COLUMN title TEXT;
-"#;
-
 /// Build the full migration set. `'static` because the SQL is embedded
 /// in the binary; rusqlite_migration just needs read access.
 pub fn migrations() -> Migrations<'static> {
-    Migrations::new(vec![
-        M::up(V1_SQL),
-        M::up(V2_SQL),
-        M::up(V3_SQL),
-        M::up(V4_SQL),
-    ])
+    Migrations::new(vec![M::up(V1_SQL)])
 }
 
 /// Apply all pending migrations to `conn`. Idempotent: re-running on an

--- a/crates/assistd-memory/src/sqlite/connection.rs
+++ b/crates/assistd-memory/src/sqlite/connection.rs
@@ -55,9 +55,6 @@ impl SqliteHandle {
             .await
             .with_context(|| format!("open SQLite at {}", path_owned.display()))?;
 
-        // Pragmas first, then migrations. WAL gives us concurrent reads
-        // alongside the single writer; foreign_keys must be ON before
-        // any FK is exercised by migrations.
         conn.call(|c| -> rusqlite::Result<_> {
             c.pragma_update(None, "journal_mode", "WAL")?;
             c.pragma_update(None, "synchronous", "NORMAL")?;
@@ -134,9 +131,6 @@ mod tests {
 
     #[tokio::test]
     async fn open_creates_parent_dirs_and_runs_migrations() {
-        // Point at a path inside a non-existent directory; open() must
-        // mkdir -p it. This is exactly what AC #1 ("created automatically
-        // on first run") demands.
         let temp = tempfile::tempdir().unwrap();
         let path = temp.path().join("nested/dir/memory.db");
 

--- a/crates/assistd-memory/src/sqlite/conversations.rs
+++ b/crates/assistd-memory/src/sqlite/conversations.rs
@@ -994,10 +994,6 @@ impl ConversationStore for SqliteConversationStore {
 #[allow(dead_code)]
 fn _force_oneshot_referenced(_: oneshot::Receiver<Result<()>>) {}
 
-/// Wrap a user-supplied query as an FTS5 literal phrase by surrounding
-/// it with double-quotes and doubling any internal quotes (per FTS5's
-/// quoted-string rules). The result is safe to paste into a `MATCH`
-/// expression as a single phrase token.
 fn fts5_literal(s: &str) -> String {
     let mut out = String::with_capacity(s.len() + 2);
     out.push('"');

--- a/crates/assistd-tools/src/commands/wm.rs
+++ b/crates/assistd-tools/src/commands/wm.rs
@@ -778,9 +778,6 @@ mod tests {
 
     #[tokio::test]
     async fn focus_rejects_non_numeric_arg() {
-        // PR 3b: the LLM must use `wm list` to get a numeric con_id;
-        // passing the X11 class (the old PR 3a behavior) is now an
-        // explicit error.
         let stub = Arc::new(StubWm::connected());
         let out = run_wm(stub.clone(), &["focus", "Firefox"]).await;
         assert_eq!(out.exit_code, 2);
@@ -992,9 +989,6 @@ mod tests {
 
     #[tokio::test]
     async fn list_emits_tsv_sorted_by_workspace_then_app() {
-        // PR 3b list format: `<id>\t<app>\t<workspace>\t<title>`.
-        // Sorted by workspace, then app, then id, so two Firefox
-        // windows on the same workspace sit together.
         let stub = Arc::new(StubWm {
             connected: true,
             windows: vec![

--- a/crates/assistd-tools/src/memory_tools.rs
+++ b/crates/assistd-tools/src/memory_tools.rs
@@ -127,10 +127,6 @@ impl Tool for RememberTool {
         }
 
         let memory_id = self.ops.save(&key, value.clone()).await?;
-        // Enqueue an embed job so semantic recall can find this memory
-        // by paraphrase. `try_send` (not `send`) so a wedged embedder
-        // never backpressures the tool. Skip when the id is 0; that's
-        // the `NoMemoryStore` sentinel, no row to FK.
         if memory_id != 0
             && self
                 .embed_tx
@@ -258,8 +254,6 @@ impl Tool for RecallTool {
                     }
                 }
                 Err(e) => {
-                    // Best-effort: log and return empty rather than
-                    // surfacing as a tool error. The LLM can retry next turn.
                     tracing::debug!(
                         target: "assistd::embed",
                         error = %e,

--- a/crates/assistd-tools/src/policy.rs
+++ b/crates/assistd-tools/src/policy.rs
@@ -186,9 +186,6 @@ impl ConfirmRouter {
         match rx.await {
             Ok(allow) => allow,
             Err(_) => {
-                // Pending sender dropped without responding; happens
-                // when the connection's read loop ends before a reply
-                // arrives. Deny.
                 self.pending.lock().remove(&confirm_id);
                 warn!(
                     target: "assistd::policy",
@@ -297,9 +294,6 @@ pub fn matches_destructive<'a>(script: &str, prefixes: &'a [Vec<String>]) -> Opt
     }
     let lower: Vec<String> = tokens.iter().map(|t| t.to_ascii_lowercase()).collect();
 
-    // Split into "commands": anything that isn't a shell separator starts a
-    // new command; these are the positions we try to anchor prefixes at.
-    // Separators include `;`, `&&`, `||`, `|`, and `&`.
     let separators: &[&str] = &["|", "||", ";", "&&", "&"];
     let mut anchors: Vec<usize> = vec![0];
     for (i, tok) in lower.iter().enumerate() {
@@ -621,9 +615,6 @@ mod tests {
 
     #[test]
     fn probe_sandbox_bwrap_missing_fails_startup() {
-        // Inject an empty PATH directly into the inner probe so the test
-        // doesn't touch process-global env, which would race with the rest
-        // of the test binary under `cargo test`'s default thread pool.
         let result = probe_sandbox_in(SandboxRequest::Bwrap, Vec::new(), std::ffi::OsStr::new(""));
         assert!(
             result.is_err(),

--- a/crates/assistd-wm/src/criteria.rs
+++ b/crates/assistd-wm/src/criteria.rs
@@ -33,8 +33,6 @@ mod tests {
         assert_eq!(escape_for_criteria("Firefox"), "Firefox");
         assert_eq!(escape_for_criteria(r#"a"b"#), r#"a\"b"#);
         assert_eq!(escape_for_criteria(r"a\b"), r"a\\b");
-        // Order matters: backslash inserted by quote-escape must NOT be
-        // re-escaped. `a"b` → `a\"b` (single inserted slash, single quote).
         assert_eq!(escape_for_criteria(r#"a"b\c"#), r#"a\"b\\c"#);
     }
 
@@ -68,9 +66,6 @@ mod tests {
 
     #[test]
     fn workspace_id_parse_or_name() {
-        // Parse-or-name preserves the prior alias semantics: digits
-        // round-trip through u32 → Num, everything else → Name.
-        // Zero-padded numbers normalize: "03" parses to 3.
         assert_eq!("3".parse::<WorkspaceId>().unwrap(), WorkspaceId::Num(3));
         assert_eq!("03".parse::<WorkspaceId>().unwrap(), WorkspaceId::Num(3));
         assert_eq!(

--- a/crates/assistd-wm/src/error.rs
+++ b/crates/assistd-wm/src/error.rs
@@ -25,7 +25,7 @@ pub enum WmError {
     /// The backend is not currently connected to a compositor. Either no
     /// backend was configured (`NoWindowManager`), the initial connect
     /// failed, or a previously-connected backend's reconnection
-    /// supervisor (PR 5) is mid-backoff.
+    /// supervisor is mid-backoff.
     #[error("compositor IPC disconnected")]
     Disconnected,
 

--- a/crates/assistd-wm/src/i3.rs
+++ b/crates/assistd-wm/src/i3.rs
@@ -33,12 +33,6 @@ use crate::{
 
 /// `WindowManager` impl wrapping a single i3 IPC command socket.
 /// Held inside `Arc<dyn WindowManager>` by the daemon's `AppState`.
-///
-/// PR 5: the cmd connection is now `Option<I3>`. The supervisor task
-/// sets it to `None` while reconnecting after a socket drop or a
-/// timeout strike, and `Some` once the new connection is seeded. The
-/// trait-method helpers return [`WmError::Disconnected`] for the None
-/// state so callers can render the right hint without blocking.
 pub struct I3Backend {
     cmd: Arc<Mutex<Option<I3>>>,
     snapshot: Arc<RwLock<Snapshot>>,
@@ -176,8 +170,6 @@ impl WindowManager for I3Backend {
             }
             Ok(Ok(t)) => t,
         };
-        // Drop the lock before walking the tree so concurrent calls
-        // can proceed against the shared cmd socket.
         drop(guard);
         let mut out = Vec::new();
         collect_windows(&tree, None, &mut out);
@@ -249,10 +241,6 @@ fn i3_layout_payload(layout: Layout) -> String {
 /// containers). Tracks the most recent `NodeType::Workspace` ancestor
 /// in `current_ws` so each window can be tagged with the workspace it
 /// lives on.
-///
-/// PR 3b: the [`Window::id`] is the i3 con_id (`reply::Node.id`),
-/// which is unique. The X11 class moves into [`Window::app`] for human
-/// display (`wm list`'s second column).
 fn collect_windows(node: &reply::Node, current_ws: Option<&str>, out: &mut Vec<Window>) {
     let next_ws = if matches!(node.node_type, reply::NodeType::Workspace) {
         node.name.as_deref()
@@ -288,10 +276,7 @@ async fn seed_snapshot(cmd: &mut I3) -> Result<Snapshot> {
         .and_then(|n| n.window_properties.as_ref())
         .and_then(|p| p.class.clone());
     let focused_title = focused.and_then(|n| n.name.clone());
-    // Active workspace seeded from a separate query: walking the
-    // tree to the focused leaf's workspace ancestor would work, but
-    // GET_WORKSPACES is one round-trip and gives an authoritative
-    // `focused == true` row that already accounts for multi-output.
+
     let active_workspace = match cmd.get_workspaces().await {
         Ok(ws) => ws.into_iter().find(|w| w.focused).map(|w| w.name),
         Err(e) => {
@@ -480,8 +465,6 @@ mod tests {
 
     #[test]
     fn resize_payload_renders_id_in_decimal() {
-        // No need for escape: con_id is a decimal integer literal,
-        // never a free-form string.
         let p = i3_resize_payload(&id(1234567890), ResizeDir::Shrink, 5);
         assert_eq!(
             p,

--- a/crates/assistd-wm/src/snapshot.rs
+++ b/crates/assistd-wm/src/snapshot.rs
@@ -21,8 +21,6 @@
 //! shape that risks GAT pitfalls and would force every backend to
 //! own-and-pin its event stream. The simpler share-the-rules form
 //! removes the bulk of the duplication without the lifetime gymnastics.
-//! Revisit if PR 5 (reconnection supervisor) ends up wanting the same
-//! generic shape.
 
 use std::sync::Arc;
 

--- a/crates/assistd-wm/src/sway.rs
+++ b/crates/assistd-wm/src/sway.rs
@@ -57,11 +57,6 @@ fn sway_id(raw: i64) -> Option<WindowId> {
 
 /// `WindowManager` impl wrapping a single Sway IPC command socket.
 /// Held inside `Arc<dyn WindowManager>` by the daemon's `AppState`.
-///
-/// PR 5: cmd is `Option<Connection>`. The supervisor task sets it to
-/// `None` while reconnecting after a socket drop or a timeout strike,
-/// and `Some` once the new connection is seeded. Trait-method helpers
-/// short-circuit with [`WmError::Disconnected`] for the None state.
 pub struct SwayBackend {
     cmd: Arc<Mutex<Option<Connection>>>,
     snapshot: Arc<RwLock<Snapshot>>,
@@ -381,9 +376,6 @@ async fn supervisor_loop(
     }
 }
 
-/// Format the Sway RUN_COMMAND payload for `resize_width`. PR 3b
-/// drops the `app_id|class` composite; Sway accepts `[con_id=N]`
-/// criteria for any window regardless of XWayland-vs-Wayland origin.
 fn sway_resize_payload(window: &WindowId, direction: ResizeDir, pixels: u32) -> String {
     format!(
         r#"[con_id="{}"] resize {} width {} px or 0 ppt"#,
@@ -460,10 +452,7 @@ async fn seed_snapshot(cmd: &mut Connection) -> Result<Snapshot> {
             .clone()
             .or_else(|| n.window_properties.as_ref().and_then(|p| p.title.clone()))
     });
-    // Active workspace seeded from a separate query: walking the tree
-    // to the focused leaf's workspace ancestor would work, but
-    // GET_WORKSPACES is one round-trip and gives an authoritative
-    // `focused == true` row that already accounts for multi-output.
+
     let active_workspace = match cmd.get_workspaces().await {
         Ok(ws) => ws.into_iter().find(|w| w.focused).map(|w| w.name),
         Err(e) => {
@@ -479,11 +468,6 @@ async fn seed_snapshot(cmd: &mut Connection) -> Result<Snapshot> {
     })
 }
 
-/// Project a Sway `WindowEvent` into the shared snapshot's
-/// `(id, class, title, kind)` tuple and dispatch to
-/// [`apply_window_event`]. The Sway-specific bits (`app_id` lookup,
-/// XWayland fallback, name-vs-window_properties.title preference)
-/// live here; the race rules live in `crate::snapshot`.
 async fn handle_window_event(w: &swayipc_async::WindowEvent, snap: &Arc<RwLock<Snapshot>>) {
     let kind = match w.change {
         WindowChange::Focus => WindowChangeKind::Focus,
@@ -529,9 +513,6 @@ mod tests {
 
     #[test]
     fn resize_payload_uses_con_id_criteria() {
-        // PR 3b: Sway's `[con_id=N]` is a single-clause match; no
-        // more `app_id|class` composite, since con_id covers Wayland-
-        // native and XWayland views uniformly.
         let p = sway_resize_payload(&id(42), ResizeDir::Grow, 50);
         assert_eq!(p, r#"[con_id="42"] resize grow width 50 px or 0 ppt"#);
     }
@@ -555,8 +536,6 @@ mod tests {
 
     #[test]
     fn layout_payload_emits_bare_form() {
-        // No criteria prefix; Sway speaks the i3 dialect for layout
-        // and acts on the focused container.
         for (l, expected) in [
             (Layout::Default, "layout default"),
             (Layout::Tabbed, "layout tabbed"),

--- a/crates/assistd-wm/tests/common/mod.rs
+++ b/crates/assistd-wm/tests/common/mod.rs
@@ -40,9 +40,6 @@ pub async fn assert_focused_context_agrees(wm: &Arc<dyn WindowManager>) {
         .await
         .expect("focused_context query failed")
         .expect("expected Some(FocusedWindowContext) for a focused session");
-    // PR 3b: focused_window() returns the compositor con_id; the
-    // focused_context().id field carries the same id, surfaced from the
-    // same snapshot read. Both are `Option<WindowId>` (NonZeroU64).
     assert_eq!(
         ctx.id, focused,
         "focused_context().id should agree with focused_window()"

--- a/crates/assistd/src/chat/app.rs
+++ b/crates/assistd/src/chat/app.rs
@@ -46,7 +46,7 @@ pub const SLASH_COMMANDS: &[(&str, &str)] = &[
 /// One image staged by `/attach`, waiting to ride along with the user's
 /// next text submission.
 pub struct PendingAttachment {
-    /// Display name (file basename) shown in the `📎×N` indicator and
+    /// Display name (file basename) shown in the attachment indicator and
     /// the user-prompt tag.
     pub name: String,
     pub mime: String,
@@ -435,9 +435,6 @@ impl App {
         self.slash_selected
     }
 
-    /// Replace the input buffer with the highlighted suggestion. No
-    /// trailing space — the user adds one themselves if the command
-    /// takes an argument.
     fn accept_slash_selection(&mut self) {
         let suggestions = self.slash_suggestions();
         if let Some((cmd, _)) = suggestions.get(self.slash_selected).copied() {
@@ -445,9 +442,6 @@ impl App {
         }
     }
 
-    /// Recompute slash-popup invariants after the input buffer mutates.
-    /// Resets dismissal when the prefix leaves; clamps the selection
-    /// to the (possibly smaller) filtered list.
     fn refresh_slash_state(&mut self) {
         let buf = self.input.buffer();
         if !buf.starts_with('/') {
@@ -560,10 +554,6 @@ impl App {
         }
     }
 
-    /// Process keys while the `/resume` branch picker is open.
-    /// Up/Down move the highlight, Enter dispatches a `Switch`, Esc
-    /// cancels. Other keys are swallowed so the input line stays
-    /// untouched.
     fn handle_picker_key(&mut self, ev: KeyEvent) {
         let Some(picker) = self.picker_modal.as_mut() else {
             return;
@@ -707,19 +697,11 @@ impl App {
         let now = Instant::now();
         match ev {
             Event::Delta { text, .. } => {
-                // First visible delta of a turn (or of a new phase
-                // after thinking) closes any open Thinking block,
-                // stamping its duration and auto-collapsing it.
                 self.output.finish_thinking();
                 self.throughput.on_delta(now);
                 self.output.append_assistant(&text);
             }
             Event::ReasoningDelta { text, .. } => {
-                // Throughput is generation-throughput; reasoning
-                // tokens are generated, so count them here too. The
-                // append_thinking call closes any open assistant
-                // line cleanly and opens a fresh Thinking block when
-                // none is live (mid-turn multi-phase reasoning).
                 self.throughput.on_delta(now);
                 self.output.append_thinking(&text);
             }
@@ -1281,10 +1263,6 @@ impl App {
         self.spawn_branch_command(BranchOp::ResumePicker, req);
     }
 
-    /// Drain the branch buffer that just landed in response to
-    /// `/resume` and open the interactive picker. The current branch
-    /// (in the active session) starts highlighted so Enter on it is a
-    /// no-op switch.
     fn open_branch_picker(&mut self) {
         let entries = std::mem::take(&mut self.branches_buffer);
         if entries.is_empty() {
@@ -1298,9 +1276,6 @@ impl App {
         self.picker_modal = Some(BranchPickerModal { entries, selected });
     }
 
-    /// Dispatch a `Request::Switch` for the currently-highlighted
-    /// branch in the picker, then close the modal. Used by the
-    /// picker's Enter handler.
     fn picker_confirm(&mut self) {
         let target = match self.picker_modal.as_ref().and_then(|m| m.current_target()) {
             Some(t) => t,
@@ -1313,11 +1288,6 @@ impl App {
         self.handle_switch_cmd(target);
     }
 
-    /// Open a daemon dialog connection for a Query and pump its
-    /// streaming events onto `chat_tx`. The dialog connection stays
-    /// open while the query is generating so the modal can write a
-    /// `Request::ConfirmResponse` back on the same connection if the
-    /// model triggers a destructive bash command.
     fn spawn_query(&mut self, text: String, attachments: Vec<Attachment>) {
         let ipc = self.ipc.clone();
         let chat_tx = self.chat_tx.clone();

--- a/crates/assistd/src/chat/app.rs
+++ b/crates/assistd/src/chat/app.rs
@@ -1297,12 +1297,7 @@ impl App {
 
         let req_id = Uuid::new_v4().to_string();
         let req = if attachments.is_empty() {
-            Request::Query {
-                id: req_id,
-                text,
-                attachments: Vec::new(),
-                version: Some(assistd_ipc::PROTOCOL_VERSION),
-            }
+            Request::query(req_id, text)
         } else {
             let wire_attachments: Vec<assistd_ipc::ImageAttachment> = attachments
                 .into_iter()
@@ -1312,12 +1307,7 @@ impl App {
                     }
                 })
                 .collect();
-            Request::Query {
-                id: req_id,
-                text,
-                attachments: wire_attachments,
-                version: Some(assistd_ipc::PROTOCOL_VERSION),
-            }
+            Request::query_with_attachments(req_id, text, wire_attachments)
         };
 
         tokio::spawn(async move {

--- a/crates/assistd/src/chat/mod.rs
+++ b/crates/assistd/src/chat/mod.rs
@@ -279,13 +279,6 @@ async fn run_tui(ctx: TuiContext) -> Result<()> {
     Ok(())
 }
 
-/// Auto-spawn a detached daemon child. We exec the same binary
-/// (`current_exe`) so a `cargo run` build doesn't accidentally fork
-/// off a stale system install. The child calls `setsid()` itself on
-/// startup (gated on `--client-mode`) so it becomes its own session
-/// leader and survives the TUI's controlling-terminal closing; we
-/// drop the `Child` handle without reaping, which is fine because
-/// the daemon already self-handles SIGTERM.
 fn spawn_daemon_detached(config: Option<&Path>) -> Result<()> {
     use std::process::{Command, Stdio};
 

--- a/crates/assistd/src/chat/output.rs
+++ b/crates/assistd/src/chat/output.rs
@@ -146,7 +146,7 @@ impl OutputPane {
     }
 
     /// Push a styled informational line, used by `/attach` to confirm
-    /// "📎 attached: name.png (image/png, 12 KB)" without polluting the
+    /// "attached: name.png (image/png, 12 KB)" without polluting the
     /// error stream. Distinct from `push_user` (no `> ` prefix) and
     /// `push_error` (no `!! ` prefix or red color).
     pub fn push_info(&mut self, text: &str) {
@@ -484,12 +484,6 @@ impl OutputPane {
 
     fn close_open_assistant(&mut self) {
         if let Some(idx) = self.open_assistant.take() {
-            // The `begin_submit` flow proactively opens an empty
-            // assistant line so streaming Deltas have somewhere to
-            // land. If reasoning arrives first (no Delta yet), the
-            // line is still empty when we close it — pop instead of
-            // appending a blank separator on top of nothing, which
-            // would leave a stray empty row above the Thinking block.
             let empty = matches!(
                 self.items.get(idx),
                 Some(OutputItem::Text(l)) if l.spans.iter().all(|s| s.content.is_empty())
@@ -667,9 +661,6 @@ fn wrap_line_into(out: &mut Vec<Line<'static>>, line: &Line<'static>, width: u16
         out.push(Line::from(""));
         return;
     }
-    // When the line carries a background color (e.g. the user-message
-    // box), pad each wrapped chunk out to the full viewport width so the
-    // highlight extends across the row instead of stopping at the text.
     let pad_to_width = style.bg.is_some();
     for chunk in wrapped {
         let mut s = chunk.into_owned();
@@ -701,8 +692,6 @@ fn render_thinking_block(
     );
     if (t.expanded || verbose) && !t.text.is_empty() {
         for line in t.text.lines() {
-            // Empty lines in the body still need a bar so the visual
-            // column stays continuous through paragraph breaks.
             if line.is_empty() {
                 out.push(Line::from(vec![bar.clone()]));
             } else {
@@ -713,11 +702,6 @@ fn render_thinking_block(
     out.push(Line::from(""));
 }
 
-/// Header label for a Thinking block. Reads `"✻ Thinking… (Ns)"` while
-/// the block is live; the integer-second display advances at most
-/// 1 Hz (the `App::on_tick` reducer marks the output pane dirty when
-/// the second changes). After `finish_thinking`, the label freezes at
-/// `"✦ Thought for Ns"` with the final duration.
 fn thinking_header_text(t: &ThinkingBlock) -> String {
     let elapsed = match t.ended_at {
         Some(end) => end.saturating_duration_since(t.started_at),

--- a/crates/assistd/src/chat/ui.rs
+++ b/crates/assistd/src/chat/ui.rs
@@ -57,10 +57,6 @@ pub fn render(frame: &mut Frame, app: &mut App) {
     }
 }
 
-/// Render the `/resume` branch-picker modal. Each row shows the
-/// session prefix, branch name, message count, and parent (when
-/// forked); the currently-selected row is shown in reverse video
-/// and the active-session current branch carries a `●` marker.
 fn render_branch_picker_modal(frame: &mut Frame, area: Rect, picker: &BranchPickerModal) {
     let width = (area.width.saturating_mul(4) / 5).clamp(50, 120);
     let max_height = area.height.saturating_sub(2);
@@ -161,9 +157,6 @@ fn render_branch_picker_modal(frame: &mut Frame, area: Rect, picker: &BranchPick
     frame.render_widget(Paragraph::new(footer), footer_area);
 }
 
-/// Render the slash-command suggestion list above the status bar.
-/// The selected row is shown in reverse video; usage hints (e.g.
-/// `<path>` next to `/attach`) appear in dim text.
 fn render_slash_popup(
     frame: &mut Frame,
     area: Rect,
@@ -299,11 +292,6 @@ fn render_output(frame: &mut Frame, area: Rect, app: &mut App) {
         }
     }
 
-    // Inline "Generating…" indicator pinned to the bottom row of the
-    // chat pane while a turn is in flight. Replaces the bottom
-    // status-bar chip; staying inside the output rect keeps the cue
-    // visually attached to the current reply rather than buried at
-    // the screen edge.
     if app.generating {
         let row = Rect {
             x: area.x,
@@ -522,9 +510,6 @@ fn render_input(frame: &mut Frame, area: Rect, app: &App) {
     frame.set_cursor_position(Position::new(cx, cy));
 }
 
-/// Number of rows the input area needs to display `buffer` plus the prompt,
-/// wrapping at `frame_width` cells. Capped so the output pane keeps at least
-/// its minimum height (3 rows) plus the 1-row status bar.
 fn compute_input_height(frame_width: u16, frame_height: u16, buffer: &str) -> u16 {
     if frame_width == 0 {
         return 1;
@@ -536,16 +521,6 @@ fn compute_input_height(frame_width: u16, frame_height: u16, buffer: &str) -> u1
     needed.clamp(1, cap)
 }
 
-/// Word-aware wrap of the input buffer. Returns `(start, end)` char-index
-/// ranges for each visible row. The first row reserves `prompt_w` cells
-/// for the `"> "` prompt; subsequent rows use the full frame width.
-///
-/// Breaks happen at the last whitespace boundary that fits inside the
-/// row, so a word never splits across rows. When a single word is wider
-/// than the row, we fall back to a hard character break (the only way
-/// to make forward progress). If the last row exactly fills its visible
-/// width, an empty phantom row is appended so the cursor at end-of-buffer
-/// has somewhere visible to sit.
 fn wrap_input(buf: &[char], prompt_w: u16, width: u16) -> Vec<(usize, usize)> {
     let n = buf.len();
     if width == 0 {
@@ -596,9 +571,6 @@ fn wrap_input(buf: &[char], prompt_w: u16, width: u16) -> Vec<(usize, usize)> {
     rows
 }
 
-/// Locate the cursor in the wrapped layout. Returns `(row_idx, col)`.
-/// When the cursor sits exactly on a wrap boundary, it lands at column 0
-/// of the next row so editing past a wrap looks natural.
 fn locate_cursor(rows: &[(usize, usize)], cursor: usize) -> (usize, usize) {
     for (idx, &(s, e)) in rows.iter().enumerate() {
         if cursor < e {

--- a/crates/assistd/src/daemon.rs
+++ b/crates/assistd/src/daemon.rs
@@ -177,6 +177,7 @@ pub async fn run(args: DaemonArgs) -> Result<()> {
 
     let mut mcp = mcp_init::init(&config, &shutdown_tx).await;
     let mcp_tools = std::mem::take(&mut mcp.tools);
+    let mcp_startup_failures = mcp.startup_failures.clone();
 
     let tools = assistd_core::build_tools(assistd_core::BuildToolsDeps {
         config: &config,
@@ -243,7 +244,8 @@ pub async fn run(args: DaemonArgs) -> Result<()> {
         voice.output,
     )
     .with_window_manager(window_manager)
-    .with_vision_revalidator(vision_revalidator);
+    .with_vision_revalidator(vision_revalidator)
+    .with_mcp_startup_failures(mcp_startup_failures);
 
     let mut memory_stack = MemoryStack::disabled(embedding_cfg_for_state)
         .with_memory(memory_store)

--- a/crates/assistd/src/daemon.rs
+++ b/crates/assistd/src/daemon.rs
@@ -97,10 +97,6 @@ pub async fn run(args: DaemonArgs) -> Result<()> {
 
     assistd_core::install_panic_hook(Arc::downgrade(&presence));
 
-    // In router mode the daemon-managed port hosts only the router; the
-    // real /props (with `modalities`) lives on the child server's
-    // transient port. `probe_capabilities_routed` follows that indirection
-    // when present, and degrades to the direct path otherwise.
     let initial_vision_state = {
         let control = assistd_llm::LlamaServerControl::new(
             &config.llama_server.host,
@@ -198,11 +194,6 @@ pub async fn run(args: DaemonArgs) -> Result<()> {
         overflow_dir.display()
     );
 
-    // Partition the unified registry into native vs MCP by the same
-    // `mcp__` prefix mcp_init.rs stamps onto adapted tools, then render
-    // each half as a Markdown bullet section and append both to the
-    // configured base prompt. This is the single point of system-prompt
-    // assembly: adding a new tool surfaces in the prompt automatically.
     let (native_refs, mcp_refs): (Vec<&dyn assistd_tools::Tool>, Vec<&dyn assistd_tools::Tool>) =
         tools
             .iter_tools()
@@ -363,9 +354,6 @@ async fn replay_history(chat: &dyn assistd_llm::LlmBackend, rows: Vec<assistd_me
     }
 }
 
-/// Append `block` to `prompt` with a `\n\n` separator, but only when
-/// `block` is non-empty. Keeps the augmented system prompt tidy when one
-/// of the bullet sections (typically MCP) is empty.
 fn append_prompt_block(prompt: &mut String, block: &str) {
     if block.is_empty() {
         return;

--- a/crates/assistd/src/hotkey.rs
+++ b/crates/assistd/src/hotkey.rs
@@ -202,8 +202,6 @@ pub fn spawn_listener(
     Some(tokio::spawn(hotkeys.run(manager, subsystems, shutdown)))
 }
 
-// Parse and register one configured hotkey string. Returns `None` on parse
-// or registration failure; the daemon stays up via IPC socket fallback.
 fn register(
     manager: &GlobalHotKeyManager,
     spec: Option<String>,

--- a/crates/assistd/src/mcp_init.rs
+++ b/crates/assistd/src/mcp_init.rs
@@ -8,7 +8,7 @@
 
 use std::time::Duration;
 
-use assistd_core::{Config, McpServerConfig, McpTransport};
+use assistd_core::{Config, McpServerConfig, McpStartupFailure, McpTransport};
 use assistd_mcp::{
     McpServerHandle, SseConfig, StdioConfig, TransportConfig, adapt_handle_as_tools,
 };
@@ -21,6 +21,11 @@ pub struct McpSubsystem {
     pub handles: Vec<McpServerHandle>,
     /// Tool adapters discovered from each server's `tools/list` response.
     pub tools: Vec<Box<dyn assistd_tools::Tool>>,
+    /// Servers that failed to start or complete discovery; surfaced to
+    /// connected clients via `Event::Status` during `GetCapabilities` so
+    /// the TUI can render a warning instead of letting the user discover
+    /// the failure only when the model tries to call a tool.
+    pub startup_failures: Vec<McpStartupFailure>,
 }
 
 impl McpSubsystem {
@@ -35,18 +40,21 @@ impl McpSubsystem {
 /// Start all configured MCP servers and adapt their tools.
 ///
 /// Servers that fail to start or fail tool discovery are skipped with a
-/// warning; they do not prevent the daemon from starting.
+/// warning and recorded in [`McpSubsystem::startup_failures`]; they do
+/// not prevent the daemon from starting.
 pub async fn init(config: &Config, shutdown_tx: &watch::Sender<bool>) -> McpSubsystem {
     if !config.mcp.enabled {
         info!("mcp: disabled in config (mcp.enabled = false)");
         return McpSubsystem {
             handles: Vec::new(),
             tools: Vec::new(),
+            startup_failures: Vec::new(),
         };
     }
 
     let mut handles: Vec<McpServerHandle> = Vec::new();
     let mut tools: Vec<Box<dyn assistd_tools::Tool>> = Vec::new();
+    let mut startup_failures: Vec<McpStartupFailure> = Vec::new();
     for s_cfg in &config.mcp.servers {
         let transport_cfg = build_transport_config(s_cfg);
         let label = s_cfg.name.clone();
@@ -65,20 +73,31 @@ pub async fn init(config: &Config, shutdown_tx: &watch::Sender<bool>) -> McpSubs
                         handles.push(handle);
                     }
                     Err(e) => {
-                        tracing::warn!(
-                            "mcp: {} discovery failed ({e:#}); shutting down server",
-                            handle.name
-                        );
+                        let reason = format!("discovery failed: {e:#}");
+                        tracing::warn!("mcp: {} {reason}; shutting down server", handle.name);
+                        startup_failures.push(McpStartupFailure {
+                            server_name: handle.name.clone(),
+                            reason,
+                        });
                         handle.shutdown().await;
                     }
                 }
             }
             Err(e) => {
-                tracing::warn!("mcp: {label} failed to start ({e:#}); skipping");
+                let reason = format!("failed to start: {e:#}");
+                tracing::warn!("mcp: {label} {reason}; skipping");
+                startup_failures.push(McpStartupFailure {
+                    server_name: label,
+                    reason,
+                });
             }
         }
     }
-    McpSubsystem { handles, tools }
+    McpSubsystem {
+        handles,
+        tools,
+        startup_failures,
+    }
 }
 
 fn build_transport_config(s: &McpServerConfig) -> TransportConfig {

--- a/crates/assistd/src/memory_init.rs
+++ b/crates/assistd/src/memory_init.rs
@@ -156,9 +156,7 @@ fn pid_is_alive(pid: u32) -> bool {
     let Some(pid) = rustix::process::Pid::from_raw(pid as i32) else {
         return false;
     };
-    // `test_kill_process` issues `kill(pid, 0)`: no memory read, no signal
-    // sent, just an existence probe. EPERM means the process exists but
-    // we can't signal it; ESRCH (and anything else) means it's gone.
+
     match rustix::process::test_kill_process(pid) {
         Ok(()) => true,
         Err(rustix::io::Errno::PERM) => true,

--- a/crates/assistd/src/ptt.rs
+++ b/crates/assistd/src/ptt.rs
@@ -3,13 +3,6 @@
 //! Unix socket, prints event lines as they arrive (voice state, the
 //! final transcription, and for `ptt-stop' the streaming LLM
 //! response), and exits on `Event::Done` or `Event::Error`.
-//!
-//! Typical i3 binding:
-//!
-//! ```text
-//! bindsym           $mod+space exec --no-startup-id assistd ptt-start
-//! bindsym --release $mod+space exec --no-startup-id assistd ptt-stop
-//! ```
 
 use std::io::Write;
 


### PR DESCRIPTION
Final comment cleanup, removal of any legacy backporting (which was unneeded since everything was indev up until this point), and flattening migrations (v1, v2, v3, v4) into a single migration.