### PR TITLE
Add passive subscribe request to assistd-core

### DIFF
--- a/crates/assistd-core/src/socket.rs
+++ b/crates/assistd-core/src/socket.rs
@@ -297,12 +297,6 @@ async fn handle_connection(stream: UnixStream, state: Arc<AppState>) -> Result<(
 
     let router = ConfirmRouter::new(req.id().to_string(), tx.clone());
 
-    // Tee broadcast-eligible events from this connection's outbound
-    // stream onto the daemon-wide events bus so `Request::Subscribe`
-    // connections can observe activity. Skipped on Subscribe
-    // connections themselves to prevent a feedback loop: a Subscribe
-    // forwarder's events came *from* the bus, and re-broadcasting
-    // them would amplify every event across every subscriber.
     let is_subscribe = matches!(req, Request::Subscribe { .. });
     let events_bus = state.runtime.events_bus().clone();
 
@@ -314,7 +308,9 @@ async fn handle_connection(stream: UnixStream, state: Arc<AppState>) -> Result<(
     };
     let forward_fut = async {
         while let Some(event) = rx.recv().await {
-            if !is_subscribe && let Some(_kind) = event.kind() {
+            // Subscribe forwarders read from the bus; teeing back
+            // onto it would loop.
+            if !is_subscribe && event.kind().is_some() {
                 let _ = events_bus.send(event.clone());
             }
             write_event(&mut write_half, &event).await?;
@@ -1406,10 +1402,6 @@ mod tests {
         .await;
     }
 
-    /// Open a Subscribe connection without closing the write half (the
-    /// daemon keeps the stream open for the lifetime of the
-    /// subscription). Returns the write half (so the test can drop it
-    /// to signal shutdown) plus a buffered reader for events.
     async fn open_subscribe_stream(
         path: &Path,
         body: &str,
@@ -1425,10 +1417,6 @@ mod tests {
         (write, BufReader::new(read))
     }
 
-    /// Drain a Subscribe stream until either the per-line timeout
-    /// fires (the stream is idle) or the connection closes. Used by
-    /// integration tests to capture every event a subscriber received
-    /// up to a steady state.
     async fn drain_subscribe(
         reader: &mut BufReader<tokio::net::unix::OwnedReadHalf>,
         idle: std::time::Duration,
@@ -1451,21 +1439,16 @@ mod tests {
     #[tokio::test]
     async fn subscribe_receives_query_events_from_other_client() {
         with_server(test_state(), |path| async move {
-            // Open client A as a passive subscriber with the default
-            // (empty) filter — it should see every broadcast-eligible
-            // event the daemon emits.
             let (_write_a, mut read_a) = open_subscribe_stream(
                 &path,
                 r#"{"type":"subscribe","id":"sub-1","filter":{"kinds":[]}}"#,
             )
             .await;
 
-            // Give the Subscribe handler a moment to register on the
-            // broadcast bus before client B starts emitting events.
+            // Let the Subscribe handler attach to the bus before B
+            // starts emitting; otherwise the events race past it.
             tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
-            // Client B runs a normal Query. Per-request flow must be
-            // unchanged (regression check).
             let b_events = send_request_collect_events(
                 &path,
                 r#"{"type":"query","id":"q-1","text":"hello"}"#,
@@ -1480,13 +1463,6 @@ mod tests {
                 "client B regression: expected terminal Done(q-1), got {b_events:?}"
             );
 
-            // Client A should have observed the Query's Delta and
-            // Done events on the bus, plus at least one LastDelta
-            // (the on-Done flush is mandatory; the in-stream
-            // debounced emission may or may not fire depending on
-            // timing, but EchoBackend emits one Delta which sits
-            // ≥100 ms after the initial Instant::now() - DEBOUNCE,
-            // so the in-stream emission also fires here).
             let a_events =
                 drain_subscribe(&mut read_a, std::time::Duration::from_millis(200)).await;
             assert!(
@@ -1514,7 +1490,6 @@ mod tests {
     #[tokio::test]
     async fn subscribe_filter_rejects_unmatched_kinds() {
         with_server(test_state(), |path| async move {
-            // Client A subscribes with a Presence-only filter.
             let (_write_a, mut read_a) = open_subscribe_stream(
                 &path,
                 r#"{"type":"subscribe","id":"sub-2","filter":{"kinds":["presence"]}}"#,
@@ -1522,12 +1497,9 @@ mod tests {
             .await;
             tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
-            // A Query should produce Delta/Done on the bus, but the
-            // Presence-only filter must drop them.
             let _ =
                 send_request_collect_events(&path, r#"{"type":"query","id":"q-2","text":"hi"}"#)
                     .await;
-            // Now flip presence — that *does* match the filter.
             let _ = send_request_collect_events(
                 &path,
                 r#"{"type":"set_presence","id":"sp-1","target":"sleeping"}"#,
@@ -1536,7 +1508,6 @@ mod tests {
 
             let a_events =
                 drain_subscribe(&mut read_a, std::time::Duration::from_millis(200)).await;
-            // Nothing from the Query: neither Delta(q-2) nor Done(q-2).
             assert!(
                 a_events.iter().all(|e| !matches!(
                     e,
@@ -1544,7 +1515,6 @@ mod tests {
                 )),
                 "Presence-only filter leaked Query events: {a_events:?}"
             );
-            // But the Presence event passes.
             assert!(
                 a_events.iter().any(|e| matches!(
                     e,
@@ -1558,11 +1528,6 @@ mod tests {
 
     #[tokio::test]
     async fn subscribe_does_not_self_loop() {
-        // A subscriber's own forward task must not re-broadcast the
-        // events it writes (those events came from the bus in the
-        // first place). Verify by attaching a subscriber and waiting
-        // — no other client is connected, so the only way A could
-        // see an event is via a feedback loop.
         with_server(test_state(), |path| async move {
             let (_write_a, mut read_a) = open_subscribe_stream(
                 &path,

--- a/crates/assistd-core/src/socket.rs
+++ b/crates/assistd-core/src/socket.rs
@@ -297,6 +297,15 @@ async fn handle_connection(stream: UnixStream, state: Arc<AppState>) -> Result<(
 
     let router = ConfirmRouter::new(req.id().to_string(), tx.clone());
 
+    // Tee broadcast-eligible events from this connection's outbound
+    // stream onto the daemon-wide events bus so `Request::Subscribe`
+    // connections can observe activity. Skipped on Subscribe
+    // connections themselves to prevent a feedback loop: a Subscribe
+    // forwarder's events came *from* the bus, and re-broadcasting
+    // them would amplify every event across every subscriber.
+    let is_subscribe = matches!(req, Request::Subscribe { .. });
+    let events_bus = state.runtime.events_bus().clone();
+
     let router_for_dispatch = router.clone();
     let dispatch_fut = async move {
         CONFIRM_ROUTER
@@ -305,6 +314,9 @@ async fn handle_connection(stream: UnixStream, state: Arc<AppState>) -> Result<(
     };
     let forward_fut = async {
         while let Some(event) = rx.recv().await {
+            if !is_subscribe && let Some(_kind) = event.kind() {
+                let _ = events_bus.send(event.clone());
+            }
             write_event(&mut write_half, &event).await?;
         }
         Ok::<_, SocketError>(write_half)
@@ -1390,6 +1402,180 @@ mod tests {
                 "expected Delta, got {events:?}"
             );
             assert!(matches!(events.last(), Some(Event::Done { id }) if id == "future"));
+        })
+        .await;
+    }
+
+    /// Open a Subscribe connection without closing the write half (the
+    /// daemon keeps the stream open for the lifetime of the
+    /// subscription). Returns the write half (so the test can drop it
+    /// to signal shutdown) plus a buffered reader for events.
+    async fn open_subscribe_stream(
+        path: &Path,
+        body: &str,
+    ) -> (
+        tokio::net::unix::OwnedWriteHalf,
+        BufReader<tokio::net::unix::OwnedReadHalf>,
+    ) {
+        let stream = UnixStream::connect(path).await.unwrap();
+        let (read, mut write) = stream.into_split();
+        write.write_all(body.as_bytes()).await.unwrap();
+        write.write_all(b"\n").await.unwrap();
+        write.flush().await.unwrap();
+        (write, BufReader::new(read))
+    }
+
+    /// Drain a Subscribe stream until either the per-line timeout
+    /// fires (the stream is idle) or the connection closes. Used by
+    /// integration tests to capture every event a subscriber received
+    /// up to a steady state.
+    async fn drain_subscribe(
+        reader: &mut BufReader<tokio::net::unix::OwnedReadHalf>,
+        idle: std::time::Duration,
+    ) -> Vec<Event> {
+        let mut out = Vec::new();
+        loop {
+            let mut line = String::new();
+            match tokio::time::timeout(idle, reader.read_line(&mut line)).await {
+                Ok(Ok(0)) => break,
+                Ok(Ok(_)) => match serde_json::from_str::<Event>(line.trim()) {
+                    Ok(ev) => out.push(ev),
+                    Err(e) => panic!("subscriber received invalid event {line:?}: {e}"),
+                },
+                Ok(Err(_)) | Err(_) => break,
+            }
+        }
+        out
+    }
+
+    #[tokio::test]
+    async fn subscribe_receives_query_events_from_other_client() {
+        with_server(test_state(), |path| async move {
+            // Open client A as a passive subscriber with the default
+            // (empty) filter — it should see every broadcast-eligible
+            // event the daemon emits.
+            let (_write_a, mut read_a) = open_subscribe_stream(
+                &path,
+                r#"{"type":"subscribe","id":"sub-1","filter":{"kinds":[]}}"#,
+            )
+            .await;
+
+            // Give the Subscribe handler a moment to register on the
+            // broadcast bus before client B starts emitting events.
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+            // Client B runs a normal Query. Per-request flow must be
+            // unchanged (regression check).
+            let b_events = send_request_collect_events(
+                &path,
+                r#"{"type":"query","id":"q-1","text":"hello"}"#,
+            )
+            .await;
+            assert!(
+                matches!(b_events.first(), Some(Event::Delta { id, text }) if id == "q-1" && text == "hello"),
+                "client B regression: expected Delta(q-1, hello) first, got {b_events:?}"
+            );
+            assert!(
+                matches!(b_events.last(), Some(Event::Done { id }) if id == "q-1"),
+                "client B regression: expected terminal Done(q-1), got {b_events:?}"
+            );
+
+            // Client A should have observed the Query's Delta and
+            // Done events on the bus, plus at least one LastDelta
+            // (the on-Done flush is mandatory; the in-stream
+            // debounced emission may or may not fire depending on
+            // timing, but EchoBackend emits one Delta which sits
+            // ≥100 ms after the initial Instant::now() - DEBOUNCE,
+            // so the in-stream emission also fires here).
+            let a_events =
+                drain_subscribe(&mut read_a, std::time::Duration::from_millis(200)).await;
+            assert!(
+                a_events
+                    .iter()
+                    .any(|e| matches!(e, Event::Delta { id, text } if id == "q-1" && text == "hello")),
+                "subscriber missed Delta from q-1; got {a_events:?}"
+            );
+            assert!(
+                a_events
+                    .iter()
+                    .any(|e| matches!(e, Event::Done { id } if id == "q-1")),
+                "subscriber missed Done from q-1; got {a_events:?}"
+            );
+            assert!(
+                a_events
+                    .iter()
+                    .any(|e| matches!(e, Event::LastDelta { id, text } if id == "q-1" && text == "hello")),
+                "subscriber missed LastDelta(q-1, 'hello'); got {a_events:?}"
+            );
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn subscribe_filter_rejects_unmatched_kinds() {
+        with_server(test_state(), |path| async move {
+            // Client A subscribes with a Presence-only filter.
+            let (_write_a, mut read_a) = open_subscribe_stream(
+                &path,
+                r#"{"type":"subscribe","id":"sub-2","filter":{"kinds":["presence"]}}"#,
+            )
+            .await;
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+            // A Query should produce Delta/Done on the bus, but the
+            // Presence-only filter must drop them.
+            let _ =
+                send_request_collect_events(&path, r#"{"type":"query","id":"q-2","text":"hi"}"#)
+                    .await;
+            // Now flip presence — that *does* match the filter.
+            let _ = send_request_collect_events(
+                &path,
+                r#"{"type":"set_presence","id":"sp-1","target":"sleeping"}"#,
+            )
+            .await;
+
+            let a_events =
+                drain_subscribe(&mut read_a, std::time::Duration::from_millis(200)).await;
+            // Nothing from the Query: neither Delta(q-2) nor Done(q-2).
+            assert!(
+                a_events.iter().all(|e| !matches!(
+                    e,
+                    Event::Delta { id, .. } | Event::Done { id, .. } if id == "q-2"
+                )),
+                "Presence-only filter leaked Query events: {a_events:?}"
+            );
+            // But the Presence event passes.
+            assert!(
+                a_events.iter().any(|e| matches!(
+                    e,
+                    Event::Presence { id, .. } if id == "sp-1"
+                )),
+                "expected Presence(sp-1) on subscriber, got {a_events:?}"
+            );
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn subscribe_does_not_self_loop() {
+        // A subscriber's own forward task must not re-broadcast the
+        // events it writes (those events came from the bus in the
+        // first place). Verify by attaching a subscriber and waiting
+        // — no other client is connected, so the only way A could
+        // see an event is via a feedback loop.
+        with_server(test_state(), |path| async move {
+            let (_write_a, mut read_a) = open_subscribe_stream(
+                &path,
+                r#"{"type":"subscribe","id":"sub-3","filter":{"kinds":[]}}"#,
+            )
+            .await;
+
+            let a_events =
+                drain_subscribe(&mut read_a, std::time::Duration::from_millis(150)).await;
+            assert!(
+                a_events.is_empty(),
+                "idle subscriber emitted unexpected events: {a_events:?}"
+            );
         })
         .await;
     }

--- a/crates/assistd-core/src/state/mod.rs
+++ b/crates/assistd-core/src/state/mod.rs
@@ -17,6 +17,7 @@ pub(crate) mod persistence;
 pub(crate) mod presence_handlers;
 pub(crate) mod query;
 pub(crate) mod runtime;
+pub(crate) mod subscribe;
 pub(crate) mod subsystems;
 pub(crate) mod voice_handlers;
 pub(crate) mod wire;
@@ -80,6 +81,12 @@ impl AppState {
     /// is responsible for surfacing `Err` to the client as an
     /// [`Event::Error`] if one hasn't been emitted already.
     pub async fn dispatch(self: Arc<Self>, req: Request, tx: mpsc::Sender<Event>) -> Result<()> {
+        // `Subscribe` is long-lived by design (a passive bus
+        // attachment that stays open until the client disconnects),
+        // so the `dispatch_envelope_secs` cap doesn't apply.
+        if matches!(req, Request::Subscribe { .. }) {
+            return self.dispatch_inner(req, tx).await;
+        }
         let envelope = Duration::from_secs(self.config.timeouts.dispatch_envelope_secs);
         let req_id = req.id().to_string();
         let req_kind = req.kind();
@@ -154,6 +161,7 @@ impl AppState {
                 self.handle_resume_or_new(id, recency_secs, tx).await
             }
             Request::NewSession { id } => self.handle_new_session(id, tx).await,
+            Request::Subscribe { id, filter } => self.handle_subscribe(id, filter, tx).await,
             Request::ConfirmResponse { id, confirm_id, .. } => {
                 let _ = tx
                     .send(Event::Error {

--- a/crates/assistd-core/src/state/mod.rs
+++ b/crates/assistd-core/src/state/mod.rs
@@ -81,9 +81,7 @@ impl AppState {
     /// is responsible for surfacing `Err` to the client as an
     /// [`Event::Error`] if one hasn't been emitted already.
     pub async fn dispatch(self: Arc<Self>, req: Request, tx: mpsc::Sender<Event>) -> Result<()> {
-        // `Subscribe` is long-lived by design (a passive bus
-        // attachment that stays open until the client disconnects),
-        // so the `dispatch_envelope_secs` cap doesn't apply.
+        // Subscribe lives for the client's lifetime; no envelope cap.
         if matches!(req, Request::Subscribe { .. }) {
             return self.dispatch_inner(req, tx).await;
         }

--- a/crates/assistd-core/src/state/query.rs
+++ b/crates/assistd-core/src/state/query.rs
@@ -24,12 +24,8 @@ use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use tracing::Instrument;
 
-/// Maximum cadence at which a turn's running reply is republished as
-/// [`Event::LastDelta`] on the broadcast bus. Picked to feel real-time
-/// (≤100 ms staleness) for a status-bar consumer while bounding the
-/// per-turn bus traffic at ~10 events/sec regardless of token rate.
-/// A final `LastDelta` carrying the complete reply is always flushed
-/// when the turn ends, regardless of this window.
+/// Caps the per-turn `Event::LastDelta` republish rate so a fast
+/// token stream doesn't flood passive subscribers.
 const LAST_DELTA_DEBOUNCE: Duration = Duration::from_millis(100);
 
 /// The two presence-side guards that must outlive the entire turn
@@ -295,8 +291,7 @@ impl AppState {
         let mut first_sentence_emitted = false;
 
         let events_bus = self.runtime.events_bus().clone();
-        // Initialize so the first Delta is eligible to emit a
-        // LastDelta without waiting a full debounce window.
+        // Backdate so the first Delta emits without waiting a window.
         let mut last_emit_at = Instant::now()
             .checked_sub(LAST_DELTA_DEBOUNCE)
             .unwrap_or_else(Instant::now);

--- a/crates/assistd-core/src/state/query.rs
+++ b/crates/assistd-core/src/state/query.rs
@@ -19,10 +19,18 @@ use assistd_memory::{PersistedMessage, SessionId, TurnId};
 use assistd_tools::Attachment;
 use assistd_voice::{SentenceBuffer, SpeakDecision};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use tracing::Instrument;
+
+/// Maximum cadence at which a turn's running reply is republished as
+/// [`Event::LastDelta`] on the broadcast bus. Picked to feel real-time
+/// (≤100 ms staleness) for a status-bar consumer while bounding the
+/// per-turn bus traffic at ~10 events/sec regardless of token rate.
+/// A final `LastDelta` carrying the complete reply is always flushed
+/// when the turn ends, regardless of this window.
+const LAST_DELTA_DEBOUNCE: Duration = Duration::from_millis(100);
 
 /// The two presence-side guards that must outlive the entire turn
 /// (including post-Done audio playback). The agent-turn lock is held
@@ -286,6 +294,13 @@ impl AppState {
         let mut client_alive = true;
         let mut first_sentence_emitted = false;
 
+        let events_bus = self.runtime.events_bus().clone();
+        // Initialize so the first Delta is eligible to emit a
+        // LastDelta without waiting a full debounce window.
+        let mut last_emit_at = Instant::now()
+            .checked_sub(LAST_DELTA_DEBOUNCE)
+            .unwrap_or_else(Instant::now);
+
         loop {
             let llm_event = match (partial_flush, awaiting_tool_result) {
                 (Some(d), false) => match tokio::time::timeout(d, llm_rx.recv()).await {
@@ -315,6 +330,13 @@ impl AppState {
                 LlmEvent::Delta { text } => {
                     let sentences = sentence_buf.push(&text);
                     assistant_accum.push_str(&text);
+                    if last_emit_at.elapsed() >= LAST_DELTA_DEBOUNCE {
+                        let _ = events_bus.send(Event::LastDelta {
+                            id: id.clone(),
+                            text: assistant_accum.clone(),
+                        });
+                        last_emit_at = Instant::now();
+                    }
                     (
                         Event::Delta {
                             id: id.clone(),
@@ -342,6 +364,10 @@ impl AppState {
                     awaiting_tool_result = true;
                     if !assistant_accum.is_empty() {
                         let pre_text = std::mem::take(&mut assistant_accum);
+                        let _ = events_bus.send(Event::LastDelta {
+                            id: id.clone(),
+                            text: pre_text.clone(),
+                        });
                         self.persist_message_fire_and_forget(
                             turn_id,
                             PersistedMessage::assistant_text(pre_text),
@@ -415,6 +441,10 @@ impl AppState {
                     let sentences = tail.into_iter().collect();
                     if !assistant_accum.is_empty() {
                         let final_text = std::mem::take(&mut assistant_accum);
+                        let _ = events_bus.send(Event::LastDelta {
+                            id: id.clone(),
+                            text: final_text.clone(),
+                        });
                         self.persist_message_fire_and_forget(
                             turn_id,
                             PersistedMessage::assistant_text(final_text),

--- a/crates/assistd-core/src/state/runtime.rs
+++ b/crates/assistd-core/src/state/runtime.rs
@@ -1,15 +1,24 @@
 //! `RuntimeState` groups the per-process bookkeeping that AppState
 //! needs but that isn't a "subsystem backend" or "memory stack": the
 //! active (session, branch) pointer, the agent-turn lock, the
-//! persistence task tracker, and the warmup-join handle.
+//! persistence task tracker, the warmup-join handle, and the
+//! process-wide events broadcast bus that feeds passive
+//! `Request::Subscribe` connections.
 //!
 //! `ConversationContext` also lives here — it's the runtime-mutable
 //! pointer that `/switch` and `/fork` swap.
 
+use assistd_ipc::Event;
 use assistd_memory::{BranchId, SessionId};
 use std::sync::Arc;
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, broadcast};
 use tokio_util::task::TaskTracker;
+
+/// Capacity of the events broadcast bus. Slow subscribers that fall
+/// more than this many events behind receive a `RecvError::Lagged`
+/// signal and resume from the latest event; the handler logs and
+/// keeps the connection open.
+const EVENTS_BUS_CAPACITY: usize = 256;
 
 /// Active (session, branch) pointer shared by every persistence write
 /// site. Held under a `RwLock` because the persistence path takes a
@@ -86,17 +95,27 @@ pub struct RuntimeState {
     /// race PTT-start by stuffing in a foreign join handle.
     pub(in crate::state) warmup_handle:
         Arc<Mutex<Option<tokio::task::JoinHandle<anyhow::Result<()>>>>>,
+    /// Process-wide passive event bus. Connections tee broadcast-
+    /// eligible outbound events into this sender so that
+    /// `Request::Subscribe` connections can observe each other's
+    /// activity; the per-turn delta coalescer also writes
+    /// `Event::LastDelta` summaries here directly. External code
+    /// obtains a sender / receiver via [`Self::events_bus`] and
+    /// [`Self::subscribe_events`].
+    events_bus: broadcast::Sender<Event>,
 }
 
 impl RuntimeState {
     /// Build a fresh runtime state with default locks and a
     /// brand-new auto-generated conversation context.
     pub fn new() -> Self {
+        let (events_bus, _) = broadcast::channel(EVENTS_BUS_CAPACITY);
         Self {
             conversation_ctx: Arc::new(ConversationContext::new(SessionId::new(), BranchId(0))),
             agent_turn_lock: Arc::new(Mutex::new(())),
             persistence_tracker: TaskTracker::new(),
             warmup_handle: Arc::new(Mutex::new(None)),
+            events_bus,
         }
     }
 
@@ -110,6 +129,20 @@ impl RuntimeState {
     /// writer-task channel sender drops.
     pub fn persistence_tracker_handle(&self) -> TaskTracker {
         self.persistence_tracker.clone()
+    }
+
+    /// Borrow the events broadcast sender. Used by the socket fan-
+    /// out tee and by the per-turn delta coalescer to publish
+    /// events to passive subscribers.
+    pub fn events_bus(&self) -> &broadcast::Sender<Event> {
+        &self.events_bus
+    }
+
+    /// Open a fresh receiver on the events broadcast bus. Used by
+    /// the Subscribe handler; equivalent to
+    /// `self.events_bus().subscribe()`.
+    pub fn subscribe_events(&self) -> broadcast::Receiver<Event> {
+        self.events_bus.subscribe()
     }
 }
 

--- a/crates/assistd-core/src/state/runtime.rs
+++ b/crates/assistd-core/src/state/runtime.rs
@@ -14,10 +14,8 @@ use std::sync::Arc;
 use tokio::sync::{Mutex, broadcast};
 use tokio_util::task::TaskTracker;
 
-/// Capacity of the events broadcast bus. Slow subscribers that fall
-/// more than this many events behind receive a `RecvError::Lagged`
-/// signal and resume from the latest event; the handler logs and
-/// keeps the connection open.
+/// Slow subscribers that fall more than this many events behind
+/// receive a `RecvError::Lagged` and resume from the latest event.
 const EVENTS_BUS_CAPACITY: usize = 256;
 
 /// Active (session, branch) pointer shared by every persistence write
@@ -95,13 +93,6 @@ pub struct RuntimeState {
     /// race PTT-start by stuffing in a foreign join handle.
     pub(in crate::state) warmup_handle:
         Arc<Mutex<Option<tokio::task::JoinHandle<anyhow::Result<()>>>>>,
-    /// Process-wide passive event bus. Connections tee broadcast-
-    /// eligible outbound events into this sender so that
-    /// `Request::Subscribe` connections can observe each other's
-    /// activity; the per-turn delta coalescer also writes
-    /// `Event::LastDelta` summaries here directly. External code
-    /// obtains a sender / receiver via [`Self::events_bus`] and
-    /// [`Self::subscribe_events`].
     events_bus: broadcast::Sender<Event>,
 }
 
@@ -131,16 +122,12 @@ impl RuntimeState {
         self.persistence_tracker.clone()
     }
 
-    /// Borrow the events broadcast sender. Used by the socket fan-
-    /// out tee and by the per-turn delta coalescer to publish
-    /// events to passive subscribers.
+    /// Sender side of the process-wide events broadcast bus.
     pub fn events_bus(&self) -> &broadcast::Sender<Event> {
         &self.events_bus
     }
 
-    /// Open a fresh receiver on the events broadcast bus. Used by
-    /// the Subscribe handler; equivalent to
-    /// `self.events_bus().subscribe()`.
+    /// Open a fresh receiver on the events broadcast bus.
     pub fn subscribe_events(&self) -> broadcast::Receiver<Event> {
         self.events_bus.subscribe()
     }

--- a/crates/assistd-core/src/state/subscribe.rs
+++ b/crates/assistd-core/src/state/subscribe.rs
@@ -1,0 +1,61 @@
+//! Handler for [`assistd_ipc::Request::Subscribe`] — passive fan-out
+//! connections that forward broadcast-eligible events from the
+//! daemon-wide bus to a long-lived client (tray icon, status bar,
+//! external dashboard) until the client disconnects or the daemon
+//! shuts down.
+
+use super::AppState;
+use anyhow::Result;
+use assistd_ipc::{Event, SubscribeFilter};
+use std::sync::Arc;
+use tokio::sync::broadcast::error::RecvError;
+use tokio::sync::mpsc;
+use tracing::{debug, warn};
+
+impl AppState {
+    pub(super) async fn handle_subscribe(
+        self: Arc<Self>,
+        id: String,
+        filter: SubscribeFilter,
+        tx: mpsc::Sender<Event>,
+    ) -> Result<()> {
+        let mut rx = self.runtime.subscribe_events();
+        debug!(
+            target: "assistd::subscribe",
+            id = %id,
+            kinds = ?filter.kinds,
+            "subscriber attached"
+        );
+        loop {
+            tokio::select! {
+                _ = tx.closed() => {
+                    debug!(
+                        target: "assistd::subscribe",
+                        id = %id,
+                        "subscriber detached (client closed)"
+                    );
+                    return Ok(());
+                }
+                recv = rx.recv() => match recv {
+                    Ok(event) => {
+                        if let Some(kind) = event.kind()
+                            && filter.matches(kind)
+                            && tx.send(event).await.is_err()
+                        {
+                            return Ok(());
+                        }
+                    }
+                    Err(RecvError::Lagged(skipped)) => {
+                        warn!(
+                            target: "assistd::subscribe",
+                            id = %id,
+                            skipped,
+                            "subscriber lagged; dropping events"
+                        );
+                    }
+                    Err(RecvError::Closed) => return Ok(()),
+                },
+            }
+        }
+    }
+}

--- a/crates/assistd-core/src/state/subscribe.rs
+++ b/crates/assistd-core/src/state/subscribe.rs
@@ -1,8 +1,6 @@
-//! Handler for [`assistd_ipc::Request::Subscribe`] — passive fan-out
-//! connections that forward broadcast-eligible events from the
-//! daemon-wide bus to a long-lived client (tray icon, status bar,
-//! external dashboard) until the client disconnects or the daemon
-//! shuts down.
+//! Handler for [`assistd_ipc::Request::Subscribe`]: forwards
+//! broadcast-eligible events from the daemon-wide bus to a passive
+//! client until either side closes the connection.
 
 use super::AppState;
 use anyhow::Result;

--- a/crates/assistd-ipc/src/lib.rs
+++ b/crates/assistd-ipc/src/lib.rs
@@ -26,14 +26,11 @@
 //!
 //! ## Passive subscription
 //!
-//! [`Request::Subscribe`] keeps the connection open for the lifetime of
-//! the client and forwards every broadcast-eligible event the daemon
-//! emits across all connections, filtered by [`SubscribeFilter`]. The
-//! filter selects from [`EventKind`]; an empty filter receives every
-//! broadcast-eligible kind. Subscribe never emits a terminal `Done`:
-//! the stream closes only when the client shuts down the connection or
-//! the daemon exits. Events arrive carrying the **originating turn's**
-//! `id`, not the `Subscribe.id` — subscribers correlate by event id.
+//! [`Request::Subscribe`] is a long-lived attachment to the daemon-
+//! wide events bus. The connection stays open until either side
+//! closes it; no terminal `Done` is emitted. Events arrive with the
+//! originating turn's `id` (not `Subscribe.id`), filtered by the
+//! requested [`SubscribeFilter`].
 
 use base64::Engine;
 use serde::{Deserialize, Serialize};
@@ -114,21 +111,10 @@ pub enum VoiceCaptureState {
     Transcribing,
 }
 
-/// Categories of [`Event`] that may be observed by a passive
-/// [`Request::Subscribe`] connection.
-///
-/// The set is intentionally narrower than [`Event`]: only events that
-/// represent **global** daemon state changes (and therefore make sense
-/// to fan out across every connected client) appear here. Dialog-local
-/// events — history rows, branch info, memory values, semantic hits,
-/// confirm prompts, capability replies, mid-stream status — stay
-/// scoped to the connection that issued the originating request and
-/// are never broadcast.
-///
-/// `LastDelta` is a daemon-coalesced summary of an in-flight turn's
-/// reply: it carries the cumulative accumulated text at the moment of
-/// emission and is debounced server-side so subscribers see at most a
-/// handful per second regardless of token rate.
+/// Categories of [`Event`] that pass through the daemon-wide
+/// broadcast bus and so can be selected by a [`SubscribeFilter`].
+/// Dialog-local events stay scoped to the originating connection
+/// and have no [`EventKind`] variant.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(rename_all = "snake_case")]
 pub enum EventKind {
@@ -145,9 +131,7 @@ pub enum EventKind {
 }
 
 /// Set-of-kinds filter for [`Request::Subscribe`]. An empty `kinds`
-/// vector matches **every** broadcast-eligible kind (the firehose);
-/// a populated vector matches only the listed kinds. Duplicates are
-/// tolerated by the daemon (the filter is treated as a set).
+/// vector matches every broadcast-eligible kind.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct SubscribeFilter {
     #[serde(default)]
@@ -155,8 +139,7 @@ pub struct SubscribeFilter {
 }
 
 impl SubscribeFilter {
-    /// True when `kind` should be delivered under this filter. An
-    /// empty `kinds` vector matches every kind.
+    /// True when `kind` should be delivered under this filter.
     pub fn matches(&self, kind: EventKind) -> bool {
         self.kinds.is_empty() || self.kinds.contains(&kind)
     }
@@ -332,14 +315,11 @@ pub enum Request {
     /// [`Request::ResumeOrNew`] which may decide to keep an existing
     /// branch when it's recent or empty.
     NewSession { id: String },
-    /// Passive fan-out subscription. The daemon registers this
-    /// connection against an internal events bus and forwards every
-    /// broadcast-eligible event that matches `filter`. The connection
-    /// stays open until the client closes it or the daemon shuts
-    /// down; **no terminal `Done` is emitted for the subscription
-    /// itself**. Events arrive carrying the **originating turn's**
-    /// `id`, not this `Subscribe.id` — subscribers correlate by
-    /// inspecting the event stream.
+    /// Attach a passive subscriber to the daemon-wide events bus.
+    /// Forwards every broadcast-eligible event that matches
+    /// `filter` until the client disconnects. No terminal `Done`
+    /// is emitted for the subscription itself; events carry the
+    /// originating turn's `id`, not `Subscribe.id`.
     Subscribe {
         id: String,
         #[serde(default)]
@@ -658,14 +638,10 @@ pub enum Event {
     Error { id: String, message: String },
     /// Terminal success event; the stream is over.
     Done { id: String },
-    /// Daemon-coalesced summary of an in-flight turn's assistant
-    /// reply. Emitted **only onto the broadcast bus** for passive
-    /// [`Request::Subscribe`] consumers; never appears on the
-    /// originating turn's per-request stream. `text` is the
-    /// cumulative accumulated reply at the moment of emission, not
-    /// the latest token — so subscribers always see the full
-    /// running snapshot. Server-side debouncing caps the emission
-    /// rate; a final `LastDelta` is flushed on turn completion.
+    /// Daemon-coalesced cumulative snapshot of an in-flight turn's
+    /// reply. Emitted only onto the broadcast bus for
+    /// [`Request::Subscribe`] consumers; `text` is the running
+    /// reply so far, not just the latest token.
     LastDelta { id: String, text: String },
 }
 
@@ -706,14 +682,10 @@ impl Event {
         }
     }
 
-    /// Classify this event for [`Request::Subscribe`] filtering.
-    ///
-    /// Returns `None` for dialog-local events that are never
-    /// broadcast across connections (memory rows, branch info,
-    /// semantic hits, confirm prompts, history entries, and so on).
-    /// The exhaustive match below is intentional: adding a new
-    /// [`Event`] variant must force a deliberate decision about
-    /// whether it belongs on the broadcast bus.
+    /// Classify this event for [`SubscribeFilter`] matching. Returns
+    /// `None` for dialog-local events that don't cross the broadcast
+    /// bus. The match below is intentionally exhaustive — adding an
+    /// [`Event`] variant forces a decision about its bus eligibility.
     pub fn kind(&self) -> Option<EventKind> {
         Some(match self {
             Event::Delta { .. } => EventKind::Delta,

--- a/crates/assistd-ipc/src/lib.rs
+++ b/crates/assistd-ipc/src/lib.rs
@@ -23,6 +23,17 @@
 //!
 //! Every event carries the originating request's `id`, so a future
 //! multiplexing transport can correlate concurrent in-flight requests.
+//!
+//! ## Passive subscription
+//!
+//! [`Request::Subscribe`] keeps the connection open for the lifetime of
+//! the client and forwards every broadcast-eligible event the daemon
+//! emits across all connections, filtered by [`SubscribeFilter`]. The
+//! filter selects from [`EventKind`]; an empty filter receives every
+//! broadcast-eligible kind. Subscribe never emits a terminal `Done`:
+//! the stream closes only when the client shuts down the connection or
+//! the daemon exits. Events arrive carrying the **originating turn's**
+//! `id`, not the `Subscribe.id` — subscribers correlate by event id.
 
 use base64::Engine;
 use serde::{Deserialize, Serialize};
@@ -101,6 +112,54 @@ pub enum VoiceCaptureState {
     Queued,
     Recording,
     Transcribing,
+}
+
+/// Categories of [`Event`] that may be observed by a passive
+/// [`Request::Subscribe`] connection.
+///
+/// The set is intentionally narrower than [`Event`]: only events that
+/// represent **global** daemon state changes (and therefore make sense
+/// to fan out across every connected client) appear here. Dialog-local
+/// events — history rows, branch info, memory values, semantic hits,
+/// confirm prompts, capability replies, mid-stream status — stay
+/// scoped to the connection that issued the originating request and
+/// are never broadcast.
+///
+/// `LastDelta` is a daemon-coalesced summary of an in-flight turn's
+/// reply: it carries the cumulative accumulated text at the moment of
+/// emission and is debounced server-side so subscribers see at most a
+/// handful per second regardless of token rate.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum EventKind {
+    Delta,
+    ReasoningDelta,
+    ToolCall,
+    ToolResult,
+    Presence,
+    ListenState,
+    VoiceState,
+    Done,
+    Error,
+    LastDelta,
+}
+
+/// Set-of-kinds filter for [`Request::Subscribe`]. An empty `kinds`
+/// vector matches **every** broadcast-eligible kind (the firehose);
+/// a populated vector matches only the listed kinds. Duplicates are
+/// tolerated by the daemon (the filter is treated as a set).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct SubscribeFilter {
+    #[serde(default)]
+    pub kinds: Vec<EventKind>,
+}
+
+impl SubscribeFilter {
+    /// True when `kind` should be delivered under this filter. An
+    /// empty `kinds` vector matches every kind.
+    pub fn matches(&self, kind: EventKind) -> bool {
+        self.kinds.is_empty() || self.kinds.contains(&kind)
+    }
 }
 
 /// Wire-protocol request sent by a client to the daemon over the Unix socket.
@@ -273,6 +332,19 @@ pub enum Request {
     /// [`Request::ResumeOrNew`] which may decide to keep an existing
     /// branch when it's recent or empty.
     NewSession { id: String },
+    /// Passive fan-out subscription. The daemon registers this
+    /// connection against an internal events bus and forwards every
+    /// broadcast-eligible event that matches `filter`. The connection
+    /// stays open until the client closes it or the daemon shuts
+    /// down; **no terminal `Done` is emitted for the subscription
+    /// itself**. Events arrive carrying the **originating turn's**
+    /// `id`, not this `Subscribe.id` — subscribers correlate by
+    /// inspecting the event stream.
+    Subscribe {
+        id: String,
+        #[serde(default)]
+        filter: SubscribeFilter,
+    },
 }
 
 impl Request {
@@ -329,7 +401,8 @@ impl Request {
             | Request::Switch { id, .. }
             | Request::Undo { id }
             | Request::ResumeOrNew { id, .. }
-            | Request::NewSession { id } => id,
+            | Request::NewSession { id }
+            | Request::Subscribe { id, .. } => id,
         }
     }
 
@@ -366,6 +439,7 @@ impl Request {
             Request::Undo { .. } => "undo",
             Request::ResumeOrNew { .. } => "resume_or_new",
             Request::NewSession { .. } => "new_session",
+            Request::Subscribe { .. } => "subscribe",
         }
     }
 }
@@ -584,6 +658,15 @@ pub enum Event {
     Error { id: String, message: String },
     /// Terminal success event; the stream is over.
     Done { id: String },
+    /// Daemon-coalesced summary of an in-flight turn's assistant
+    /// reply. Emitted **only onto the broadcast bus** for passive
+    /// [`Request::Subscribe`] consumers; never appears on the
+    /// originating turn's per-request stream. `text` is the
+    /// cumulative accumulated reply at the moment of emission, not
+    /// the latest token — so subscribers always see the full
+    /// running snapshot. Server-side debouncing caps the emission
+    /// rate; a final `LastDelta` is flushed on turn completion.
+    LastDelta { id: String, text: String },
 }
 
 impl Event {
@@ -618,8 +701,47 @@ impl Event {
             | Event::HistoryEntry { id, .. }
             | Event::UndoApplied { id, .. }
             | Event::Error { id, .. }
-            | Event::Done { id } => id,
+            | Event::Done { id }
+            | Event::LastDelta { id, .. } => id,
         }
+    }
+
+    /// Classify this event for [`Request::Subscribe`] filtering.
+    ///
+    /// Returns `None` for dialog-local events that are never
+    /// broadcast across connections (memory rows, branch info,
+    /// semantic hits, confirm prompts, history entries, and so on).
+    /// The exhaustive match below is intentional: adding a new
+    /// [`Event`] variant must force a deliberate decision about
+    /// whether it belongs on the broadcast bus.
+    pub fn kind(&self) -> Option<EventKind> {
+        Some(match self {
+            Event::Delta { .. } => EventKind::Delta,
+            Event::ReasoningDelta { .. } => EventKind::ReasoningDelta,
+            Event::ToolCall { .. } => EventKind::ToolCall,
+            Event::ToolResult { .. } => EventKind::ToolResult,
+            Event::Presence { .. } => EventKind::Presence,
+            Event::VoiceState { .. } => EventKind::VoiceState,
+            Event::ListenState { .. } => EventKind::ListenState,
+            Event::Done { .. } => EventKind::Done,
+            Event::Error { .. } => EventKind::Error,
+            Event::LastDelta { .. } => EventKind::LastDelta,
+            Event::Transcription { .. }
+            | Event::VoiceOutputState { .. }
+            | Event::SemanticHit { .. }
+            | Event::MemoryValue { .. }
+            | Event::MemoryKeys { .. }
+            | Event::MemoryRow { .. }
+            | Event::MemoryForgetResult { .. }
+            | Event::ReindexProgress { .. }
+            | Event::ConfirmRequest { .. }
+            | Event::Capabilities { .. }
+            | Event::Status { .. }
+            | Event::BranchInfo { .. }
+            | Event::BranchSwitched { .. }
+            | Event::HistoryEntry { .. }
+            | Event::UndoApplied { .. } => return None,
+        })
     }
 }
 
@@ -1367,5 +1489,256 @@ mod tests {
     fn socket_path_falls_back_to_nobody_without_user() {
         let path = socket_path_for(None, None);
         assert_eq!(path, PathBuf::from("/tmp/assistd-nobody.sock"));
+    }
+
+    #[test]
+    fn subscribe_request_roundtrip_empty_filter() {
+        let req = Request::Subscribe {
+            id: "s-1".into(),
+            filter: SubscribeFilter::default(),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert_eq!(
+            json,
+            r#"{"type":"subscribe","id":"s-1","filter":{"kinds":[]}}"#
+        );
+        let parsed: Request = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, req);
+    }
+
+    #[test]
+    fn subscribe_request_accepts_missing_filter_field() {
+        let parsed: Request = serde_json::from_str(r#"{"type":"subscribe","id":"s-1"}"#).unwrap();
+        assert_eq!(
+            parsed,
+            Request::Subscribe {
+                id: "s-1".into(),
+                filter: SubscribeFilter::default(),
+            }
+        );
+    }
+
+    #[test]
+    fn subscribe_request_roundtrip_populated_filter() {
+        let req = Request::Subscribe {
+            id: "s-2".into(),
+            filter: SubscribeFilter {
+                kinds: vec![
+                    EventKind::Presence,
+                    EventKind::ListenState,
+                    EventKind::LastDelta,
+                ],
+            },
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert_eq!(
+            json,
+            r#"{"type":"subscribe","id":"s-2","filter":{"kinds":["presence","listen_state","last_delta"]}}"#
+        );
+        let parsed: Request = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, req);
+    }
+
+    #[test]
+    fn subscribe_request_id_and_kind() {
+        let req = Request::Subscribe {
+            id: "s-3".into(),
+            filter: SubscribeFilter::default(),
+        };
+        assert_eq!(req.id(), "s-3");
+        assert_eq!(req.kind(), "subscribe");
+    }
+
+    #[test]
+    fn subscribe_filter_default_matches_all() {
+        let f = SubscribeFilter::default();
+        for k in [
+            EventKind::Delta,
+            EventKind::ReasoningDelta,
+            EventKind::ToolCall,
+            EventKind::ToolResult,
+            EventKind::Presence,
+            EventKind::ListenState,
+            EventKind::VoiceState,
+            EventKind::Done,
+            EventKind::Error,
+            EventKind::LastDelta,
+        ] {
+            assert!(f.matches(k), "default filter should match {k:?}");
+        }
+    }
+
+    #[test]
+    fn subscribe_filter_matches_listed_only() {
+        let f = SubscribeFilter {
+            kinds: vec![EventKind::Presence, EventKind::LastDelta],
+        };
+        assert!(f.matches(EventKind::Presence));
+        assert!(f.matches(EventKind::LastDelta));
+        assert!(!f.matches(EventKind::Delta));
+        assert!(!f.matches(EventKind::ToolCall));
+        assert!(!f.matches(EventKind::Done));
+    }
+
+    #[test]
+    fn last_delta_event_roundtrip() {
+        let ev = Event::LastDelta {
+            id: "q-7".into(),
+            text: "Hello world".into(),
+        };
+        let json = serde_json::to_string(&ev).unwrap();
+        assert_eq!(
+            json,
+            r#"{"type":"last_delta","id":"q-7","text":"Hello world"}"#
+        );
+        let parsed: Event = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, ev);
+    }
+
+    #[test]
+    fn last_delta_is_not_terminal() {
+        let ev = Event::LastDelta {
+            id: "q-1".into(),
+            text: "snapshot".into(),
+        };
+        assert!(!ev.is_terminal());
+        assert_eq!(ev.id(), "q-1");
+    }
+
+    #[test]
+    fn event_kind_classifies_broadcast_eligible_variants() {
+        let cases: Vec<(Event, EventKind)> = vec![
+            (
+                Event::Delta {
+                    id: "q".into(),
+                    text: "t".into(),
+                },
+                EventKind::Delta,
+            ),
+            (
+                Event::ReasoningDelta {
+                    id: "q".into(),
+                    text: "t".into(),
+                },
+                EventKind::ReasoningDelta,
+            ),
+            (
+                Event::ToolCall {
+                    id: "q".into(),
+                    name: "bash".into(),
+                    args: serde_json::json!({}),
+                },
+                EventKind::ToolCall,
+            ),
+            (
+                Event::ToolResult {
+                    id: "q".into(),
+                    name: "bash".into(),
+                    result: serde_json::json!({}),
+                },
+                EventKind::ToolResult,
+            ),
+            (
+                Event::Presence {
+                    id: "q".into(),
+                    state: PresenceState::Active,
+                },
+                EventKind::Presence,
+            ),
+            (
+                Event::VoiceState {
+                    id: "q".into(),
+                    state: VoiceCaptureState::Idle,
+                },
+                EventKind::VoiceState,
+            ),
+            (
+                Event::ListenState {
+                    id: "q".into(),
+                    active: false,
+                },
+                EventKind::ListenState,
+            ),
+            (Event::Done { id: "q".into() }, EventKind::Done),
+            (
+                Event::Error {
+                    id: "q".into(),
+                    message: "m".into(),
+                },
+                EventKind::Error,
+            ),
+            (
+                Event::LastDelta {
+                    id: "q".into(),
+                    text: "t".into(),
+                },
+                EventKind::LastDelta,
+            ),
+        ];
+        for (ev, expected) in cases {
+            assert_eq!(ev.kind(), Some(expected), "wrong kind for {ev:?}");
+        }
+    }
+
+    #[test]
+    fn event_kind_returns_none_for_dialog_local_variants() {
+        let dialog_local = vec![
+            Event::Transcription {
+                id: "q".into(),
+                text: "t".into(),
+            },
+            Event::VoiceOutputState {
+                id: "q".into(),
+                enabled: true,
+            },
+            Event::MemoryValue {
+                id: "q".into(),
+                key: "k".into(),
+                value: None,
+            },
+            Event::MemoryKeys {
+                id: "q".into(),
+                keys: Vec::new(),
+            },
+            Event::MemoryRow {
+                id: "q".into(),
+                memory_id: 0,
+                key: "k".into(),
+                value: "v".into(),
+            },
+            Event::MemoryForgetResult {
+                id: "q".into(),
+                deleted: false,
+                key: None,
+            },
+            Event::ReindexProgress {
+                id: "q".into(),
+                kind: "chunks".into(),
+                done: 0,
+                total: 0,
+            },
+            Event::ConfirmRequest {
+                id: "q".into(),
+                confirm_id: "c".into(),
+                tool: "bash".into(),
+                script: "ls".into(),
+                matched_pattern: "ls".into(),
+            },
+            Event::Capabilities {
+                id: "q".into(),
+                vision: false,
+                model_name: "m".into(),
+            },
+            Event::Status {
+                id: "q".into(),
+                severity: "info".into(),
+                component: "llm".into(),
+                event: "ok".into(),
+                message: "".into(),
+            },
+        ];
+        for ev in dialog_local {
+            assert_eq!(ev.kind(), None, "expected None for {ev:?}");
+        }
     }
 }

--- a/crates/assistd/src/chat/app.rs
+++ b/crates/assistd/src/chat/app.rs
@@ -919,7 +919,8 @@ impl App {
             | Event::MemoryKeys { .. }
             | Event::MemoryRow { .. }
             | Event::MemoryForgetResult { .. }
-            | Event::ReindexProgress { .. } => {}
+            | Event::ReindexProgress { .. }
+            | Event::LastDelta { .. } => {}
         }
     }
 

--- a/crates/assistd/src/ptt.rs
+++ b/crates/assistd/src/ptt.rs
@@ -103,7 +103,8 @@ pub async fn run(action: PttAction) -> Result<()> {
             | Event::BranchInfo { .. }
             | Event::BranchSwitched { .. }
             | Event::HistoryEntry { .. }
-            | Event::UndoApplied { .. } => {}
+            | Event::UndoApplied { .. }
+            | Event::LastDelta { .. } => {}
             Event::ConfirmRequest { .. } => {
                 eprintln!(
                     "[daemon asked for destructive-command confirmation; denying \

--- a/crates/assistd/src/query.rs
+++ b/crates/assistd/src/query.rs
@@ -152,7 +152,8 @@ pub async fn run(args: QueryArgs) -> Result<()> {
             | Event::BranchInfo { .. }
             | Event::BranchSwitched { .. }
             | Event::HistoryEntry { .. }
-            | Event::UndoApplied { .. } => {}
+            | Event::UndoApplied { .. }
+            | Event::LastDelta { .. } => {}
             Event::ConfirmRequest { .. } => {
                 eprintln!(
                     "[daemon asked for destructive-command confirmation; denying \


### PR DESCRIPTION
- Added passive `Request::Subscribe` to the assistd IPC: 
    - broadcast bus on `RuntimeState` 
    - debounced `Event::LastDelta` coalescer 
    - socket fan-out tee,