### PR TITLE
System tray status icon (StatusNotifierItem) for daemon idle / listening / generating

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,6 +115,7 @@ name = "assistd-cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "assistd-config",
  "assistd-core",
  "assistd-embed",
  "assistd-ipc",
@@ -130,6 +131,7 @@ dependencies = [
  "futures-util",
  "global-hotkey",
  "image",
+ "ksni",
  "libc",
  "nvml-wrapper",
  "ratatui",
@@ -351,6 +353,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-io"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -376,6 +390,17 @@ checksum = "958321a23896f573a3f1809437af5816f3bc90dd2d5ffe8b1cd5645f42230c17"
 dependencies = [
  "async-io",
  "libc",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1035,6 +1060,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1048,6 +1100,27 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1330,6 +1403,12 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hound"
@@ -1819,6 +1898,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ksni"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7ca513d0be42df5edb485af9f44a12b2cb85af773d91c27dc796d1c58b78edc"
+dependencies = [
+ "futures-util",
+ "pastey",
+ "serde",
+ "tokio",
+ "zbus",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1949,6 +2041,15 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "minimal-lexical"
@@ -2284,6 +2385,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2341,6 +2452,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "pastey"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
 
 [[package]]
 name = "percent-encoding"
@@ -3556,6 +3673,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
+ "tracing",
  "windows-sys 0.61.2",
 ]
 
@@ -3818,6 +3936,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3896,6 +4025,7 @@ checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
 
@@ -4775,6 +4905,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus"
+version = "5.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3bcbf15c8708d7fc1be0c993622e0a5cbd5e8b52bfa40afa4c3e0cd8d724ac1"
+dependencies = [
+ "async-broadcast",
+ "async-recursion",
+ "async-trait",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix 1.1.4",
+ "serde",
+ "serde_repr",
+ "tokio",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51fa5406ad9175a8c825a931f8cf347116b531b3634fcb0b627c290f1f2516ff"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7074f3e50b894eac91750142016d30d0a89be8e67dbfd9704fb875825760e52d"
+dependencies = [
+ "serde",
+ "winnow",
+ "zvariant",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4873,4 +5059,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
 dependencies = [
  "zune-core",
+]
+
+[[package]]
+name = "zvariant"
+version = "5.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c1567a6ec68df868cbbfde844cfc6d81649fe5109a62b116b19fabd53e618ee"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7d5b780599bbde114e39d9a0799577fad1ced5105d38515745f7b3099d8ceda"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d464f5733ffa07a3164d656f18533caace9d0638596721355d73256a410d691"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn",
+ "winnow",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ tokio-i3ipc = "0.16"
 swayipc-async = "3"
 url = "2"
 parking_lot = "0.12"
+ksni = { version = "0.3.4", default-features = false, features = ["tokio"] }
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/config/config.sample.toml
+++ b/config/config.sample.toml
@@ -520,3 +520,18 @@ hotkey = "Super+Escape"
 # presence_wake_cold_start_secs = 60 # llama-server spawn + first /health = 200
 # dispatch_envelope_secs = 600       # outer cap on a single dispatch call
 # stream_inactivity_secs = 30        # SSE per-chunk no-bytes deadline
+
+# ---- Tray icon ----------------------------------------------------------
+# Icon-theme names rendered by `assistd tray` (a StatusNotifierItem
+# client suitable for compositor autostart). Defaults are freedesktop
+# names that ship in every major theme (Adwaita, Breeze, Papirus); set
+# any field to an installed icon name if you ship custom artwork under
+# `~/.local/share/icons/<theme>/`.
+#
+# [tray]
+# icon_active       = "user-available"         # daemon awake, idle
+# icon_drowsy       = "user-away"              # presence = Drowsy
+# icon_sleeping     = "user-offline"           # presence = Sleeping
+# icon_listening    = "audio-input-microphone" # continuous listen is on
+# icon_generating   = "system-run"             # a query is streaming
+# icon_disconnected = "network-offline"        # daemon socket unreachable

--- a/crates/assistd-config/src/defaults.rs
+++ b/crates/assistd-config/src/defaults.rs
@@ -147,6 +147,16 @@ pub const DEFAULT_MCP_SSE_READ_TIMEOUT_SECS: u64 = 30;
 /// open but server not processing requests".
 pub const DEFAULT_MCP_SSE_PING_INTERVAL_SECS: u64 = 15;
 
+/// System-tray icon-theme names. Picked to be present in every major
+/// icon theme (Adwaita, Breeze, Papirus) so a fresh install shows
+/// recognizable icons without shipping any image assets in the repo.
+pub const DEFAULT_TRAY_ICON_ACTIVE: &str = "user-available";
+pub const DEFAULT_TRAY_ICON_DROWSY: &str = "user-away";
+pub const DEFAULT_TRAY_ICON_SLEEPING: &str = "user-offline";
+pub const DEFAULT_TRAY_ICON_LISTENING: &str = "audio-input-microphone";
+pub const DEFAULT_TRAY_ICON_GENERATING: &str = "system-run";
+pub const DEFAULT_TRAY_ICON_DISCONNECTED: &str = "network-offline";
+
 /// Returns the default SQLite memory database path, honouring `$XDG_DATA_HOME`.
 ///
 /// Resolves to `$XDG_DATA_HOME/assistd/memory.db` when set and non-empty,

--- a/crates/assistd-config/src/lib.rs
+++ b/crates/assistd-config/src/lib.rs
@@ -37,6 +37,7 @@ pub mod sleep;
 pub mod timeouts;
 pub mod tools;
 pub mod top;
+pub mod tray;
 pub mod voice;
 
 pub use agent::AgentConfig;
@@ -58,6 +59,7 @@ pub use tools::{
     ToolsScreenshotConfig, ToolsWriteConfig,
 };
 pub use top::Config;
+pub use tray::TrayConfig;
 pub use voice::{
     CodeBlockMode, ContinuousListenConfig, SynthesisConfig, TranscriptionConfig, VoiceConfig,
 };

--- a/crates/assistd-config/src/top.rs
+++ b/crates/assistd-config/src/top.rs
@@ -17,6 +17,7 @@ use crate::remote::RemoteConfig;
 use crate::sleep::SleepConfig;
 use crate::timeouts::TimeoutsConfig;
 use crate::tools::ToolsConfig;
+use crate::tray::TrayConfig;
 use crate::voice::VoiceConfig;
 
 /// Top-level assistd configuration, deserialized from `config.toml`.
@@ -45,6 +46,8 @@ pub struct Config {
     pub mcp: McpConfig,
     #[serde(default)]
     pub timeouts: TimeoutsConfig,
+    #[serde(default)]
+    pub tray: TrayConfig,
 }
 
 impl Config {

--- a/crates/assistd-config/src/tray.rs
+++ b/crates/assistd-config/src/tray.rs
@@ -1,0 +1,76 @@
+use crate::defaults::{
+    DEFAULT_TRAY_ICON_ACTIVE, DEFAULT_TRAY_ICON_DISCONNECTED, DEFAULT_TRAY_ICON_DROWSY,
+    DEFAULT_TRAY_ICON_GENERATING, DEFAULT_TRAY_ICON_LISTENING, DEFAULT_TRAY_ICON_SLEEPING,
+};
+use serde::{Deserialize, Serialize};
+
+/// System-tray icon settings for `assistd tray`.
+///
+/// Each field is the name of an icon in the user's freedesktop icon
+/// theme. The defaults pick names that ship in every major theme
+/// (Adwaita, Breeze, Papirus); users who want assistd-branded artwork
+/// install custom icons under `~/.local/share/icons/<theme>/` and
+/// reference them by name here.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TrayConfig {
+    /// Daemon presence is `Active` and no query is in flight.
+    #[serde(default = "default_tray_icon_active")]
+    pub icon_active: String,
+
+    /// Daemon presence is `Drowsy`.
+    #[serde(default = "default_tray_icon_drowsy")]
+    pub icon_drowsy: String,
+
+    /// Daemon presence is `Sleeping`.
+    #[serde(default = "default_tray_icon_sleeping")]
+    pub icon_sleeping: String,
+
+    /// Continuous listening is active.
+    #[serde(default = "default_tray_icon_listening")]
+    pub icon_listening: String,
+
+    /// At least one query is currently streaming.
+    #[serde(default = "default_tray_icon_generating")]
+    pub icon_generating: String,
+
+    /// Daemon socket is unreachable (not running, or connection dropped).
+    #[serde(default = "default_tray_icon_disconnected")]
+    pub icon_disconnected: String,
+}
+
+impl Default for TrayConfig {
+    fn default() -> Self {
+        Self {
+            icon_active: default_tray_icon_active(),
+            icon_drowsy: default_tray_icon_drowsy(),
+            icon_sleeping: default_tray_icon_sleeping(),
+            icon_listening: default_tray_icon_listening(),
+            icon_generating: default_tray_icon_generating(),
+            icon_disconnected: default_tray_icon_disconnected(),
+        }
+    }
+}
+
+fn default_tray_icon_active() -> String {
+    DEFAULT_TRAY_ICON_ACTIVE.to_string()
+}
+
+fn default_tray_icon_drowsy() -> String {
+    DEFAULT_TRAY_ICON_DROWSY.to_string()
+}
+
+fn default_tray_icon_sleeping() -> String {
+    DEFAULT_TRAY_ICON_SLEEPING.to_string()
+}
+
+fn default_tray_icon_listening() -> String {
+    DEFAULT_TRAY_ICON_LISTENING.to_string()
+}
+
+fn default_tray_icon_generating() -> String {
+    DEFAULT_TRAY_ICON_GENERATING.to_string()
+}
+
+fn default_tray_icon_disconnected() -> String {
+    DEFAULT_TRAY_ICON_DISCONNECTED.to_string()
+}

--- a/crates/assistd/Cargo.toml
+++ b/crates/assistd/Cargo.toml
@@ -10,7 +10,7 @@ name = "assistd"
 path = "src/main.rs"
 
 [features]
-default = ["daemon", "client", "chat"]
+default = ["daemon", "client", "chat", "tray"]
 daemon = [
     "dep:assistd-core",
     "dep:assistd-embed",
@@ -40,6 +40,13 @@ chat = [
     "dep:shlex",
     "dep:ratatui-image",
     "dep:image",
+]
+tray = [
+    "client",
+    "dep:assistd-config",
+    "dep:ksni",
+    "dep:tracing",
+    "dep:tracing-subscriber",
 ]
 
 [dependencies]
@@ -74,6 +81,8 @@ rustix           = { workspace = true, optional = true }
 shlex            = { workspace = true, optional = true }
 ratatui-image    = { workspace = true, optional = true }
 image            = { workspace = true, optional = true }
+ksni             = { workspace = true, optional = true }
+assistd-config   = { workspace = true, optional = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/assistd/src/main.rs
+++ b/crates/assistd/src/main.rs
@@ -31,6 +31,8 @@ mod presence;
 mod ptt;
 #[cfg(feature = "client")]
 mod query;
+#[cfg(feature = "tray")]
+mod tray;
 #[cfg(feature = "client")]
 mod voice_ctl;
 #[cfg(feature = "daemon")]
@@ -126,6 +128,11 @@ enum Commands {
     #[cfg(feature = "chat")]
     Chat(chat::ChatArgs),
 
+    /// Run the system-tray icon (StatusNotifierItem over DBus). Long-
+    /// lived; suitable for compositor autostart (`exec assistd tray`).
+    #[cfg(feature = "tray")]
+    Tray(tray::TrayArgs),
+
     /// Inspect or mutate persistent memory: search conversation
     /// history, save / load / list / forget / delete key-value
     /// memories.
@@ -171,6 +178,8 @@ async fn main() -> Result<()> {
         Commands::VoiceState => voice_ctl::run(voice_ctl::VoiceCtlAction::State).await,
         #[cfg(feature = "chat")]
         Commands::Chat(args) => chat::run(args).await,
+        #[cfg(feature = "tray")]
+        Commands::Tray(args) => tray::run(args).await,
         #[cfg(feature = "client")]
         Commands::Memory(args) => memory_cli::run(args).await,
     }

--- a/crates/assistd/src/tray/menu.rs
+++ b/crates/assistd/src/tray/menu.rs
@@ -1,0 +1,202 @@
+//! ksni `Tray` implementation and the small task that turns menu
+//! clicks into IPC calls.
+//!
+//! The activate callbacks ksni invokes on a menu click must not block
+//! (the panel freezes if they do), so they only push a [`MenuAction`]
+//! onto an mpsc channel. [`run_actions`] drains that channel from a
+//! tokio task and issues fresh `one_shot` IPC calls per action — never
+//! multiplexed on the long-lived Subscribe connection that
+//! `subscribe.rs` owns.
+
+use anyhow::Result;
+use assistd_config::TrayConfig;
+use assistd_ipc::{Event, IpcClient, PresenceState, Request};
+use ksni::{
+    Category, Status, ToolTip, Tray,
+    menu::{MenuItem, StandardItem},
+};
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
+use uuid::Uuid;
+
+use super::state::{TrayState, TrayTracker, icon_name_for, tooltip_for};
+
+/// Menu click → background task.
+#[derive(Debug, Clone, Copy)]
+pub enum MenuAction {
+    /// Issue `SetPresence(target)` to the daemon.
+    SetPresence(PresenceState),
+    /// Tear down the tray and exit cleanly.
+    Quit,
+}
+
+/// State owned by the ksni service. Property reads and menu rendering
+/// happen on ksni's task; `subscribe.rs` and `run_actions` reach in via
+/// `Handle::update` and `Handle::shutdown` respectively.
+pub struct TrayItem {
+    tracker: TrayTracker,
+    cfg: TrayConfig,
+    actions: UnboundedSender<MenuAction>,
+}
+
+impl TrayItem {
+    pub fn new(cfg: TrayConfig, actions: UnboundedSender<MenuAction>) -> Self {
+        Self {
+            tracker: TrayTracker::default(),
+            cfg,
+            actions,
+        }
+    }
+
+    /// Apply an incoming daemon event. Returns `true` when the visible
+    /// tray state changed.
+    pub fn ingest(&mut self, event: &Event) -> bool {
+        self.tracker.ingest(event)
+    }
+
+    /// Mark the IPC connection up. Returns `true` when the visible
+    /// tray state changed.
+    pub fn set_connected(&mut self) -> bool {
+        self.tracker.set_connected()
+    }
+
+    /// Mark the IPC connection down. Returns `true` when the visible
+    /// tray state changed.
+    pub fn set_disconnected(&mut self) -> bool {
+        self.tracker.set_disconnected()
+    }
+}
+
+impl Tray for TrayItem {
+    fn id(&self) -> String {
+        "org.assistd.Tray".into()
+    }
+
+    fn title(&self) -> String {
+        "assistd".into()
+    }
+
+    fn category(&self) -> Category {
+        Category::ApplicationStatus
+    }
+
+    fn status(&self) -> Status {
+        Status::Active
+    }
+
+    fn icon_name(&self) -> String {
+        icon_name_for(self.tracker.current(), &self.cfg).to_string()
+    }
+
+    fn tool_tip(&self) -> ToolTip {
+        ToolTip {
+            icon_name: String::new(),
+            icon_pixmap: Vec::new(),
+            title: tooltip_for(self.tracker.current()).into(),
+            description: String::new(),
+        }
+    }
+
+    fn menu(&self) -> Vec<MenuItem<Self>> {
+        let state = self.tracker.current();
+        let toggle_enabled = !matches!(state, TrayState::Disconnected);
+        let toggle_label = toggle_label_for(self.tracker.presence()).to_string();
+        vec![
+            StandardItem {
+                label: toggle_label,
+                enabled: toggle_enabled,
+                activate: Box::new(|item: &mut Self| {
+                    let target = toggle_target(item.tracker.presence());
+                    let _ = item.actions.send(MenuAction::SetPresence(target));
+                }),
+                ..Default::default()
+            }
+            .into(),
+            MenuItem::Separator,
+            StandardItem {
+                label: "Quit tray".into(),
+                activate: Box::new(|item: &mut Self| {
+                    let _ = item.actions.send(MenuAction::Quit);
+                }),
+                ..Default::default()
+            }
+            .into(),
+        ]
+    }
+}
+
+fn toggle_label_for(presence: PresenceState) -> &'static str {
+    match presence {
+        PresenceState::Sleeping => "Wake",
+        PresenceState::Active | PresenceState::Drowsy => "Sleep",
+    }
+}
+
+fn toggle_target(presence: PresenceState) -> PresenceState {
+    match presence {
+        PresenceState::Sleeping => PresenceState::Active,
+        PresenceState::Active | PresenceState::Drowsy => PresenceState::Sleeping,
+    }
+}
+
+/// Drain the menu-action channel until a [`MenuAction::Quit`] is
+/// received or the sender is dropped. Returns `Ok(())` on a clean exit
+/// triggered by Quit; bubbles up only fatal channel errors (none today).
+pub async fn run_actions(mut rx: UnboundedReceiver<MenuAction>, ipc: IpcClient) -> Result<()> {
+    while let Some(action) = rx.recv().await {
+        match action {
+            MenuAction::SetPresence(target) => {
+                if let Err(e) = send_set_presence(&ipc, target).await {
+                    tracing::warn!(target: "tray", "set_presence({target:?}) failed: {e:#}");
+                }
+            }
+            MenuAction::Quit => return Ok(()),
+        }
+    }
+    Ok(())
+}
+
+async fn send_set_presence(ipc: &IpcClient, target: PresenceState) -> Result<()> {
+    let req = Request::SetPresence {
+        id: Uuid::new_v4().to_string(),
+        target,
+    };
+    let mut stream = ipc.one_shot(req).await?;
+    loop {
+        match stream.next_event().await? {
+            Some(Event::Done { .. }) => return Ok(()),
+            Some(Event::Error { message, .. }) => {
+                anyhow::bail!("daemon error: {message}");
+            }
+            Some(_) => continue,
+            None => anyhow::bail!("daemon closed before Done"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn toggle_label_inverts_with_presence() {
+        assert_eq!(toggle_label_for(PresenceState::Active), "Sleep");
+        assert_eq!(toggle_label_for(PresenceState::Drowsy), "Sleep");
+        assert_eq!(toggle_label_for(PresenceState::Sleeping), "Wake");
+    }
+
+    #[test]
+    fn toggle_target_inverts_with_presence() {
+        assert_eq!(
+            toggle_target(PresenceState::Active),
+            PresenceState::Sleeping
+        );
+        assert_eq!(
+            toggle_target(PresenceState::Drowsy),
+            PresenceState::Sleeping
+        );
+        assert_eq!(
+            toggle_target(PresenceState::Sleeping),
+            PresenceState::Active
+        );
+    }
+}

--- a/crates/assistd/src/tray/mod.rs
+++ b/crates/assistd/src/tray/mod.rs
@@ -1,0 +1,127 @@
+//! `assistd tray`: a long-lived StatusNotifierItem client that
+//! subscribes to the daemon's broadcast bus and reflects daemon state
+//! as an icon in Waybar / i3status-rust / KDE / GNOME-with-AppIndicator.
+//!
+//! Three tasks make up the runtime:
+//!
+//! - the ksni service, owning the [`TrayItem`] and answering DBus
+//!   property/menu queries;
+//! - the [`subscribe`] loop, holding a passive `Request::Subscribe`
+//!   on the daemon socket and pushing event updates into the tray
+//!   through `Handle::update`;
+//! - the [`menu::run_actions`] task, draining the mpsc channel that
+//!   menu activate callbacks feed and issuing one-shot
+//!   `Request::SetPresence` calls.
+//!
+//! The tray never auto-spawns the daemon — it stays in the
+//! `Disconnected` icon variant until the user starts `assistd daemon`
+//! separately, then reconnects on the next backoff tick.
+
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use assistd_config::Config;
+use assistd_ipc::IpcClient;
+use clap::Args;
+use ksni::TrayMethods;
+use tokio::signal::unix::{SignalKind, signal};
+use tokio::sync::mpsc;
+
+mod menu;
+mod state;
+mod subscribe;
+
+use menu::TrayItem;
+
+/// Arguments for the `tray` subcommand.
+#[derive(Args)]
+pub struct TrayArgs {
+    /// Path to config file [default: `~/.config/assistd/config.toml`]
+    #[arg(long, short)]
+    pub config: Option<PathBuf>,
+}
+
+/// Launch the tray and run until SIGINT/SIGTERM or a `Quit` menu click.
+///
+/// # Errors
+///
+/// Returns an error if config loading fails, the session DBus is
+/// unavailable, or the ksni service cannot register on DBus.
+pub async fn run(args: TrayArgs) -> Result<()> {
+    init_tracing();
+
+    let config_path = match args.config.clone() {
+        Some(p) => p,
+        None => Config::default_path()?,
+    };
+    let config = Config::load_from_file(&config_path)
+        .with_context(|| format!("loading config from {}", config_path.display()))?;
+    config.validate()?;
+    tracing::info!(target: "tray", "loaded config from {}", config_path.display());
+
+    if std::env::var_os("DBUS_SESSION_BUS_ADDRESS").is_none() {
+        anyhow::bail!(
+            "DBUS_SESSION_BUS_ADDRESS is not set; the tray needs a session DBus to register with. \
+             Are you running from a graphical session?"
+        );
+    }
+
+    let (actions_tx, actions_rx) = mpsc::unbounded_channel();
+    let item = TrayItem::new(config.tray.clone(), actions_tx);
+
+    let handle = item
+        .assume_sni_available(true)
+        .spawn()
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to register StatusNotifierItem on DBus: {e}"))?;
+    tracing::info!(target: "tray", "tray icon registered on DBus");
+
+    let ipc = IpcClient::new();
+    let subscribe_handle = handle.clone();
+    let subscribe_ipc = ipc.clone();
+    let subscribe_task =
+        tokio::spawn(async move { subscribe::run(subscribe_handle, subscribe_ipc).await });
+
+    let action_task = tokio::spawn(menu::run_actions(actions_rx, ipc));
+
+    wait_for_shutdown(action_task).await;
+
+    handle.shutdown().await;
+    subscribe_task.abort();
+    let _ = subscribe_task.await;
+    Ok(())
+}
+
+/// Block until any of: Ctrl-C, SIGTERM, or the menu-action task
+/// finishing (which happens when the user clicks Quit).
+async fn wait_for_shutdown(action_task: tokio::task::JoinHandle<Result<()>>) {
+    let mut sigterm = match signal(SignalKind::terminate()) {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!(target: "tray", "could not install SIGTERM handler: {e}");
+            let _ = action_task.await;
+            return;
+        }
+    };
+    tokio::select! {
+        _ = tokio::signal::ctrl_c() => {
+            tracing::info!(target: "tray", "ctrl-c received, shutting down");
+        }
+        _ = sigterm.recv() => {
+            tracing::info!(target: "tray", "SIGTERM received, shutting down");
+        }
+        res = action_task => {
+            match res {
+                Ok(Ok(())) => tracing::info!(target: "tray", "quit menu item activated"),
+                Ok(Err(e)) => tracing::warn!(target: "tray", "menu action handler failed: {e:#}"),
+                Err(e) => tracing::warn!(target: "tray", "menu action task panicked: {e}"),
+            }
+        }
+    }
+}
+
+fn init_tracing() {
+    let filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
+    let _ = tracing_subscriber::fmt().with_env_filter(filter).try_init();
+}

--- a/crates/assistd/src/tray/state.rs
+++ b/crates/assistd/src/tray/state.rs
@@ -1,0 +1,299 @@
+//! Tray state machine. Translates raw daemon events into the small
+//! enum the icon renderer cares about, applying a fixed priority order
+//! so concurrent signals (e.g. listening while generating) produce a
+//! single deterministic icon.
+
+use std::collections::HashSet;
+
+use assistd_config::TrayConfig;
+use assistd_ipc::{Event, PresenceState};
+
+/// What the tray icon should currently display.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TrayState {
+    /// Daemon socket is unreachable.
+    Disconnected,
+    /// At least one query turn is in flight.
+    Generating,
+    /// Continuous listening is on.
+    Listening,
+    /// Daemon is awake and idle.
+    Active,
+    /// Daemon is drowsing or sleeping (rendered the same at-a-glance).
+    Sleeping,
+}
+
+/// Mutable bag of raw signals received over IPC, plus the priority
+/// resolution that derives a single [`TrayState`] from them.
+#[derive(Debug, Clone)]
+pub struct TrayTracker {
+    presence: PresenceState,
+    listening: bool,
+    in_flight: HashSet<String>,
+    connected: bool,
+}
+
+impl Default for TrayTracker {
+    fn default() -> Self {
+        Self {
+            presence: PresenceState::Active,
+            listening: false,
+            in_flight: HashSet::new(),
+            connected: false,
+        }
+    }
+}
+
+impl TrayTracker {
+    /// Resolve the raw signals into a single tray state, applying the
+    /// priority order disconnected → generating → listening → presence.
+    pub fn current(&self) -> TrayState {
+        if !self.connected {
+            return TrayState::Disconnected;
+        }
+        if !self.in_flight.is_empty() {
+            return TrayState::Generating;
+        }
+        if self.listening {
+            return TrayState::Listening;
+        }
+        match self.presence {
+            PresenceState::Active => TrayState::Active,
+            PresenceState::Drowsy | PresenceState::Sleeping => TrayState::Sleeping,
+        }
+    }
+
+    /// The daemon's most recently observed presence (independent of
+    /// connection state). Used by the menu to label the "Sleep / Wake"
+    /// toggle item.
+    pub fn presence(&self) -> PresenceState {
+        self.presence
+    }
+
+    /// Mark the connection up. Returns `true` when the resolved
+    /// [`TrayState`] actually changed.
+    pub fn set_connected(&mut self) -> bool {
+        let before = self.current();
+        self.connected = true;
+        before != self.current()
+    }
+
+    /// Mark the connection down and drop all per-turn state we can no
+    /// longer trust. Returns `true` when the resolved [`TrayState`]
+    /// actually changed.
+    pub fn set_disconnected(&mut self) -> bool {
+        let before = self.current();
+        self.connected = false;
+        self.in_flight.clear();
+        self.listening = false;
+        before != self.current()
+    }
+
+    /// Apply an incoming wire event, updating the relevant raw signal.
+    /// Returns `true` when the resolved [`TrayState`] actually changed,
+    /// so the caller can skip redundant DBus property-changed broadcasts.
+    pub fn ingest(&mut self, event: &Event) -> bool {
+        let before = self.current();
+        match event {
+            Event::Delta { id, .. } | Event::ToolCall { id, .. } => {
+                self.in_flight.insert(id.clone());
+            }
+            Event::Done { id, .. } | Event::Error { id, .. } => {
+                self.in_flight.remove(id);
+            }
+            Event::Presence { state, .. } => {
+                self.presence = *state;
+            }
+            Event::ListenState { active, .. } => {
+                self.listening = *active;
+            }
+            _ => {}
+        }
+        before != self.current()
+    }
+}
+
+/// Map a resolved state to the freedesktop icon-theme name configured
+/// for it.
+pub fn icon_name_for(state: TrayState, cfg: &TrayConfig) -> &str {
+    match state {
+        TrayState::Disconnected => &cfg.icon_disconnected,
+        TrayState::Generating => &cfg.icon_generating,
+        TrayState::Listening => &cfg.icon_listening,
+        TrayState::Active => &cfg.icon_active,
+        TrayState::Sleeping => &cfg.icon_sleeping,
+    }
+}
+
+/// Short human-readable label for the tooltip.
+pub fn tooltip_for(state: TrayState) -> &'static str {
+    match state {
+        TrayState::Disconnected => "assistd: daemon offline",
+        TrayState::Generating => "assistd: thinking…",
+        TrayState::Listening => "assistd: listening",
+        TrayState::Active => "assistd: idle",
+        TrayState::Sleeping => "assistd: sleeping",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn delta(id: &str) -> Event {
+        Event::Delta {
+            id: id.into(),
+            text: String::new(),
+        }
+    }
+
+    fn tool_call(id: &str) -> Event {
+        Event::ToolCall {
+            id: id.into(),
+            name: "x".into(),
+            args: serde_json::Value::Null,
+        }
+    }
+
+    fn done(id: &str) -> Event {
+        Event::Done { id: id.into() }
+    }
+
+    fn error(id: &str) -> Event {
+        Event::Error {
+            id: id.into(),
+            message: "boom".into(),
+        }
+    }
+
+    fn presence(state: PresenceState) -> Event {
+        Event::Presence {
+            id: "x".into(),
+            state,
+        }
+    }
+
+    fn listen(active: bool) -> Event {
+        Event::ListenState {
+            id: "x".into(),
+            active,
+        }
+    }
+
+    #[test]
+    fn disconnected_takes_top_priority() {
+        let t = TrayTracker::default();
+        assert_eq!(t.current(), TrayState::Disconnected);
+    }
+
+    #[test]
+    fn generating_outranks_listening_and_presence() {
+        let mut t = TrayTracker::default();
+        t.set_connected();
+        t.ingest(&listen(true));
+        t.ingest(&delta("a"));
+        assert_eq!(t.current(), TrayState::Generating);
+    }
+
+    #[test]
+    fn listening_outranks_presence() {
+        let mut t = TrayTracker::default();
+        t.set_connected();
+        t.ingest(&presence(PresenceState::Active));
+        t.ingest(&listen(true));
+        assert_eq!(t.current(), TrayState::Listening);
+    }
+
+    #[test]
+    fn drowsy_and_sleeping_both_render_as_sleeping() {
+        let mut t = TrayTracker::default();
+        t.set_connected();
+        t.ingest(&presence(PresenceState::Drowsy));
+        assert_eq!(t.current(), TrayState::Sleeping);
+        t.ingest(&presence(PresenceState::Sleeping));
+        assert_eq!(t.current(), TrayState::Sleeping);
+        t.ingest(&presence(PresenceState::Active));
+        assert_eq!(t.current(), TrayState::Active);
+    }
+
+    #[test]
+    fn concurrent_turns_keep_generating_until_all_resolve() {
+        let mut t = TrayTracker::default();
+        t.set_connected();
+        t.ingest(&delta("a"));
+        t.ingest(&tool_call("b"));
+        assert_eq!(t.current(), TrayState::Generating);
+        t.ingest(&done("a"));
+        assert_eq!(t.current(), TrayState::Generating);
+        t.ingest(&error("b"));
+        assert_eq!(t.current(), TrayState::Active);
+    }
+
+    #[test]
+    fn done_for_unknown_id_is_harmless() {
+        let mut t = TrayTracker::default();
+        t.set_connected();
+        let changed = t.ingest(&done("never-seen"));
+        assert!(!changed);
+        assert_eq!(t.current(), TrayState::Active);
+    }
+
+    #[test]
+    fn disconnect_clears_in_flight_and_listening() {
+        let mut t = TrayTracker::default();
+        t.set_connected();
+        t.ingest(&listen(true));
+        t.ingest(&delta("a"));
+        assert!(t.set_disconnected());
+        assert_eq!(t.current(), TrayState::Disconnected);
+
+        let changed = t.set_connected();
+        assert!(changed);
+        // After reconnect, in-flight and listening are gone; presence
+        // defaults to Active until the daemon broadcasts otherwise.
+        assert_eq!(t.current(), TrayState::Active);
+    }
+
+    #[test]
+    fn ingest_returns_change_flag() {
+        let mut t = TrayTracker::default();
+        t.set_connected();
+        // First Delta: enters Generating → state changed.
+        assert!(t.ingest(&delta("a")));
+        // Second Delta for the same id: still Generating → no change.
+        assert!(!t.ingest(&delta("a")));
+        // Done for the only in-flight id: back to Active → state changed.
+        assert!(t.ingest(&done("a")));
+    }
+
+    #[test]
+    fn unrelated_events_do_not_change_state() {
+        let mut t = TrayTracker::default();
+        t.set_connected();
+        let changed = t.ingest(&Event::ToolResult {
+            id: "a".into(),
+            name: "x".into(),
+            result: serde_json::Value::Null,
+        });
+        assert!(!changed);
+        let changed = t.ingest(&Event::LastDelta {
+            id: "a".into(),
+            text: "x".into(),
+        });
+        assert!(!changed);
+    }
+
+    #[test]
+    fn icon_name_for_threads_through_config() {
+        let cfg = TrayConfig::default();
+        assert_eq!(icon_name_for(TrayState::Active, &cfg), &cfg.icon_active);
+        assert_eq!(
+            icon_name_for(TrayState::Disconnected, &cfg),
+            &cfg.icon_disconnected
+        );
+        assert_eq!(
+            icon_name_for(TrayState::Generating, &cfg),
+            &cfg.icon_generating
+        );
+    }
+}

--- a/crates/assistd/src/tray/subscribe.rs
+++ b/crates/assistd/src/tray/subscribe.rs
@@ -1,0 +1,174 @@
+//! Long-lived passive subscription to the daemon's broadcast bus.
+//!
+//! Connects, seeds the current presence and listening state, then
+//! pumps events into the [`TrayItem`] through `Handle::update` for as
+//! long as the daemon is reachable. On any disconnect — clean EOF or
+//! I/O error — flips the tray to `Disconnected` and retries with
+//! exponential backoff (1, 2, 4, … s, capped at 60 s).
+
+use std::time::Duration;
+
+use assistd_ipc::{
+    Event, EventKind, IpcClient, IpcClientError, Request, SubscribeFilter,
+    client::EventStream as IpcEventStream,
+};
+use ksni::Handle;
+use uuid::Uuid;
+
+use super::menu::TrayItem;
+
+/// Run the reconnect loop forever. Returns only if the ksni handle has
+/// shut down (signalling app exit).
+pub async fn run(handle: Handle<TrayItem>, ipc: IpcClient) {
+    let mut attempt: u32 = 0;
+    loop {
+        match try_once(&handle, &ipc).await {
+            Ok(ExitReason::ServiceShutdown) => return,
+            Ok(ExitReason::DaemonClosed) => {
+                tracing::info!(target: "tray", "daemon closed the subscribe connection");
+                attempt = 0;
+            }
+            Err(e) => {
+                tracing::warn!(target: "tray", "subscribe attempt failed: {e}");
+            }
+        }
+        if push(&handle, |item| item.set_disconnected())
+            .await
+            .is_none()
+        {
+            return;
+        }
+        tokio::time::sleep(backoff_delay(attempt)).await;
+        attempt = attempt.saturating_add(1);
+    }
+}
+
+/// Why a single subscribe attempt returned.
+enum ExitReason {
+    /// ksni told us the service is gone — quit the loop.
+    ServiceShutdown,
+    /// The daemon closed cleanly; reconnect after the usual backoff.
+    DaemonClosed,
+}
+
+async fn try_once(
+    handle: &Handle<TrayItem>,
+    ipc: &IpcClient,
+) -> Result<ExitReason, IpcClientError> {
+    let req = Request::Subscribe {
+        id: Uuid::new_v4().to_string(),
+        filter: SubscribeFilter {
+            kinds: vec![
+                EventKind::Delta,
+                EventKind::ToolCall,
+                EventKind::Done,
+                EventKind::Error,
+                EventKind::Presence,
+                EventKind::ListenState,
+            ],
+        },
+    };
+    let stream = ipc.one_shot(req).await?;
+
+    if push(handle, |item| item.set_connected()).await.is_none() {
+        return Ok(ExitReason::ServiceShutdown);
+    }
+
+    seed_initial_state(handle, ipc).await;
+
+    pump_events(handle, stream).await
+}
+
+async fn pump_events(
+    handle: &Handle<TrayItem>,
+    mut stream: IpcEventStream,
+) -> Result<ExitReason, IpcClientError> {
+    loop {
+        match stream.next_event().await? {
+            Some(ev) => {
+                if push(handle, |item| item.ingest(&ev)).await.is_none() {
+                    return Ok(ExitReason::ServiceShutdown);
+                }
+            }
+            None => return Ok(ExitReason::DaemonClosed),
+        }
+    }
+}
+
+/// Subscribe is passive — it doesn't replay the daemon's current
+/// presence or listening state. Run a pair of one-shot probes against
+/// fresh connections so the tray icon reflects reality immediately
+/// after a reconnect.
+async fn seed_initial_state(handle: &Handle<TrayItem>, ipc: &IpcClient) {
+    let presence_req = Request::GetPresence {
+        id: Uuid::new_v4().to_string(),
+    };
+    let listen_req = Request::GetListenState {
+        id: Uuid::new_v4().to_string(),
+    };
+    let (presence_res, listen_res) =
+        tokio::join!(ipc.one_shot(presence_req), ipc.one_shot(listen_req));
+
+    if let Ok(stream) = presence_res {
+        consume_until_terminal(handle, stream).await;
+    }
+    if let Ok(stream) = listen_res {
+        consume_until_terminal(handle, stream).await;
+    }
+}
+
+async fn consume_until_terminal(handle: &Handle<TrayItem>, mut stream: IpcEventStream) {
+    loop {
+        match stream.next_event().await {
+            Ok(Some(ev)) => {
+                let terminal = matches!(ev, Event::Done { .. } | Event::Error { .. });
+                if push(handle, |item| item.ingest(&ev)).await.is_none() {
+                    return;
+                }
+                if terminal {
+                    return;
+                }
+            }
+            Ok(None) | Err(_) => return,
+        }
+    }
+}
+
+async fn push<F>(handle: &Handle<TrayItem>, f: F) -> Option<bool>
+where
+    F: FnOnce(&mut TrayItem) -> bool + Send,
+{
+    handle.update(f).await
+}
+
+/// Exponential backoff capped at 60 s. Mirrors the shape used in
+/// `assistd-llm`'s llama-server supervisor without taking a dependency
+/// on it — the workspace's three-use rule says inline.
+fn backoff_delay(attempt: u32) -> Duration {
+    const CAP_SECS: u64 = 60;
+    let secs = 1u64.checked_shl(attempt).unwrap_or(CAP_SECS).min(CAP_SECS);
+    Duration::from_secs(secs)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn backoff_matches_spec_sequence() {
+        let expected = [1, 2, 4, 8, 16, 32, 60, 60, 60];
+        for (i, want) in expected.iter().enumerate() {
+            assert_eq!(
+                backoff_delay(i as u32),
+                Duration::from_secs(*want),
+                "attempt {i}"
+            );
+        }
+    }
+
+    #[test]
+    fn backoff_caps_for_large_attempts() {
+        assert_eq!(backoff_delay(64), Duration::from_secs(60));
+        assert_eq!(backoff_delay(u32::MAX), Duration::from_secs(60));
+    }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -85,6 +85,19 @@ them. `core` sits at the top because it's where every subsystem is
 wired into a working daemon. The binary itself is intentionally thin:
 parse argv, load config, build `AppState`, hand off.
 
+The same binary also ships several client subcommands that speak the
+Unix-socket IPC: `query`, `chat`, `cycle` / `sleep` / `wake` /
+`drowse`, `ptt-start` / `ptt-stop`, `listen-*`, `voice-*`, `memory`,
+and `tray`. The tray subcommand is a long-lived
+[StatusNotifierItem](https://www.freedesktop.org/wiki/Specifications/StatusNotifierItem/)
+client (via the [`ksni`](https://crates.io/crates/ksni) crate): it
+holds a passive `Request::Subscribe` connection, translates the
+broadcast events into icon state (disconnected → generating →
+listening → presence), and provides a Sleep / Wake menu that issues
+`Request::SetPresence` on isolated one-shot connections. Like every
+other client it depends only on `assistd-ipc` + `assistd-config`, so
+client-only builds stay daemon-free.
+
 ## Subsystem walk-throughs
 
 ### LLM lifecycle (`assistd-llm` ↔ llama-server)

--- a/docs/wm/i3.md
+++ b/docs/wm/i3.md
@@ -67,6 +67,28 @@ If you prefer to let `assistd chat` auto-spawn the daemon on first use
 (it runs `assistd daemon --client-mode` under `setsid`), skip this
 line. The trade-off is a slightly slower first launch.
 
+## System tray icon
+
+`assistd tray` publishes a StatusNotifierItem over DBus and reflects
+daemon state at a glance: idle, listening, generating, sleeping, or
+offline. It is a passive client — it never auto-spawns the daemon, so
+keep the `exec assistd daemon` line above as well.
+
+```i3config
+# Launch the tray at session start. Reconnects automatically if the
+# daemon restarts.
+exec --no-startup-id assistd tray
+```
+
+i3's built-in `i3bar` does not implement StatusNotifierWatcher, so the
+icon needs an SNI host running in the bar. Any of these works:
+[Polybar](https://github.com/polybar/polybar) with the `tray` module,
+[i3status-rust](https://github.com/greshake/i3status-rust) with its
+`tray` block, [stalonetray](https://github.com/kolbusa/stalonetray)
+floating, or KDE's `org.kde.plasma.private.systemtray` if you mix
+panels. Customise the icon names under `[tray]` in
+`~/.config/assistd/config.toml` if you ship your own theme.
+
 ## Push-to-talk (hold to speak)
 
 Press-and-hold `$mod+space` to record; release to transcribe and send

--- a/docs/wm/sway.md
+++ b/docs/wm/sway.md
@@ -81,6 +81,26 @@ If you'd rather let `assistd chat` auto-spawn the daemon on first use
 (it runs `assistd daemon --client-mode` under `setsid`), skip this
 line. The trade-off is a slightly slower first launch.
 
+## System tray icon
+
+`assistd tray` publishes a StatusNotifierItem over DBus and reflects
+daemon state at a glance: idle, listening, generating, sleeping, or
+offline. It is a passive client — it never auto-spawns the daemon, so
+keep the `exec assistd daemon` line above as well.
+
+```sway
+# Launch the tray at session start. Reconnects automatically if the
+# daemon restarts.
+exec assistd tray
+```
+
+Sway has no built-in tray host;
+[Waybar](https://github.com/Alexays/Waybar) with the `tray` module is
+the canonical answer. The icon appears as soon as Waybar starts and
+flips state within ~100 ms of any daemon transition. Customise the
+icon names under `[tray]` in `~/.config/assistd/config.toml` if you
+ship your own theme.
+
 ## Push-to-talk (hold to speak)
 
 Press-and-hold `$mod+space` to record; release to transcribe and send


### PR DESCRIPTION
addition of `assistd tray`, a StatusNotifierItem subcommand that subscribes to the daemon and shows idle/listening/generating/sleeping/disconnected icons with a Sleep/Wake menu.