### PR TITLE
Tray popup refinement

### DIFF
--- a/crates/assistd-core/src/state/memory_stack.rs
+++ b/crates/assistd-core/src/state/memory_stack.rs
@@ -1,9 +1,4 @@
-//! `MemoryStack` groups the persistence + embedding handles that the
-//! daemon wires together at startup.
-//!
-//! Added in Step 2 but not yet referenced by [`AppState`]; the
-//! `#[allow(dead_code)]` annotation keeps clippy quiet until Step 3
-//! flips the field set.
+//! `MemoryStack`: persistence and embedding handles owned by `AppState`.
 
 use assistd_config::EmbeddingConfig;
 use assistd_embed::{EmbedJob, Embedder, NoEmbedder};
@@ -28,8 +23,6 @@ pub struct MemoryStack {
 
 impl MemoryStack {
     /// Construct a stack with every store wired to its no-op placeholder.
-    /// Matches the post-`AppState::new` defaults today's daemon then
-    /// overrides via chained `with_*` calls.
     pub fn disabled(embedding_cfg: EmbeddingConfig) -> Self {
         let memory: Arc<dyn MemoryStore> = Arc::new(NoMemoryStore);
         let conversations: Arc<dyn ConversationStore> = Arc::new(NoConversationStore);
@@ -48,19 +41,12 @@ impl MemoryStack {
         }
     }
 
-    /// Set the memory backend. Rebuilds [`Self::memory_ops`] so the
-    /// combined façade reflects the new handle; both `with_memory` and
-    /// [`Self::with_conversations`] enforce this invariant so callers
-    /// can chain them in any order.
     pub fn with_memory(mut self, m: Arc<dyn MemoryStore>) -> Self {
         self.memory = m.clone();
         self.memory_ops = Arc::new(MemoryOps::new(m, self.conversations.clone()));
         self
     }
 
-    /// Set the conversation store. Rebuilds [`Self::memory_ops`] in
-    /// lockstep with [`Self::with_memory`]; see the cross-update test
-    /// below.
     pub fn with_conversations(mut self, c: Arc<dyn ConversationStore>) -> Self {
         self.conversations = c.clone();
         self.memory_ops = Arc::new(MemoryOps::new(self.memory.clone(), c));

--- a/crates/assistd-core/src/state/mod.rs
+++ b/crates/assistd-core/src/state/mod.rs
@@ -132,6 +132,7 @@ impl AppState {
             Request::GetListenState { id } => self.handle_get_listen_state(id, tx).await,
             Request::VoiceToggle { id } => self.handle_voice_toggle(id, tx).await,
             Request::VoiceSkip { id } => self.handle_voice_skip(id, tx).await,
+            Request::InterruptTurn { id } => self.handle_interrupt_turn(id, tx).await,
             Request::GetVoiceState { id } => self.handle_get_voice_state(id, tx).await,
             Request::MemorySave { id, key, value } => {
                 self.handle_memory_save(id, key, value, tx).await

--- a/crates/assistd-core/src/state/query.rs
+++ b/crates/assistd-core/src/state/query.rs
@@ -1,11 +1,4 @@
-//! `handle_query`: the main per-turn driver. Re-probes vision, decodes
-//! attachments, wakes presence, runs the agent loop, streams events
-//! back through the IPC channel, and finalizes persistence.
-//!
-//! The work is split into eight named phases below so the orchestrator
-//! reads as a sequence of preconditions, side-effects, and cleanup
-//! rather than one 500-line block. Helpers stay on `impl AppState` so
-//! the per-substruct field paths remain at one indentation level.
+//! `handle_query`: per-turn agent loop driver.
 
 use super::AppState;
 use super::context::combine_context_blocks;
@@ -24,25 +17,16 @@ use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use tracing::Instrument;
 
-/// Caps the per-turn `Event::LastDelta` republish rate so a fast
-/// token stream doesn't flood passive subscribers.
 const LAST_DELTA_DEBOUNCE: Duration = Duration::from_millis(100);
 
-/// The two presence-side guards that must outlive the entire turn
-/// (including post-Done audio playback). The agent-turn lock is held
-/// separately because it's released as soon as the LLM stream ends —
-/// concurrent queries shouldn't wait for audio.
 struct QueryGuards {
     _request: RequestGuard,
     _stream: LlmStreamGuard,
 }
 
 impl AppState {
-    /// Handle a single user query: wake the daemon if needed, run the agent
-    /// loop, stream events back through `tx`, and persist the turn.
-    ///
-    /// This is the primary entry point for all LLM-backed queries, including
-    /// those dispatched internally by [`Self::handle_ptt_stop`].
+    /// Handle a single user query: wake the daemon if needed, run the
+    /// agent loop, stream events through `tx`, and persist the turn.
     pub async fn handle_query(
         self: Arc<Self>,
         id: String,
@@ -67,10 +51,8 @@ impl AppState {
 
         let cancel = tokio_util::sync::CancellationToken::new();
         let _cancel_on_return = cancel.clone().drop_guard();
-        // Publish the token so an external `InterruptTurn` can reach it.
-        // The slot is held only while this turn is in flight; we clear
-        // it before releasing `agent_turn_lock` so the next queued turn
-        // starts with an empty slot.
+        // Publish the token so `Request::InterruptTurn` can reach it
+        // while this turn holds `agent_turn_lock`.
         *self.runtime.current_cancel.lock().await = Some(cancel.clone());
 
         let title_user_text = text.clone();
@@ -248,11 +230,6 @@ impl AppState {
         let events_bus = self.runtime.events_bus().clone();
         tokio::spawn(
             async move {
-                // Emit SpeakingState{true} on the first sentence we
-                // actually play; flip back to false after wait_idle.
-                // Turns that never play a sentence (TTS off, skipped,
-                // empty reply) emit nothing — passive subscribers like
-                // the tray popup only care about audible playback.
                 let mut emitted_start = false;
                 while let Some(sentence) = speech_rx.recv().await {
                     match ctrl.should_speak(start_epoch) {
@@ -273,22 +250,15 @@ impl AppState {
                                     "voice_output.speak failed; sentence dropped"
                                 );
                             }
-                            // `speak()` synthesises then enqueues; if a
-                            // skip fired mid-synthesis the controller's
-                            // playback.clear() already ran, then this
-                            // call appended the just-synthesised PCM
-                            // *after* the clear. Re-check the epoch and
-                            // cancel again so the late-arriving audio
-                            // doesn't leak through.
+                            // `speak()` may append PCM after a mid-synthesis
+                            // skip already cleared the queue; re-check the
+                            // epoch so the late audio doesn't play.
                             if matches!(ctrl.should_speak(start_epoch), SpeakDecision::DropForSkip)
                             {
                                 ctrl.inner().cancel().await;
                             }
                         }
-                        SpeakDecision::DropSilent | SpeakDecision::DropForSkip => {
-                            // TTS toggled off, or skipped: drain the channel
-                            // without speaking.
-                        }
+                        SpeakDecision::DropSilent | SpeakDecision::DropForSkip => {}
                     }
                 }
                 if let Err(e) = ctrl.inner().wait_idle().await {
@@ -310,12 +280,6 @@ impl AppState {
     }
 
     #[allow(clippy::too_many_arguments)]
-    /// Returns `true` when the loop emitted a terminal `Event::Done`
-    /// from the LLM stream. Returns `false` when the loop broke early
-    /// (cancelled turn, client gone, llm_rx dropped before
-    /// `LlmEvent::Done`). The caller uses this in
-    /// [`Self::finalize_turn`] to decide whether to emit a synthetic
-    /// `Done` so the IPC client never hangs.
     async fn drive_event_loop(
         self: Arc<Self>,
         id: String,
@@ -348,8 +312,6 @@ impl AppState {
                     Ok(Some(ev)) => ev,
                     Ok(None) => break,
                     Err(_) => {
-                        // Idle timeout: flush partial sentence (if any)
-                        // without disturbing fence state.
                         if let Some(partial) = sentence_buf.flush_idle()
                             && speech_tx.send(partial).await.is_err()
                         {
@@ -386,17 +348,13 @@ impl AppState {
                         sentences,
                     )
                 }
-                LlmEvent::ReasoningDelta { text } => {
-                    // Reasoning is ephemeral display-only: never
-                    // persisted to history, never fed to TTS.
-                    (
-                        Event::ReasoningDelta {
-                            id: id.clone(),
-                            text,
-                        },
-                        Vec::new(),
-                    )
-                }
+                LlmEvent::ReasoningDelta { text } => (
+                    Event::ReasoningDelta {
+                        id: id.clone(),
+                        text,
+                    },
+                    Vec::new(),
+                ),
                 LlmEvent::ToolCall {
                     id: call_id,
                     name,
@@ -538,7 +496,6 @@ impl AppState {
         id: String,
         done_emitted: bool,
     ) -> Result<()> {
-        // Every exit path lands an ended_at timestamp on the turn row.
         if let Some(t) = turn_id {
             let conv = self.memory.conversations.clone();
             self.runtime.persistence_tracker.spawn(async move {
@@ -556,11 +513,8 @@ impl AppState {
 
         match gen_result {
             Ok(Ok(())) => {
-                // Cancellation (e.g. `Request::InterruptTurn`) makes
-                // `Agent::run_turn` return `Ok(())` mid-stream without
-                // emitting a `LlmEvent::Done`. The IPC contract still
-                // requires a terminal event per request, so synthesise
-                // one here when the event loop never observed Done.
+                // A cancelled turn returns Ok(()) without a LlmEvent::Done;
+                // the IPC contract still requires a terminal event.
                 if !done_emitted {
                     let _ = tx.send(Event::Done { id }).await;
                 }

--- a/crates/assistd-core/src/state/query.rs
+++ b/crates/assistd-core/src/state/query.rs
@@ -67,6 +67,11 @@ impl AppState {
 
         let cancel = tokio_util::sync::CancellationToken::new();
         let _cancel_on_return = cancel.clone().drop_guard();
+        // Publish the token so an external `InterruptTurn` can reach it.
+        // The slot is held only while this turn is in flight; we clear
+        // it before releasing `agent_turn_lock` so the next queued turn
+        // starts with an empty slot.
+        *self.runtime.current_cancel.lock().await = Some(cancel.clone());
 
         let title_user_text = text.clone();
         let (llm_tx, llm_rx) = mpsc::channel::<LlmEvent>(32);
@@ -86,7 +91,8 @@ impl AppState {
         let start_epoch = self.subsystems.voice_output.current_epoch();
         let speech_handle = self.spawn_speech_worker(id.clone(), start_epoch, speech_rx);
 
-        self.clone()
+        let done_emitted = self
+            .clone()
             .drive_event_loop(
                 id.clone(),
                 llm_rx,
@@ -101,9 +107,10 @@ impl AppState {
             .await;
 
         let gen_result = generator.await;
+        *self.runtime.current_cancel.lock().await = None;
         drop(_agent_guard);
 
-        self.finalize_turn(turn_id, gen_result, speech_handle, &tx, id)
+        self.finalize_turn(turn_id, gen_result, speech_handle, &tx, id, done_emitted)
             .await
     }
 
@@ -266,6 +273,17 @@ impl AppState {
                                     "voice_output.speak failed; sentence dropped"
                                 );
                             }
+                            // `speak()` synthesises then enqueues; if a
+                            // skip fired mid-synthesis the controller's
+                            // playback.clear() already ran, then this
+                            // call appended the just-synthesised PCM
+                            // *after* the clear. Re-check the epoch and
+                            // cancel again so the late-arriving audio
+                            // doesn't leak through.
+                            if matches!(ctrl.should_speak(start_epoch), SpeakDecision::DropForSkip)
+                            {
+                                ctrl.inner().cancel().await;
+                            }
                         }
                         SpeakDecision::DropSilent | SpeakDecision::DropForSkip => {
                             // TTS toggled off, or skipped: drain the channel
@@ -292,6 +310,12 @@ impl AppState {
     }
 
     #[allow(clippy::too_many_arguments)]
+    /// Returns `true` when the loop emitted a terminal `Event::Done`
+    /// from the LLM stream. Returns `false` when the loop broke early
+    /// (cancelled turn, client gone, llm_rx dropped before
+    /// `LlmEvent::Done`). The caller uses this in
+    /// [`Self::finalize_turn`] to decide whether to emit a synthetic
+    /// `Done` so the IPC client never hangs.
     async fn drive_event_loop(
         self: Arc<Self>,
         id: String,
@@ -303,13 +327,14 @@ impl AppState {
         turn_id: Option<TurnId>,
         title_user_text: String,
         current_session: Arc<SessionId>,
-    ) {
+    ) -> bool {
         let mut awaiting_tool_result = false;
 
         let mut assistant_accum = String::new();
 
         let mut client_alive = true;
         let mut first_sentence_emitted = false;
+        let mut done_emitted = false;
 
         let events_bus = self.runtime.events_bus().clone();
         // Backdate so the first Delta emits without waiting a window.
@@ -470,6 +495,7 @@ impl AppState {
                         current_session.clone(),
                         title_user_text.clone(),
                     );
+                    done_emitted = true;
                     (Event::Done { id: id.clone() }, sentences)
                 }
             };
@@ -500,6 +526,7 @@ impl AppState {
                 break;
             }
         }
+        done_emitted
     }
 
     async fn finalize_turn(
@@ -509,6 +536,7 @@ impl AppState {
         speech_handle: JoinHandle<()>,
         tx: &mpsc::Sender<Event>,
         id: String,
+        done_emitted: bool,
     ) -> Result<()> {
         // Every exit path lands an ended_at timestamp on the turn row.
         if let Some(t) = turn_id {
@@ -527,7 +555,17 @@ impl AppState {
         let _ = speech_handle.await;
 
         match gen_result {
-            Ok(Ok(())) => Ok(()),
+            Ok(Ok(())) => {
+                // Cancellation (e.g. `Request::InterruptTurn`) makes
+                // `Agent::run_turn` return `Ok(())` mid-stream without
+                // emitting a `LlmEvent::Done`. The IPC contract still
+                // requires a terminal event per request, so synthesise
+                // one here when the event loop never observed Done.
+                if !done_emitted {
+                    let _ = tx.send(Event::Done { id }).await;
+                }
+                Ok(())
+            }
             Ok(Err(e)) => {
                 let _ = tx
                     .send(Event::Error {

--- a/crates/assistd-core/src/state/query.rs
+++ b/crates/assistd-core/src/state/query.rs
@@ -84,7 +84,7 @@ impl AppState {
         };
         let (speech_tx, speech_rx) = mpsc::channel::<String>(32);
         let start_epoch = self.subsystems.voice_output.current_epoch();
-        let speech_handle = self.spawn_speech_worker(start_epoch, speech_rx);
+        let speech_handle = self.spawn_speech_worker(id.clone(), start_epoch, speech_rx);
 
         self.clone()
             .drive_event_loop(
@@ -233,16 +233,31 @@ impl AppState {
 
     fn spawn_speech_worker(
         &self,
+        id: String,
         start_epoch: u64,
         mut speech_rx: mpsc::Receiver<String>,
     ) -> JoinHandle<()> {
         let ctrl = self.subsystems.voice_output.clone();
+        let events_bus = self.runtime.events_bus().clone();
         tokio::spawn(
             async move {
+                // Emit SpeakingState{true} on the first sentence we
+                // actually play; flip back to false after wait_idle.
+                // Turns that never play a sentence (TTS off, skipped,
+                // empty reply) emit nothing — passive subscribers like
+                // the tray popup only care about audible playback.
+                let mut emitted_start = false;
                 while let Some(sentence) = speech_rx.recv().await {
                     match ctrl.should_speak(start_epoch) {
                         SpeakDecision::Speak => {
                             let preview: String = sentence.chars().take(60).collect();
+                            if !emitted_start {
+                                let _ = events_bus.send(Event::SpeakingState {
+                                    id: id.clone(),
+                                    speaking: true,
+                                });
+                                emitted_start = true;
+                            }
                             if let Err(e) = ctrl.inner().speak(sentence).await {
                                 tracing::warn!(
                                     target: "assistd::voice",
@@ -264,6 +279,12 @@ impl AppState {
                         error = %e,
                         "voice_output.wait_idle failed (non-fatal)"
                     );
+                }
+                if emitted_start {
+                    let _ = events_bus.send(Event::SpeakingState {
+                        id,
+                        speaking: false,
+                    });
                 }
             }
             .in_current_span(),

--- a/crates/assistd-core/src/state/runtime.rs
+++ b/crates/assistd-core/src/state/runtime.rs
@@ -12,6 +12,7 @@ use assistd_ipc::Event;
 use assistd_memory::{BranchId, SessionId};
 use std::sync::Arc;
 use tokio::sync::{Mutex, broadcast};
+use tokio_util::sync::CancellationToken;
 use tokio_util::task::TaskTracker;
 
 /// Slow subscribers that fall more than this many events behind
@@ -93,6 +94,15 @@ pub struct RuntimeState {
     /// race PTT-start by stuffing in a foreign join handle.
     pub(in crate::state) warmup_handle:
         Arc<Mutex<Option<tokio::task::JoinHandle<anyhow::Result<()>>>>>,
+    /// Cancellation handle for the currently-running agent turn, if
+    /// any. `handle_query` installs its token here after acquiring
+    /// `agent_turn_lock` and clears the slot before releasing the
+    /// lock, so at most one token is ever present. A
+    /// [`Request::InterruptTurn`](assistd_ipc::Request::InterruptTurn)
+    /// dispatch takes the token out and calls `cancel()`, which
+    /// unblocks the agent's `select!` against this same token and
+    /// shuts the turn down on the next await point.
+    pub(in crate::state) current_cancel: Arc<Mutex<Option<CancellationToken>>>,
     events_bus: broadcast::Sender<Event>,
 }
 
@@ -106,6 +116,7 @@ impl RuntimeState {
             agent_turn_lock: Arc::new(Mutex::new(())),
             persistence_tracker: TaskTracker::new(),
             warmup_handle: Arc::new(Mutex::new(None)),
+            current_cancel: Arc::new(Mutex::new(None)),
             events_bus,
         }
     }

--- a/crates/assistd-core/src/state/runtime.rs
+++ b/crates/assistd-core/src/state/runtime.rs
@@ -1,12 +1,4 @@
-//! `RuntimeState` groups the per-process bookkeeping that AppState
-//! needs but that isn't a "subsystem backend" or "memory stack": the
-//! active (session, branch) pointer, the agent-turn lock, the
-//! persistence task tracker, the warmup-join handle, and the
-//! process-wide events broadcast bus that feeds passive
-//! `Request::Subscribe` connections.
-//!
-//! `ConversationContext` also lives here — it's the runtime-mutable
-//! pointer that `/switch` and `/fork` swap.
+//! `RuntimeState`: per-process bookkeeping owned by `AppState`.
 
 use assistd_ipc::Event;
 use assistd_memory::{BranchId, SessionId};
@@ -15,16 +7,9 @@ use tokio::sync::{Mutex, broadcast};
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::TaskTracker;
 
-/// Slow subscribers that fall more than this many events behind
-/// receive a `RecvError::Lagged` and resume from the latest event.
 const EVENTS_BUS_CAPACITY: usize = 256;
 
-/// Active (session, branch) pointer shared by every persistence write
-/// site. Held under a `RwLock` because the persistence path takes a
-/// read lock on every message append (cheap, lock-free in practice
-/// under WAL) while `/switch` takes a write lock once per command. We
-/// hold `Arc<SessionId>` inside so reads return a cheap `Arc::clone`
-/// without copying the underlying string.
+/// Active (session, branch) pointer shared by every persistence write site.
 pub struct ConversationContext {
     inner: tokio::sync::RwLock<ConversationContextInner>,
 }
@@ -36,7 +21,6 @@ struct ConversationContextInner {
 }
 
 impl ConversationContext {
-    /// Construct a new context, wrapping `session_id` in an `Arc`.
     pub fn new(session_id: SessionId, branch_id: BranchId) -> Self {
         Self {
             inner: tokio::sync::RwLock::new(ConversationContextInner {
@@ -46,7 +30,6 @@ impl ConversationContext {
         }
     }
 
-    /// Construct a new context from an already-`Arc`-wrapped session id.
     pub fn from_arc(session_id: Arc<SessionId>, branch_id: BranchId) -> Self {
         Self {
             inner: tokio::sync::RwLock::new(ConversationContextInner {
@@ -56,15 +39,11 @@ impl ConversationContext {
         }
     }
 
-    /// Read snapshot under a brief shared lock. The `Arc<SessionId>`
-    /// clone is reference-count only.
     pub async fn current(&self) -> (Arc<SessionId>, BranchId) {
         let g = self.inner.read().await;
         (g.session_id.clone(), g.branch_id)
     }
 
-    /// Atomically swap to a different (session, branch). Used by
-    /// `/switch` and by daemon-startup resume.
     pub async fn replace(&self, session_id: Arc<SessionId>, branch_id: BranchId) {
         let mut g = self.inner.write().await;
         g.session_id = session_id;
@@ -72,43 +51,26 @@ impl ConversationContext {
     }
 }
 
-/// Runtime bookkeeping owned by `AppState`. Added in Step 2 but not
-/// yet wired into the struct; Step 3 flips the field set.
+/// Runtime bookkeeping owned by `AppState`.
 pub struct RuntimeState {
     pub conversation_ctx: Arc<ConversationContext>,
-    /// Serializes entire agent turns. Concurrent queries each grab this
-    /// lock before running `Agent::run_turn`, so one query's tool-call /
+    /// Serializes entire agent turns so one query's tool-call /
     /// tool-result cycle never interleaves with another's.
-    /// Not `pub`: kept within `state/` so handlers can reach it but
-    /// external code cannot.
     pub(in crate::state) agent_turn_lock: Arc<Mutex<()>>,
-    /// Tracks fire-and-forget persistence tasks so daemon shutdown can
-    /// drain them before dropping the writer-task channel. Not `pub`
-    /// for the same reason as `agent_turn_lock` — handlers reach it
-    /// internally; outside code uses
-    /// [`Self::persistence_tracker_handle`].
+    /// Fire-and-forget persistence tasks, drained at daemon shutdown
+    /// before the writer-task channel sender drops.
     pub(in crate::state) persistence_tracker: TaskTracker,
-    /// Handle to the `presence.ensure_active()` task spawned at
-    /// PTT-start. PTT-stop joins it in parallel with Whisper
-    /// transcription. Not `pub` so external code can't accidentally
-    /// race PTT-start by stuffing in a foreign join handle.
+    /// Handle to the `presence.ensure_active()` task PTT-start spawns;
+    /// PTT-stop joins it alongside Whisper transcription.
     pub(in crate::state) warmup_handle:
         Arc<Mutex<Option<tokio::task::JoinHandle<anyhow::Result<()>>>>>,
-    /// Cancellation handle for the currently-running agent turn, if
-    /// any. `handle_query` installs its token here after acquiring
-    /// `agent_turn_lock` and clears the slot before releasing the
-    /// lock, so at most one token is ever present. A
-    /// [`Request::InterruptTurn`](assistd_ipc::Request::InterruptTurn)
-    /// dispatch takes the token out and calls `cancel()`, which
-    /// unblocks the agent's `select!` against this same token and
-    /// shuts the turn down on the next await point.
+    /// Cancellation token for the currently-running agent turn, taken
+    /// by `Request::InterruptTurn` to abort the turn on its next await.
     pub(in crate::state) current_cancel: Arc<Mutex<Option<CancellationToken>>>,
     events_bus: broadcast::Sender<Event>,
 }
 
 impl RuntimeState {
-    /// Build a fresh runtime state with default locks and a
-    /// brand-new auto-generated conversation context.
     pub fn new() -> Self {
         let (events_bus, _) = broadcast::channel(EVENTS_BUS_CAPACITY);
         Self {
@@ -126,19 +88,14 @@ impl RuntimeState {
         self
     }
 
-    /// Return a clone of the persistence tracker. Daemon shutdown
-    /// owns one and uses it to drain in-flight writes before the
-    /// writer-task channel sender drops.
     pub fn persistence_tracker_handle(&self) -> TaskTracker {
         self.persistence_tracker.clone()
     }
 
-    /// Sender side of the process-wide events broadcast bus.
     pub fn events_bus(&self) -> &broadcast::Sender<Event> {
         &self.events_bus
     }
 
-    /// Open a fresh receiver on the events broadcast bus.
     pub fn subscribe_events(&self) -> broadcast::Receiver<Event> {
         self.events_bus.subscribe()
     }

--- a/crates/assistd-core/src/state/subsystems.rs
+++ b/crates/assistd-core/src/state/subsystems.rs
@@ -1,9 +1,5 @@
-//! `Subsystems` groups the LLM-, voice-, presence-, tools-, and
-//! window-manager handles that AppState routes requests through.
-//!
-//! Substructs are added in this step but not yet wired into
-//! [`AppState`]; the `#[allow(dead_code)]` annotation keeps clippy
-//! quiet until Step 3 flips the field set.
+//! `Subsystems`: LLM, voice, presence, tools, and WM handles owned by
+//! `AppState`.
 
 use crate::PresenceManager;
 use assistd_llm::LlmBackend;
@@ -12,16 +8,11 @@ use assistd_voice::{ContinuousListener, VoiceInput, VoiceOutputController};
 use assistd_wm::{NoWindowManager, WindowManager};
 use std::sync::Arc;
 
-/// One MCP server that failed to start or complete tool discovery during
-/// daemon boot. Retained on [`Subsystems`] so the daemon can surface the
-/// failure to connected clients via `Event::Status` instead of leaving
-/// users to discover broken servers only when the model invokes a tool.
+/// One MCP server that failed to start during daemon boot, surfaced
+/// to clients via `Event::Status`.
 #[derive(Debug, Clone)]
 pub struct McpStartupFailure {
-    /// Configured server name (matches `mcp.servers[].name`).
     pub server_name: String,
-    /// Human-readable reason for the failure, suitable for the TUI to
-    /// render verbatim (e.g. `"binary not found at /usr/bin/foo-mcp"`).
     pub reason: String,
 }
 
@@ -34,15 +25,10 @@ pub struct Subsystems {
     pub voice_output: Arc<VoiceOutputController>,
     pub window_manager: Arc<dyn WindowManager>,
     pub vision_revalidator: Option<Arc<crate::VisionRevalidator>>,
-    /// MCP servers that failed at boot. Empty in the happy path.
     pub mcp_startup_failures: Vec<McpStartupFailure>,
 }
 
 impl Subsystems {
-    /// Construct a `Subsystems` with all required backends supplied.
-    /// `window_manager` defaults to [`NoWindowManager`] and
-    /// `vision_revalidator` to `None`; use the `with_*` builders to
-    /// attach those.
     pub fn new(
         llm: Arc<dyn LlmBackend>,
         presence: Arc<PresenceManager>,

--- a/crates/assistd-core/src/state/voice_handlers.rs
+++ b/crates/assistd-core/src/state/voice_handlers.rs
@@ -197,6 +197,28 @@ impl AppState {
         Ok(())
     }
 
+    /// Interrupt the in-flight LLM turn (if any) and drop any pending
+    /// TTS audio. The agent loop is cancelled by flipping the per-turn
+    /// `CancellationToken` published in `runtime.current_cancel`; on
+    /// the next await point inside `Agent::run_turn` the select arm
+    /// fires and `handle_query` proceeds to its `Done` path on the
+    /// originating connection. The TTS skip drains queued sentences so
+    /// playback stops at the current chunk boundary.
+    ///
+    /// Idempotent: with no turn in flight, this is just a TTS skip.
+    pub(super) async fn handle_interrupt_turn(
+        self: Arc<Self>,
+        id: String,
+        tx: mpsc::Sender<Event>,
+    ) -> Result<()> {
+        if let Some(token) = self.runtime.current_cancel.lock().await.take() {
+            token.cancel();
+        }
+        self.subsystems.voice_output.skip().await;
+        let _ = tx.send(Event::Done { id }).await;
+        Ok(())
+    }
+
     /// Report whether TTS is currently enabled.
     pub(super) async fn handle_get_voice_state(
         self: Arc<Self>,

--- a/crates/assistd-core/src/state/voice_handlers.rs
+++ b/crates/assistd-core/src/state/voice_handlers.rs
@@ -1,5 +1,4 @@
-//! Handlers for the voice-input (PTT, continuous listen) and
-//! voice-output (TTS toggle/skip) variants of `Request`.
+//! Voice-input (PTT, listen) and voice-output (TTS) request handlers.
 
 use super::AppState;
 use anyhow::Result;
@@ -9,11 +8,6 @@ use tokio::sync::mpsc;
 use tracing::Instrument;
 
 impl AppState {
-    /// Begin a push-to-talk recording. Returns immediately on success
-    /// so the CLI client exits cleanly; the daemon holds the capture
-    /// session open until a matching `PttStop` arrives on a separate
-    /// connection. Rejects when continuous listening currently owns
-    /// the mic; the two modes can't share one cpal stream.
     pub(super) async fn handle_ptt_start(
         self: Arc<Self>,
         id: String,
@@ -56,9 +50,6 @@ impl AppState {
         }
     }
 
-    /// Enable continuous listening. Rejects if PTT currently holds the
-    /// mic; the two modes are mutually exclusive because cpal cannot
-    /// share one input stream.
     pub(super) async fn handle_listen_start(
         self: Arc<Self>,
         id: String,
@@ -96,7 +87,6 @@ impl AppState {
         }
     }
 
-    /// Disable continuous listening. Idempotent.
     pub(super) async fn handle_listen_stop(
         self: Arc<Self>,
         id: String,
@@ -125,8 +115,6 @@ impl AppState {
         }
     }
 
-    /// Flip continuous listening state. Routes to start or stop
-    /// depending on the current value of `listener.is_active()`.
     pub(super) async fn handle_listen_toggle(
         self: Arc<Self>,
         id: String,
@@ -139,7 +127,6 @@ impl AppState {
         }
     }
 
-    /// Report whether continuous listening is currently active.
     pub(super) async fn handle_get_listen_state(
         self: Arc<Self>,
         id: String,
@@ -156,10 +143,6 @@ impl AppState {
         Ok(())
     }
 
-    /// Flip TTS on/off at runtime. Off cancels currently-queued audio;
-    /// on is a pure flag flip. Subsequent sentences from the in-flight
-    /// query speak again as soon as the toggle returns. Emits the
-    /// post-toggle `VoiceOutputState` + `Done`.
     pub(super) async fn handle_voice_toggle(
         self: Arc<Self>,
         id: String,
@@ -177,10 +160,6 @@ impl AppState {
         Ok(())
     }
 
-    /// Abort the current TTS response: drops queued audio and any
-    /// pending sentences for active speech workers. Does not start
-    /// recording. Emits `VoiceOutputState` + `Done`; the enabled flag
-    /// is unchanged.
     pub(super) async fn handle_voice_skip(
         self: Arc<Self>,
         id: String,
@@ -197,15 +176,8 @@ impl AppState {
         Ok(())
     }
 
-    /// Interrupt the in-flight LLM turn (if any) and drop any pending
-    /// TTS audio. The agent loop is cancelled by flipping the per-turn
-    /// `CancellationToken` published in `runtime.current_cancel`; on
-    /// the next await point inside `Agent::run_turn` the select arm
-    /// fires and `handle_query` proceeds to its `Done` path on the
-    /// originating connection. The TTS skip drains queued sentences so
-    /// playback stops at the current chunk boundary.
-    ///
-    /// Idempotent: with no turn in flight, this is just a TTS skip.
+    /// Cancel the in-flight agent turn (if any) and drop queued TTS
+    /// audio. Idempotent.
     pub(super) async fn handle_interrupt_turn(
         self: Arc<Self>,
         id: String,
@@ -219,7 +191,6 @@ impl AppState {
         Ok(())
     }
 
-    /// Report whether TTS is currently enabled.
     pub(super) async fn handle_get_voice_state(
         self: Arc<Self>,
         id: String,
@@ -235,10 +206,6 @@ impl AppState {
         Ok(())
     }
 
-    /// End the push-to-talk recording, transcribe, and (if the
-    /// transcription has content) dispatch it internally as a Query
-    /// so the streaming LLM response flows back on the same
-    /// connection before the terminal `Done`.
     #[tracing::instrument(skip_all, fields(correlation_id = %id))]
     pub(super) async fn handle_ptt_stop(
         self: Arc<Self>,
@@ -310,7 +277,6 @@ impl AppState {
             .await;
 
         if text.trim().is_empty() {
-            // VAD trimmed to silence; don't dispatch an empty user message.
             let _ = tx.send(Event::Done { id }).await;
             return Ok(());
         }

--- a/crates/assistd-embed/src/lib.rs
+++ b/crates/assistd-embed/src/lib.rs
@@ -8,31 +8,12 @@
     )
 )]
 
-//! Embedding subsystem: a dedicated llama-server instance that serves
-//! `/v1/embeddings`, plus the [`Embedder`] trait callers depend on.
+//! Embedding subsystem: a dedicated llama-server `/v1/embeddings`
+//! instance plus the [`Embedder`] trait callers depend on.
 //!
-//! Topology rationale (vs. swapping models on the chat router):
-//! - The chat server runs in **router mode** with on-demand model load/unload
-//!   driven by the presence state machine. Toggling `--embedding` per request
-//!   would require server-level reconfiguration that llama.cpp doesn't
-//!   support at runtime.
-//! - The embedding model is small enough (~30-300 MB Q4) to keep resident
-//!   on CPU 24/7 without VRAM pressure.
-//! - Embedding stays available when the chat router is `Drowsy` /
-//!   `Sleeping`, so semantic retrieval keeps working in low-power states.
-//!
-//! Public surface:
-//! - [`Embedder`] - trait `AppState`/tools hold as `Arc<dyn Embedder>`.
-//! - [`NoEmbedder`] - successful-no-op fallback used when the subsystem is
-//!   disabled in config or fails to start (mirrors `NoMemoryStore` /
-//!   `NoVoiceOutput`).
-//! - [`LlamaEmbedder`] - concrete HTTP client for an `/v1/embeddings`
-//!   endpoint.
-//! - [`server::EmbedService`] - supervised process lifecycle.
-//!
-//! The background [`spawn_embedder_task`] worker is added in a follow-up
-//! commit alongside the `assistd-memory` `WriteOp` variants it dispatches
-//! into.
+//! Runs separately from the chat router so embeddings stay available
+//! while the router is `Drowsy` / `Sleeping`. The embedding model is
+//! small enough (~30-300 MB Q4) to keep CPU-resident.
 
 pub mod client;
 pub mod embedder_task;

--- a/crates/assistd-ipc/src/lib.rs
+++ b/crates/assistd-ipc/src/lib.rs
@@ -125,6 +125,7 @@ pub enum EventKind {
     Presence,
     ListenState,
     VoiceState,
+    SpeakingState,
     Done,
     Error,
     LastDelta,
@@ -478,6 +479,13 @@ pub enum Event {
     /// / `VoiceSkip` / `GetVoiceState`. Skip leaves the flag unchanged
     /// (true if synthesis was on before the skip).
     VoiceOutputState { id: String, enabled: bool },
+    /// TTS playback state for a turn. Emitted onto the broadcast bus
+    /// when a turn's speech worker enqueues its first sentence
+    /// (`speaking: true`) and again once the playback queue drains
+    /// (`speaking: false`). Turns with synthesis disabled or no spoken
+    /// sentences emit nothing. `id` echoes the originating turn id so
+    /// passive subscribers can correlate with `Delta` / `LastDelta`.
+    SpeakingState { id: String, speaking: bool },
     /// One semantic-search hit emitted by `MemorySemanticSearch`. The
     /// daemon emits zero or more of these ranked by cosine similarity
     /// (best-first), then a terminal `Done`. `content` is the *full*
@@ -663,6 +671,7 @@ impl Event {
             | Event::Transcription { id, .. }
             | Event::ListenState { id, .. }
             | Event::VoiceOutputState { id, .. }
+            | Event::SpeakingState { id, .. }
             | Event::SemanticHit { id, .. }
             | Event::MemoryValue { id, .. }
             | Event::MemoryKeys { id, .. }
@@ -695,6 +704,7 @@ impl Event {
             Event::Presence { .. } => EventKind::Presence,
             Event::VoiceState { .. } => EventKind::VoiceState,
             Event::ListenState { .. } => EventKind::ListenState,
+            Event::SpeakingState { .. } => EventKind::SpeakingState,
             Event::Done { .. } => EventKind::Done,
             Event::Error { .. } => EventKind::Error,
             Event::LastDelta { .. } => EventKind::LastDelta,
@@ -1386,6 +1396,32 @@ mod tests {
     }
 
     #[test]
+    fn speaking_state_event_roundtrip() {
+        let evt = Event::SpeakingState {
+            id: "q-1".into(),
+            speaking: true,
+        };
+        let json = serde_json::to_string(&evt).unwrap();
+        assert_eq!(
+            json,
+            r#"{"type":"speaking_state","id":"q-1","speaking":true}"#
+        );
+        let parsed: Event = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, evt);
+    }
+
+    #[test]
+    fn speaking_state_is_bus_eligible_and_not_terminal() {
+        let evt = Event::SpeakingState {
+            id: "q-1".into(),
+            speaking: false,
+        };
+        assert!(!evt.is_terminal());
+        assert_eq!(evt.id(), "q-1");
+        assert_eq!(evt.kind(), Some(EventKind::SpeakingState));
+    }
+
+    #[test]
     fn voice_output_state_is_not_terminal() {
         let evt = Event::VoiceOutputState {
             id: "vt-1".into(),
@@ -1532,6 +1568,7 @@ mod tests {
             EventKind::Presence,
             EventKind::ListenState,
             EventKind::VoiceState,
+            EventKind::SpeakingState,
             EventKind::Done,
             EventKind::Error,
             EventKind::LastDelta,

--- a/crates/assistd-ipc/src/lib.rs
+++ b/crates/assistd-ipc/src/lib.rs
@@ -203,12 +203,8 @@ pub enum Request {
     /// and any pending sentences for the active query. Does not change
     /// the enabled flag. Emits `VoiceOutputState` + `Done`.
     VoiceSkip { id: String },
-    /// Interrupt the in-flight LLM turn (if any) and stop any TTS
-    /// playback associated with it. The daemon cancels the agent loop
-    /// — the originating `Query` connection observes a final `Done`
-    /// — and drains the TTS queue. Idempotent: with no turn in flight
-    /// it is a no-op apart from the TTS skip. Emits `Done` to the
-    /// caller.
+    /// Cancel the in-flight agent turn (if any) and drop queued TTS
+    /// audio. Idempotent. Emits `Done`.
     InterruptTurn { id: String },
     /// Report whether TTS is currently enabled. Emits `VoiceOutputState`
     /// + `Done` with no state change.
@@ -488,12 +484,8 @@ pub enum Event {
     /// / `VoiceSkip` / `GetVoiceState`. Skip leaves the flag unchanged
     /// (true if synthesis was on before the skip).
     VoiceOutputState { id: String, enabled: bool },
-    /// TTS playback state for a turn. Emitted onto the broadcast bus
-    /// when a turn's speech worker enqueues its first sentence
-    /// (`speaking: true`) and again once the playback queue drains
-    /// (`speaking: false`). Turns with synthesis disabled or no spoken
-    /// sentences emit nothing. `id` echoes the originating turn id so
-    /// passive subscribers can correlate with `Delta` / `LastDelta`.
+    /// TTS playback state for a turn: `speaking: true` on the first
+    /// enqueued sentence, `false` once the playback queue drains.
     SpeakingState { id: String, speaking: bool },
     /// One semantic-search hit emitted by `MemorySemanticSearch`. The
     /// daemon emits zero or more of these ranked by cosine similarity

--- a/crates/assistd-ipc/src/lib.rs
+++ b/crates/assistd-ipc/src/lib.rs
@@ -203,6 +203,13 @@ pub enum Request {
     /// and any pending sentences for the active query. Does not change
     /// the enabled flag. Emits `VoiceOutputState` + `Done`.
     VoiceSkip { id: String },
+    /// Interrupt the in-flight LLM turn (if any) and stop any TTS
+    /// playback associated with it. The daemon cancels the agent loop
+    /// — the originating `Query` connection observes a final `Done`
+    /// — and drains the TTS queue. Idempotent: with no turn in flight
+    /// it is a no-op apart from the TTS skip. Emits `Done` to the
+    /// caller.
+    InterruptTurn { id: String },
     /// Report whether TTS is currently enabled. Emits `VoiceOutputState`
     /// + `Done` with no state change.
     GetVoiceState { id: String },
@@ -366,6 +373,7 @@ impl Request {
             | Request::GetListenState { id }
             | Request::VoiceToggle { id }
             | Request::VoiceSkip { id }
+            | Request::InterruptTurn { id }
             | Request::GetVoiceState { id }
             | Request::MemorySave { id, .. }
             | Request::MemoryLoad { id, .. }
@@ -403,6 +411,7 @@ impl Request {
             Request::GetListenState { .. } => "get_listen_state",
             Request::VoiceToggle { .. } => "voice_toggle",
             Request::VoiceSkip { .. } => "voice_skip",
+            Request::InterruptTurn { .. } => "interrupt_turn",
             Request::GetVoiceState { .. } => "get_voice_state",
             Request::MemorySave { .. } => "memory_save",
             Request::MemoryLoad { .. } => "memory_load",
@@ -1369,6 +1378,17 @@ mod tests {
         assert_eq!(json, r#"{"type":"voice_skip","id":"vs-1"}"#);
         let parsed: Request = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed, req);
+    }
+
+    #[test]
+    fn interrupt_turn_request_roundtrip() {
+        let req = Request::InterruptTurn { id: "it-1".into() };
+        let json = serde_json::to_string(&req).unwrap();
+        assert_eq!(json, r#"{"type":"interrupt_turn","id":"it-1"}"#);
+        let parsed: Request = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, req);
+        assert_eq!(req.kind(), "interrupt_turn");
+        assert_eq!(req.id(), "it-1");
     }
 
     #[test]

--- a/crates/assistd-wm/src/criteria.rs
+++ b/crates/assistd-wm/src/criteria.rs
@@ -38,25 +38,13 @@ pub fn format_criteria_clause(c: &PlacementCriteria) -> String {
     }
 }
 
-/// Build the `floating enable, resize set W H, move position X Y,
-/// sticky enable` payload for the configured anchor, given the focused
-/// workspace's pixel rect.
+/// Build the `floating enable, resize, move position, sticky enable`
+/// payload for the configured anchor on the focused workspace.
 ///
-/// We use an explicit pixel position (`move position {X}px {Y}px`)
-/// rather than `move position 100 ppt 100 ppt, move left Wpx` because
-/// i3 silently clamps off-screen ppt-based positions to keep some
-/// portion of the window visible. With clamping in play, the
-/// `move position` becomes a near-no-op and the chained `move left`
-/// then walks the window leftward by `W` pixels on each placement —
-/// the popup ends up further off-screen with every wake event.
-///
-/// Pixel coordinates are output-relative (no `absolute` keyword) so
-/// multi-monitor setups continue to anchor the popup to whichever
-/// output the focused workspace currently lives on.
-///
-/// `sticky enable` keeps the floating popup visible on every workspace
-/// of its output, so switching workspaces (mod+N on i3, swaymsg
-/// workspace N on sway) doesn't take it away from the user.
+/// Uses explicit pixel positions (`move position {X}px {Y}px`) because
+/// i3's ppt-based positioning silently clamps off-screen values, which
+/// makes a follow-up `move left Wpx` walk the popup further off-screen
+/// on every wake.
 pub fn format_place_floating_pixels(
     c: &PlacementCriteria,
     anchor: PlacementAnchor,

--- a/crates/assistd-wm/src/criteria.rs
+++ b/crates/assistd-wm/src/criteria.rs
@@ -38,8 +38,9 @@ pub fn format_criteria_clause(c: &PlacementCriteria) -> String {
     }
 }
 
-/// Build the `floating enable, resize set W H, move position X Y` payload
-/// for the configured anchor, given the focused workspace's pixel rect.
+/// Build the `floating enable, resize set W H, move position X Y,
+/// sticky enable` payload for the configured anchor, given the focused
+/// workspace's pixel rect.
 ///
 /// We use an explicit pixel position (`move position {X}px {Y}px`)
 /// rather than `move position 100 ppt 100 ppt, move left Wpx` because
@@ -52,6 +53,10 @@ pub fn format_criteria_clause(c: &PlacementCriteria) -> String {
 /// Pixel coordinates are output-relative (no `absolute` keyword) so
 /// multi-monitor setups continue to anchor the popup to whichever
 /// output the focused workspace currently lives on.
+///
+/// `sticky enable` keeps the floating popup visible on every workspace
+/// of its output, so switching workspaces (mod+N on i3, swaymsg
+/// workspace N on sway) doesn't take it away from the user.
 pub fn format_place_floating_pixels(
     c: &PlacementCriteria,
     anchor: PlacementAnchor,
@@ -61,7 +66,7 @@ pub fn format_place_floating_pixels(
     let (x, y) = compute_target_position(anchor, workspace);
     format!(
         "{prefix} floating enable, {prefix} resize set {} {}, \
-         {prefix} move position {} px {} px",
+         {prefix} move position {} px {} px, {prefix} sticky enable",
         anchor.width, anchor.height, x, y,
     )
 }
@@ -210,7 +215,8 @@ mod tests {
             concat!(
                 r#"[title="^dev.assistd.popup$"] floating enable, "#,
                 r#"[title="^dev.assistd.popup$"] resize set 360 120, "#,
-                r#"[title="^dev.assistd.popup$"] move position 1550 px 905 px"#,
+                r#"[title="^dev.assistd.popup$"] move position 1550 px 905 px, "#,
+                r#"[title="^dev.assistd.popup$"] sticky enable"#,
             )
         );
     }
@@ -228,7 +234,8 @@ mod tests {
             concat!(
                 r#"[title="^dev.assistd.popup$"] floating enable, "#,
                 r#"[title="^dev.assistd.popup$"] resize set 360 120, "#,
-                r#"[title="^dev.assistd.popup$"] move position 1550 px 10 px"#,
+                r#"[title="^dev.assistd.popup$"] move position 1550 px 10 px, "#,
+                r#"[title="^dev.assistd.popup$"] sticky enable"#,
             )
         );
     }
@@ -245,7 +252,8 @@ mod tests {
             concat!(
                 r#"[title="^dev.assistd.popup$"] floating enable, "#,
                 r#"[title="^dev.assistd.popup$"] resize set 360 120, "#,
-                r#"[title="^dev.assistd.popup$"] move position 10 px 10 px"#,
+                r#"[title="^dev.assistd.popup$"] move position 10 px 10 px, "#,
+                r#"[title="^dev.assistd.popup$"] sticky enable"#,
             )
         );
     }
@@ -263,7 +271,8 @@ mod tests {
             concat!(
                 r#"[title="^dev.assistd.popup$"] floating enable, "#,
                 r#"[title="^dev.assistd.popup$"] resize set 360 120, "#,
-                r#"[title="^dev.assistd.popup$"] move position 10 px 925 px"#,
+                r#"[title="^dev.assistd.popup$"] move position 10 px 925 px, "#,
+                r#"[title="^dev.assistd.popup$"] sticky enable"#,
             )
         );
     }
@@ -281,7 +290,8 @@ mod tests {
             concat!(
                 r#"[title="^dev.assistd.popup$"] floating enable, "#,
                 r#"[title="^dev.assistd.popup$"] resize set 360 120, "#,
-                r#"[title="^dev.assistd.popup$"] move position 780 px 467 px"#,
+                r#"[title="^dev.assistd.popup$"] move position 780 px 467 px, "#,
+                r#"[title="^dev.assistd.popup$"] sticky enable"#,
             )
         );
     }

--- a/crates/assistd/Cargo.toml
+++ b/crates/assistd/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/main.rs"
 [features]
 default = ["daemon", "client", "chat", "tray", "tray-popup"]
 daemon = [
+    "dep:assistd-config",
     "dep:assistd-core",
     "dep:assistd-embed",
     "dep:assistd-llm",

--- a/crates/assistd/src/chat/app.rs
+++ b/crates/assistd/src/chat/app.rs
@@ -769,6 +769,7 @@ impl App {
             Event::VoiceOutputState { enabled, .. } => {
                 self.voice_output_enabled = enabled;
             }
+            Event::SpeakingState { .. } => {}
             Event::Capabilities {
                 vision, model_name, ..
             } => {

--- a/crates/assistd/src/main.rs
+++ b/crates/assistd/src/main.rs
@@ -41,6 +41,8 @@ mod voice_ctl;
 mod voice_init;
 #[cfg(feature = "daemon")]
 mod voice_probe;
+#[cfg(any(feature = "daemon", feature = "tray-popup"))]
+mod wm_backend;
 #[cfg(feature = "daemon")]
 mod wm_init;
 

--- a/crates/assistd/src/ptt.rs
+++ b/crates/assistd/src/ptt.rs
@@ -85,6 +85,7 @@ pub async fn run(action: PttAction) -> Result<()> {
             Event::Presence { .. } => {}
             Event::ListenState { .. } => {}
             Event::VoiceOutputState { .. } => {}
+            Event::SpeakingState { .. } => {}
             Event::Status {
                 severity,
                 component,

--- a/crates/assistd/src/query.rs
+++ b/crates/assistd/src/query.rs
@@ -134,6 +134,7 @@ pub async fn run(args: QueryArgs) -> Result<()> {
                     if enabled { "on" } else { "off" }
                 )?;
             }
+            Event::SpeakingState { .. } => {}
             Event::Status {
                 severity,
                 component,

--- a/crates/assistd/src/tray/mod.rs
+++ b/crates/assistd/src/tray/mod.rs
@@ -68,8 +68,10 @@ pub async fn run(args: TrayArgs) -> Result<()> {
         );
     }
 
+    let ipc = IpcClient::new();
+
     #[cfg(feature = "tray-popup")]
-    let popup_handle = popup::spawn(&config).await?;
+    let popup_handle = popup::spawn(&config, ipc.clone()).await?;
     #[cfg(feature = "tray-popup")]
     let popup_sink = popup_handle.as_ref().map(|h| h.sink.clone());
     #[cfg(not(feature = "tray-popup"))]
@@ -86,7 +88,6 @@ pub async fn run(args: TrayArgs) -> Result<()> {
         .map_err(|e| anyhow::anyhow!("failed to register StatusNotifierItem on DBus: {e}"))?;
     tracing::info!(target: "tray", "tray icon registered on DBus");
 
-    let ipc = IpcClient::new();
     let subscribe_handle = handle.clone();
     let subscribe_ipc = ipc.clone();
     // Move popup_sink into the subscribe task — it's not used after the

--- a/crates/assistd/src/tray/mod.rs
+++ b/crates/assistd/src/tray/mod.rs
@@ -1,21 +1,4 @@
-//! `assistd tray`: a long-lived StatusNotifierItem client that
-//! subscribes to the daemon's broadcast bus and reflects daemon state
-//! as an icon in Waybar / i3status-rust / KDE / GNOME-with-AppIndicator.
-//!
-//! Three tasks make up the runtime:
-//!
-//! - the ksni service, owning the [`TrayItem`] and answering DBus
-//!   property/menu queries;
-//! - the [`subscribe`] loop, holding a passive `Request::Subscribe`
-//!   on the daemon socket and pushing event updates into the tray
-//!   through `Handle::update`;
-//! - the [`menu::run_actions`] task, draining the mpsc channel that
-//!   menu activate callbacks feed and issuing one-shot
-//!   `Request::SetPresence` calls.
-//!
-//! The tray never auto-spawns the daemon — it stays in the
-//! `Disconnected` icon variant until the user starts `assistd daemon`
-//! separately, then reconnects on the next backoff tick.
+//! `assistd tray`: StatusNotifierItem client mirroring daemon state.
 
 use std::path::PathBuf;
 
@@ -35,7 +18,6 @@ mod subscribe;
 
 use menu::TrayItem;
 
-/// Arguments for the `tray` subcommand.
 #[derive(Args)]
 pub struct TrayArgs {
     /// Path to config file [default: `~/.config/assistd/config.toml`]
@@ -43,12 +25,6 @@ pub struct TrayArgs {
     pub config: Option<PathBuf>,
 }
 
-/// Launch the tray and run until SIGINT/SIGTERM or a `Quit` menu click.
-///
-/// # Errors
-///
-/// Returns an error if config loading fails, the session DBus is
-/// unavailable, or the ksni service cannot register on DBus.
 pub async fn run(args: TrayArgs) -> Result<()> {
     init_tracing();
 
@@ -90,8 +66,6 @@ pub async fn run(args: TrayArgs) -> Result<()> {
 
     let subscribe_handle = handle.clone();
     let subscribe_ipc = ipc.clone();
-    // Move popup_sink into the subscribe task — it's not used after the
-    // activate-callback was built above, so we don't need a clone.
     let subscribe_task =
         tokio::spawn(
             async move { subscribe::run(subscribe_handle, subscribe_ipc, popup_sink).await },
@@ -111,9 +85,6 @@ pub async fn run(args: TrayArgs) -> Result<()> {
     Ok(())
 }
 
-/// Build the optional ksni-activate callback from the popup sink, when
-/// the popup feature is on. Without the feature, returns `None` so the
-/// tray-icon left-click does nothing.
 #[cfg(feature = "tray-popup")]
 fn build_activate_callback(sink: &Option<popup::PopupSink>) -> Option<menu::ActivateCallback> {
     let sink = sink.as_ref()?.clone();
@@ -128,8 +99,6 @@ fn build_activate_callback(_sink: &Option<()>) -> Option<menu::ActivateCallback>
     None
 }
 
-/// Block until any of: Ctrl-C, SIGTERM, or the menu-action task
-/// finishing (which happens when the user clicks Quit).
 async fn wait_for_shutdown(action_task: tokio::task::JoinHandle<Result<()>>) {
     let mut sigterm = match signal(SignalKind::terminate()) {
         Ok(s) => s,

--- a/crates/assistd/src/tray/popup/mod.rs
+++ b/crates/assistd/src/tray/popup/mod.rs
@@ -212,28 +212,14 @@ pub async fn spawn(cfg: &Config) -> anyhow::Result<Option<PopupHandle>> {
     let driver_task = tokio::spawn(driver_run(state_tx, driver_rx, place_tx, driver_cfg));
 
     let app_id = assistd_config::defaults::DEFAULT_TRAY_POPUP_APP_ID.to_string();
-    let (gui_event_tx, gui_event_rx) = std::sync::mpsc::channel::<DriverInput>();
-
-    // Bridge std mpsc → driver mpsc on a dedicated tokio task. We can't
-    // call `driver_tx.send` from inside the GUI thread directly without
-    // borrowing the tokio runtime, so a small forwarder loop is the
-    // simplest correct option.
-    let bridge_tx = driver_tx.clone();
-    let bridge_task = tokio::task::spawn_blocking(move || {
-        while let Ok(msg) = gui_event_rx.recv() {
-            if bridge_tx.send(msg).is_err() {
-                break;
-            }
-        }
-    });
-    // We don't store bridge_task; it terminates when the GUI thread
-    // closes its sender (on shutdown) which happens when the OS thread
-    // joins.
-    drop(bridge_task);
 
     let width = popup_cfg.width;
     let height = popup_cfg.height;
     let gui_state_rx = state_rx.clone();
+    // The GUI thread reports focus-lost / first-paint straight onto the
+    // driver channel: `UnboundedSender::send` is a plain non-async call
+    // with no runtime requirement, so no std-mpsc bridge task is needed.
+    let gui_event_tx = driver_tx.clone();
     // Capture the workspace runtime handle before crossing the
     // thread boundary; window::run uses it to spawn the egui waker.
     let runtime = tokio::runtime::Handle::current();

--- a/crates/assistd/src/tray/popup/mod.rs
+++ b/crates/assistd/src/tray/popup/mod.rs
@@ -1,18 +1,4 @@
-//! Floating activity popup spawned alongside the tray icon (feature
-//! `tray-popup`). Subscribes to the same daemon event stream as the
-//! tray, renders a small borderless window near the system-tray
-//! corner, and delegates placement to the compositor through
-//! `assistd-wm`.
-//!
-//! Spawned from [`crate::tray::run`] when the feature is enabled. Owns:
-//!
-//! - the watch channel the GUI thread reads from;
-//! - a driver tokio task that ingests events, runs the visibility
-//!   state machine, and pushes new snapshots;
-//! - the WM backend + placement worker task that turns "popup just
-//!   became visible" into a `floating enable, resize set, move
-//!   position …` IPC sequence on i3 / sway;
-//! - the dedicated OS thread that runs the eframe event loop.
+//! Floating activity popup spawned alongside the tray icon.
 
 use std::sync::Arc;
 use std::thread::JoinHandle as ThreadJoinHandle;
@@ -36,10 +22,7 @@ use wm_bridge::{
     WmBackendBundle, anchor_from_config, build_wm_backend, place_worker, popup_criteria,
 };
 
-/// Hook handed to the tray's subscribe loop. The subscribe loop calls
-/// [`PopupSink::ingest`] after pushing each event into the tray icon's
-/// `TrayItem`; it's a no-op when the popup feature is disabled at the
-/// call site (we return `None` from [`spawn`] in that path).
+/// Hook the tray's subscribe loop calls into for each daemon event.
 #[derive(Clone)]
 pub struct PopupSink {
     driver_tx: UnboundedSender<DriverInput>,
@@ -49,10 +32,8 @@ pub struct PopupSink {
 }
 
 impl PopupSink {
-    /// Forward a daemon event into the driver task and, if the event
-    /// matches a configured wake rule, also send a `Show`. The event
-    /// is boxed because `assistd_ipc::Event` is ~230 bytes and would
-    /// dominate the [`DriverInput`] enum size otherwise.
+    /// Forward an event into the driver, plus a `Show` when the event
+    /// matches a configured wake rule.
     pub fn ingest(&self, ev: &Event) {
         if self.matches_wake_rule(ev) {
             let _ = self.driver_tx.send(DriverInput::Show);
@@ -62,13 +43,10 @@ impl PopupSink {
             .send(DriverInput::Event(Box::new(ev.clone())));
     }
 
-    /// Tell the popup the daemon socket dropped.
     pub fn set_disconnected(&self) {
         let _ = self.driver_tx.send(DriverInput::Disconnected);
     }
 
-    /// Sender exposed so the tray-icon menu code can hand it to
-    /// `TrayItem` for the left-click handler.
     pub fn show_sender(&self) -> UnboundedSender<DriverInput> {
         self.driver_tx.clone()
     }
@@ -85,8 +63,7 @@ impl PopupSink {
     }
 }
 
-/// Live popup. Holds every spawned task/thread; [`PopupHandle::shutdown`]
-/// drains them in the right order.
+/// Owns every task and thread the popup spawned.
 pub struct PopupHandle {
     pub sink: PopupSink,
     driver_task: JoinHandle<()>,
@@ -97,22 +74,12 @@ pub struct PopupHandle {
 }
 
 impl PopupHandle {
-    /// Shut everything down cooperatively: tell the driver to quit
-    /// (which drops the watch sender, which wakes the egui-waker
-    /// task, which sends `ViewportCommand::Close` to the GUI thread).
-    /// Then drain the placement worker, join the GUI thread, and
-    /// stop the WM backend.
     pub async fn shutdown(mut self) {
         let _ = self.sink.driver_tx.send(DriverInput::Shutdown);
         let _ = self.driver_task.await;
-        // Dropping the senders inside the sink lets the place worker
-        // observe EOF and exit.
         drop(self.sink);
         let _ = self.place_task.await;
         if let Some(t) = self.gui_thread.take() {
-            // std::thread::join blocks; offload to spawn_blocking so
-            // the tokio worker stays available for the egui-waker
-            // task that's busy sending Close to the GUI loop.
             let join = tokio::task::spawn_blocking(move || t.join()).await;
             match join {
                 Ok(Ok(())) => {}
@@ -131,13 +98,7 @@ impl PopupHandle {
     }
 }
 
-/// Spawn the popup subsystem. Returns `Ok(None)` when the popup is
-/// disabled by config; otherwise builds the WM backend, spawns the
-/// driver task, the placement worker, and the GUI thread, and returns
-/// a [`PopupHandle`] the tray can shut down at exit.
-///
-/// `ipc` is handed to the driver so the close-button dismiss path
-/// can fire `Request::InterruptTurn` at the daemon.
+/// Spawn the popup subsystem; `Ok(None)` when disabled by config.
 pub async fn spawn(cfg: &Config, ipc: IpcClient) -> anyhow::Result<Option<PopupHandle>> {
     if !cfg.tray.popup.enabled {
         tracing::info!(target: "tray", "popup: disabled by config");
@@ -155,18 +116,9 @@ pub async fn spawn(cfg: &Config, ipc: IpcClient) -> anyhow::Result<Option<PopupH
 
     let anchor = anchor_from_config(&popup_cfg);
 
-    // Compute a best-effort initial position so eframe creates the
-    // window at the configured corner from the very first map — this
-    // is what kills the brief "popup flashes in the centre" on the
-    // first wake. Ask the WM backend for the focused output's scale
-    // and scale the configured size by it (a configured 360×120 popup
-    // becomes 420×140 physical at scale 1.17). On sway this comes
-    // straight from the compositor's output IPC reply; on i3 the
-    // backend cascades through `WINIT_X11_SCALE_FACTOR`, `Xft.dpi` in
-    // xrdb, and RandR-derived DPI to match what winit will apply
-    // to the popup window. The actual rect snap via `place_floating`
-    // then locks in the precise pixel position once the window is
-    // mapped, so any residual error here is invisible.
+    // Pre-position the window so it never flashes in the centre before
+    // place_floating snaps it. Scale by the focused output's DPI so the
+    // size matches what winit will apply.
     let scale = match manager.focused_output_scale().await {
         Ok(s) => {
             tracing::info!(target: "tray", "popup: focused-output scale = {s:.4}");
@@ -219,12 +171,7 @@ pub async fn spawn(cfg: &Config, ipc: IpcClient) -> anyhow::Result<Option<PopupH
     let width = popup_cfg.width;
     let height = popup_cfg.height;
     let gui_state_rx = state_rx.clone();
-    // The GUI thread reports focus-lost / first-paint straight onto the
-    // driver channel: `UnboundedSender::send` is a plain non-async call
-    // with no runtime requirement, so no std-mpsc bridge task is needed.
     let gui_event_tx = driver_tx.clone();
-    // Capture the workspace runtime handle before crossing the
-    // thread boundary; window::run uses it to spawn the egui waker.
     let runtime = tokio::runtime::Handle::current();
     let gui_thread = std::thread::Builder::new()
         .name("assistd-popup-gui".into())
@@ -288,7 +235,6 @@ mod tests {
         let scaled = scale_anchor_size(a, 1.1666666);
         assert_eq!(scaled.width, 420);
         assert_eq!(scaled.height, 140);
-        // Offsets and corner are not touched.
         assert_eq!(scaled.offset_x, -10);
         assert_eq!(scaled.offset_y, -30);
         assert_eq!(scaled.corner, AnchorCorner::BottomRight);

--- a/crates/assistd/src/tray/popup/mod.rs
+++ b/crates/assistd/src/tray/popup/mod.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 use std::thread::JoinHandle as ThreadJoinHandle;
 
 use assistd_config::{Config, TrayPopupConfig};
-use assistd_ipc::Event;
+use assistd_ipc::{Event, IpcClient};
 use tokio::sync::mpsc::{self, UnboundedSender};
 use tokio::sync::watch;
 use tokio::task::JoinHandle;
@@ -135,7 +135,10 @@ impl PopupHandle {
 /// disabled by config; otherwise builds the WM backend, spawns the
 /// driver task, the placement worker, and the GUI thread, and returns
 /// a [`PopupHandle`] the tray can shut down at exit.
-pub async fn spawn(cfg: &Config) -> anyhow::Result<Option<PopupHandle>> {
+///
+/// `ipc` is handed to the driver so the close-button dismiss path
+/// can fire `Request::InterruptTurn` at the daemon.
+pub async fn spawn(cfg: &Config, ipc: IpcClient) -> anyhow::Result<Option<PopupHandle>> {
     if !cfg.tray.popup.enabled {
         tracing::info!(target: "tray", "popup: disabled by config");
         return Ok(None);
@@ -209,7 +212,7 @@ pub async fn spawn(cfg: &Config) -> anyhow::Result<Option<PopupHandle>> {
     ));
 
     let driver_cfg = popup_cfg.clone();
-    let driver_task = tokio::spawn(driver_run(state_tx, driver_rx, place_tx, driver_cfg));
+    let driver_task = tokio::spawn(driver_run(state_tx, driver_rx, place_tx, driver_cfg, ipc));
 
     let app_id = assistd_config::defaults::DEFAULT_TRAY_POPUP_APP_ID.to_string();
 

--- a/crates/assistd/src/tray/popup/state.rs
+++ b/crates/assistd/src/tray/popup/state.rs
@@ -1,11 +1,4 @@
-//! Popup data model: rendered fields, per-turn coalescing, and the
-//! small argument-summarizer that turns a `ToolCall`'s JSON args into a
-//! one-line footer.
-//!
-//! The tracker is deliberately ignorant of the GUI layer; the daemon
-//! event stream lands here, the rendered string fields land in the
-//! shared [`PopupState`] snapshot, and the eframe app just reads the
-//! latest snapshot on each repaint.
+//! Popup data model and per-turn coalescing.
 
 use std::collections::{HashMap, HashSet};
 
@@ -13,55 +6,29 @@ use assistd_config::TrayPopupConfig;
 use assistd_ipc::Event;
 use serde_json::Value;
 
-/// Snapshot pushed through the `watch` channel to the GUI thread. The
-/// GUI side reads this each repaint; tracker mutations on the tokio
-/// side push a new snapshot only when something visible actually
-/// changed.
+/// Snapshot pushed through the `watch` channel to the GUI thread.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct PopupState {
-    /// Last N codepoints of the in-flight (or last-completed) turn's
-    /// reply text, after coalescing. May be empty when no turn has
-    /// produced any output yet.
     pub body: String,
-    /// Most recent tool invocation for the active turn, rendered as
-    /// `<fully-qualified-tool-name>` + a one-line arg summary.
     pub footer: Option<ToolCallLine>,
-    /// What the agent / daemon is currently doing, rendered as a small
-    /// status indicator above the body. Driven by the most recent event
-    /// for the displayed turn plus the daemon's listening flag.
     pub activity: PopupActivity,
-    /// Whether the GUI should show the window right now. The visibility
-    /// state machine owns this flag; the tracker leaves it untouched
-    /// when ingesting events.
     pub visible: bool,
 }
 
 /// Coarse activity classification rendered as a one-line status above
-/// the popup body. Distinct from raw event kind so the GUI can show a
-/// stable label across an event burst (e.g. `Streaming` covers both
-/// `Delta` and `LastDelta`).
+/// the popup body.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub enum PopupActivity {
-    /// No turn in flight and listener not active — popup is just
-    /// surfacing the last completed turn.
     #[default]
     Idle,
-    /// Agent is producing reply text right now.
     Streaming,
-    /// Agent is between text chunks: reasoning, planning the next tool
-    /// call, or waiting for the LLM to start the next round after a
-    /// tool result landed.
     Thinking,
-    /// Agent has dispatched a tool and is waiting for it to return.
-    /// `name` is the fully-qualified tool name.
-    RunningTool { name: String },
-    /// Daemon's continuous listener is on and no turn is in flight; the
-    /// user can speak without pressing a key.
+    RunningTool {
+        name: String,
+    },
     Listening,
 }
 
-/// Per-turn activity kind we last observed, used by the snapshot to
-/// derive [`PopupActivity`] for the displayed turn.
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum TurnActivity {
     Streaming,
@@ -70,23 +37,12 @@ enum TurnActivity {
     Finished,
 }
 
-/// Footer row rendered under the body.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ToolCallLine {
-    /// Fully-qualified tool name, exactly as it appeared on the wire
-    /// (e.g. `mcp__filesystem__read_text_file` or a native name like
-    /// `bash`). The IPC payload already prefixes MCP tools, so we
-    /// render it verbatim.
     pub name: String,
-    /// Compact one-line summary of the tool's arguments. Newlines and
-    /// control characters are flattened to spaces and the result is
-    /// truncated to a configured maximum.
     pub args_summary: String,
 }
 
-/// Per-turn working state. The popup may display content from a
-/// single turn even after it terminates, so we retain `body`, `footer`
-/// and `activity` until the *next* turn's first event lands.
 #[derive(Debug, Clone, Default)]
 struct TurnState {
     body: String,
@@ -95,38 +51,17 @@ struct TurnState {
 }
 
 /// Tracks every signal the popup cares about and produces a
-/// [`PopupState`] snapshot on demand. Owned by the popup driver task
-/// (one task, single-threaded ingestion — no internal locking needed).
+/// [`PopupState`] snapshot on demand.
 #[derive(Debug, Default)]
 pub struct PopupTracker {
-    /// Turns we've seen at least one event for. Keyed by IPC request
-    /// id. Pruned on `Done` / `Error` only if it isn't the displayed
-    /// turn — see [`PopupTracker::ingest`].
     turns: HashMap<String, TurnState>,
-    /// Turn ids that haven't yet received a `Done` / `Error`. Used so
-    /// `set_disconnected` can drop in-flight turns whose ids may no
-    /// longer map to live turns on the daemon after a restart.
     in_flight: HashSet<String>,
-    /// IPC id of the turn whose body/footer the popup is currently
-    /// showing. Switches on the first event of a new turn so concurrent
-    /// queries don't trample each other.
     displayed: Option<String>,
-    /// Whether the daemon's continuous listener is on. Tracked from
-    /// `ListenState` events so the visibility driver can extend the
-    /// auto-hide window when the user can verbally reply without
-    /// pressing a key.
     listening: bool,
-    /// Turn ids whose TTS playback is currently in flight. Tracked
-    /// from `SpeakingState` events so the visibility driver can pin
-    /// the popup open while the agent is speaking, even after the
-    /// underlying turn has emitted `Done`.
     speaking: HashSet<String>,
 }
 
 impl PopupTracker {
-    /// Build a `PopupState` from the current tracker. The truncation
-    /// cap is applied here so the GUI never sees more body text than
-    /// the user configured.
     pub fn snapshot(&self, cfg: &TrayPopupConfig) -> PopupState {
         let displayed_id = self.displayed.as_deref();
         let displayed = displayed_id.and_then(|id| self.turns.get(id));
@@ -143,31 +78,18 @@ impl PopupTracker {
         }
     }
 
-    /// Whether any turn is still in flight on the daemon side. The
-    /// visibility driver consults this to keep the popup pinned open
-    /// while the agent is mid-response — including the gap between a
-    /// `ToolCall` and the corresponding `ToolResult`, where no events
-    /// arrive but the agent is still busy.
     pub fn is_busy(&self) -> bool {
         !self.in_flight.is_empty()
     }
 
-    /// Whether the daemon's continuous listener is currently active.
-    /// Used by the driver to swap in the longer hands-free auto-hide
-    /// window.
     pub fn is_listening(&self) -> bool {
         self.listening
     }
 
-    /// Whether any turn's TTS playback is currently in flight. The
-    /// visibility driver pins the popup open while this is true so the
-    /// activity surface stays visible for the whole spoken response.
     pub fn is_speaking(&self) -> bool {
         !self.speaking.is_empty()
     }
 
-    /// Forget per-turn state — any in-flight turn id we remembered no
-    /// longer maps to a live turn on the daemon side after a restart.
     pub fn set_disconnected(&mut self) {
         self.turns.clear();
         self.in_flight.clear();
@@ -186,9 +108,6 @@ impl PopupTracker {
                 Some(TurnActivity::RunningTool(name)) => {
                     PopupActivity::RunningTool { name: name.clone() }
                 }
-                // No per-turn signal yet but the turn is still live — the
-                // model has accepted the request and is presumably
-                // composing its first response.
                 Some(TurnActivity::Finished) | None => PopupActivity::Thinking,
             };
         }
@@ -198,20 +117,16 @@ impl PopupTracker {
         PopupActivity::Idle
     }
 
-    /// Apply one daemon event. Returns the latest snapshot so the
-    /// caller can decide whether to push it onto the watch.
     pub fn ingest(&mut self, ev: &Event, cfg: &TrayPopupConfig) -> PopupState {
         match ev {
             Event::Delta { id, .. } => {
-                // Body text comes exclusively from LastDelta (the
-                // daemon's coalesced snapshot); appending the raw Delta
-                // here too would double-count tokens already in it.
+                // LastDelta carries the full coalesced body; appending
+                // the raw Delta on top would double-count tokens.
                 self.bring_turn_to_front(id);
                 self.in_flight.insert(id.clone());
                 self.turns.entry(id.clone()).or_default().activity = Some(TurnActivity::Streaming);
             }
             Event::LastDelta { id, text } => {
-                // Server-coalesced cumulative snapshot — overwrite, don't append.
                 self.bring_turn_to_front(id);
                 self.in_flight.insert(id.clone());
                 let turn = self.turns.entry(id.clone()).or_default();
@@ -235,18 +150,12 @@ impl PopupTracker {
                 turn.activity = Some(TurnActivity::RunningTool(name.clone()));
             }
             Event::ToolResult { id, .. } => {
-                // Tool came back; the agent is now planning the next
-                // step. Surface that as "thinking" until the next
-                // Delta / ToolCall arrives.
                 self.bring_turn_to_front(id);
                 self.in_flight.insert(id.clone());
                 self.turns.entry(id.clone()).or_default().activity = Some(TurnActivity::Thinking);
             }
             Event::Done { id } | Event::Error { id, .. } => {
                 self.in_flight.remove(id);
-                // Keep the displayed turn's content around so the popup
-                // doesn't blank out when a turn finishes. Non-displayed
-                // turns are dropped.
                 if self.displayed.as_deref() != Some(id.as_str()) {
                     self.turns.remove(id);
                 } else if let Some(turn) = self.turns.get_mut(id) {
@@ -268,11 +177,6 @@ impl PopupTracker {
         self.snapshot(cfg)
     }
 
-    /// Switch the displayed turn to `id` and drop any older
-    /// already-terminated turn we were holding onto. If the previous
-    /// displayed turn is still in flight, keep it in `turns` — it may
-    /// matter again later (rare, but possible if the daemon
-    /// interleaves two long-running turns).
     fn bring_turn_to_front(&mut self, id: &str) {
         if self.displayed.as_deref() != Some(id)
             && let Some(prev) = self.displayed.take()
@@ -284,15 +188,9 @@ impl PopupTracker {
     }
 }
 
-/// Cap on the footer argument summary independently of the body
-/// truncation. ~80 chars fits one wrapped line at the default popup
-/// width without intruding on the body area.
 const FOOTER_ARGS_MAX_CHARS: usize = 80;
 
-/// Render a `serde_json::Value` as a single-line, ≤`max_chars`-codepoint
-/// preview. Newlines and control characters become single spaces;
-/// objects render as flat `key=value` pairs; arrays render as their
-/// length only when long.
+/// Single-line, ≤`max_chars`-codepoint preview of a JSON value.
 pub fn summarize_args(v: &Value, max_chars: usize) -> String {
     let raw = match v {
         Value::Null => String::new(),
@@ -326,8 +224,6 @@ fn value_inline(v: &Value) -> String {
         Value::Bool(b) => b.to_string(),
         Value::Number(n) => n.to_string(),
         Value::String(s) => {
-            // Keep simple strings unquoted; quote when they'd otherwise
-            // ambiguate with the surrounding `k=v k=v` rendering.
             if s.chars().any(|c| c.is_whitespace() || c == '=') {
                 format!("\"{s}\"")
             } else {
@@ -339,9 +235,6 @@ fn value_inline(v: &Value) -> String {
     }
 }
 
-/// Replace every whitespace / control character with a single space
-/// and collapse repeated spaces. Used so a JSON `command` arg
-/// containing `\n` doesn't break the popup's one-line footer.
 fn flatten_whitespace(s: &str) -> String {
     let mut out = String::with_capacity(s.len());
     let mut prev_space = false;
@@ -362,9 +255,6 @@ fn flatten_whitespace(s: &str) -> String {
     out
 }
 
-/// Truncate to the last `max` codepoints, prepending an ellipsis when
-/// the original was longer. Operates on chars (not bytes) so we never
-/// split a multibyte codepoint.
 fn truncate_chars_from_end(s: &str, max: usize) -> String {
     if max == 0 {
         return String::new();
@@ -377,9 +267,6 @@ fn truncate_chars_from_end(s: &str, max: usize) -> String {
     format!("…{tail}")
 }
 
-/// Truncate to the first `max` codepoints, appending an ellipsis when
-/// the original was longer. Used for argument summaries — the keys are
-/// usually meaningful and the value tail rarely is.
 fn truncate_chars_from_start(s: &str, max: usize) -> String {
     if max == 0 {
         return String::new();
@@ -403,8 +290,6 @@ mod tests {
     #[test]
     fn summarize_args_object_renders_key_equals_value() {
         let s = summarize_args(&json!({"a": 1, "b": "two"}), 100);
-        // serde_json preserves insertion order for objects, which
-        // matches what the daemon sends.
         assert!(s.contains("a=1"), "missing a=1: {s}");
         assert!(s.contains("b=two"), "missing b=two: {s}");
     }
@@ -426,7 +311,7 @@ mod tests {
     fn summarize_args_truncates_to_max_chars() {
         let long = "x".repeat(1000);
         let s = summarize_args(&json!({"a": long}), 30);
-        assert_eq!(s.chars().count(), 31); // 30 chars + 1 ellipsis
+        assert_eq!(s.chars().count(), 31);
         assert!(s.ends_with('…'));
     }
 
@@ -450,11 +335,8 @@ mod tests {
 
     #[test]
     fn truncate_chars_from_end_preserves_unicode_codepoints() {
-        // Each emoji is multiple bytes; chars-based truncation must
-        // not split them.
         let s = "🦀🦀🦀🦀🦀🦀🦀🦀🦀🦀";
         let truncated = truncate_chars_from_end(s, 3);
-        // 3 emoji + 1 ellipsis
         assert_eq!(truncated.chars().count(), 4);
     }
 
@@ -483,8 +365,6 @@ mod tests {
 
     #[test]
     fn tracker_body_comes_only_from_last_delta() {
-        // Raw Delta events are in-flight / activity signals only; the
-        // body is owned by LastDelta, the daemon's coalesced snapshot.
         let mut t = PopupTracker::default();
         t.ingest(&delta("a", "hello "), &cfg());
         t.ingest(&delta("a", "world"), &cfg());
@@ -499,10 +379,6 @@ mod tests {
 
     #[test]
     fn tracker_interleaved_last_delta_and_delta_does_not_double_count() {
-        // Regression: on the real bus the daemon emits LastDelta
-        // (coalesced) and socket.rs tees the raw Delta for the same
-        // token. Appending the Delta on top of the snapshot used to
-        // duplicate tokens, so the popup body read e.g. "AA" / "ABCDD".
         let mut t = PopupTracker::default();
         t.ingest(&last_delta("a", "A"), &cfg());
         t.ingest(&delta("a", "A"), &cfg());
@@ -555,7 +431,7 @@ mod tests {
         let mut narrow = cfg();
         narrow.truncate_chars = 50;
         let s = t.snapshot(&narrow);
-        assert_eq!(s.body.chars().count(), 51); // 50 chars + 1 ellipsis
+        assert_eq!(s.body.chars().count(), 51);
         assert!(s.body.starts_with('…'));
     }
 
@@ -563,9 +439,6 @@ mod tests {
     fn tracker_ignores_unrelated_event_kinds() {
         let mut t = PopupTracker::default();
         let before = t.snapshot(&cfg());
-        // Pick an event kind the popup deliberately has no rendering
-        // for (Capabilities reply); it should leave both content and
-        // activity untouched.
         t.ingest(
             &Event::Capabilities {
                 id: "a".into(),
@@ -626,8 +499,6 @@ mod tests {
         assert!(t.is_listening());
         assert_eq!(t.snapshot(&cfg()).activity, PopupActivity::Listening);
 
-        // While a turn is in flight, the per-turn activity takes
-        // precedence over the listening flag.
         t.ingest(&delta("a", "hi"), &cfg());
         assert_eq!(t.snapshot(&cfg()).activity, PopupActivity::Streaming);
         t.ingest(&done("a"), &cfg());
@@ -658,7 +529,6 @@ mod tests {
         );
         assert!(t.is_speaking());
 
-        // Second concurrent turn starts speaking; flag stays on.
         t.ingest(
             &Event::SpeakingState {
                 id: "b".into(),
@@ -668,7 +538,6 @@ mod tests {
         );
         assert!(t.is_speaking());
 
-        // Turn 'a' finishes — 'b' still speaking, so flag stays on.
         t.ingest(
             &Event::SpeakingState {
                 id: "a".into(),

--- a/crates/assistd/src/tray/popup/state.rs
+++ b/crates/assistd/src/tray/popup/state.rs
@@ -189,12 +189,13 @@ impl PopupTracker {
     /// caller can decide whether to push it onto the watch.
     pub fn ingest(&mut self, ev: &Event, cfg: &TrayPopupConfig) -> PopupState {
         match ev {
-            Event::Delta { id, text } => {
+            Event::Delta { id, .. } => {
+                // Body text comes exclusively from LastDelta (the
+                // daemon's coalesced snapshot); appending the raw Delta
+                // here too would double-count tokens already in it.
                 self.bring_turn_to_front(id);
                 self.in_flight.insert(id.clone());
-                let turn = self.turns.entry(id.clone()).or_default();
-                turn.body.push_str(text);
-                turn.activity = Some(TurnActivity::Streaming);
+                self.turns.entry(id.clone()).or_default().activity = Some(TurnActivity::Streaming);
             }
             Event::LastDelta { id, text } => {
                 // Server-coalesced cumulative snapshot — overwrite, don't append.
@@ -461,14 +462,37 @@ mod tests {
     }
 
     #[test]
-    fn tracker_accumulates_delta_text_until_last_delta_overwrites() {
+    fn tracker_body_comes_only_from_last_delta() {
+        // Raw Delta events are in-flight / activity signals only; the
+        // body is owned by LastDelta, the daemon's coalesced snapshot.
         let mut t = PopupTracker::default();
         t.ingest(&delta("a", "hello "), &cfg());
         t.ingest(&delta("a", "world"), &cfg());
-        let s = t.snapshot(&cfg());
-        assert_eq!(s.body, "hello world");
-        t.ingest(&last_delta("a", "completely fresh body"), &cfg());
-        assert_eq!(t.snapshot(&cfg()).body, "completely fresh body");
+        assert_eq!(
+            t.snapshot(&cfg()).body,
+            "",
+            "Delta must not populate the body"
+        );
+        t.ingest(&last_delta("a", "the coalesced reply"), &cfg());
+        assert_eq!(t.snapshot(&cfg()).body, "the coalesced reply");
+    }
+
+    #[test]
+    fn tracker_interleaved_last_delta_and_delta_does_not_double_count() {
+        // Regression: on the real bus the daemon emits LastDelta
+        // (coalesced) and socket.rs tees the raw Delta for the same
+        // token. Appending the Delta on top of the snapshot used to
+        // duplicate tokens, so the popup body read e.g. "AA" / "ABCDD".
+        let mut t = PopupTracker::default();
+        t.ingest(&last_delta("a", "A"), &cfg());
+        t.ingest(&delta("a", "A"), &cfg());
+        assert_eq!(t.snapshot(&cfg()).body, "A");
+        t.ingest(&delta("a", "B"), &cfg());
+        t.ingest(&delta("a", "C"), &cfg());
+        assert_eq!(t.snapshot(&cfg()).body, "A", "raw deltas must not append");
+        t.ingest(&last_delta("a", "ABCD"), &cfg());
+        t.ingest(&delta("a", "D"), &cfg());
+        assert_eq!(t.snapshot(&cfg()).body, "ABCD");
     }
 
     #[test]

--- a/crates/assistd/src/tray/popup/state.rs
+++ b/crates/assistd/src/tray/popup/state.rs
@@ -116,6 +116,11 @@ pub struct PopupTracker {
     /// auto-hide window when the user can verbally reply without
     /// pressing a key.
     listening: bool,
+    /// Turn ids whose TTS playback is currently in flight. Tracked
+    /// from `SpeakingState` events so the visibility driver can pin
+    /// the popup open while the agent is speaking, even after the
+    /// underlying turn has emitted `Done`.
+    speaking: HashSet<String>,
 }
 
 impl PopupTracker {
@@ -154,6 +159,13 @@ impl PopupTracker {
         self.listening
     }
 
+    /// Whether any turn's TTS playback is currently in flight. The
+    /// visibility driver pins the popup open while this is true so the
+    /// activity surface stays visible for the whole spoken response.
+    pub fn is_speaking(&self) -> bool {
+        !self.speaking.is_empty()
+    }
+
     /// Forget per-turn state — any in-flight turn id we remembered no
     /// longer maps to a live turn on the daemon side after a restart.
     pub fn set_disconnected(&mut self) {
@@ -161,6 +173,7 @@ impl PopupTracker {
         self.in_flight.clear();
         self.displayed = None;
         self.listening = false;
+        self.speaking.clear();
     }
 
     fn activity(&self, displayed: Option<&TurnState>, in_flight: bool) -> PopupActivity {
@@ -242,6 +255,13 @@ impl PopupTracker {
             }
             Event::ListenState { active, .. } => {
                 self.listening = *active;
+            }
+            Event::SpeakingState { id, speaking } => {
+                if *speaking {
+                    self.speaking.insert(id.clone());
+                } else {
+                    self.speaking.remove(id);
+                }
             }
             _ => {}
         }
@@ -622,6 +642,65 @@ mod tests {
         );
         assert!(!t.is_listening());
         assert_eq!(t.snapshot(&cfg()).activity, PopupActivity::Idle);
+    }
+
+    #[test]
+    fn tracker_tracks_speaking_state_per_turn() {
+        let mut t = PopupTracker::default();
+        assert!(!t.is_speaking());
+
+        t.ingest(
+            &Event::SpeakingState {
+                id: "a".into(),
+                speaking: true,
+            },
+            &cfg(),
+        );
+        assert!(t.is_speaking());
+
+        // Second concurrent turn starts speaking; flag stays on.
+        t.ingest(
+            &Event::SpeakingState {
+                id: "b".into(),
+                speaking: true,
+            },
+            &cfg(),
+        );
+        assert!(t.is_speaking());
+
+        // Turn 'a' finishes — 'b' still speaking, so flag stays on.
+        t.ingest(
+            &Event::SpeakingState {
+                id: "a".into(),
+                speaking: false,
+            },
+            &cfg(),
+        );
+        assert!(t.is_speaking());
+
+        t.ingest(
+            &Event::SpeakingState {
+                id: "b".into(),
+                speaking: false,
+            },
+            &cfg(),
+        );
+        assert!(!t.is_speaking());
+    }
+
+    #[test]
+    fn tracker_disconnect_clears_speaking_state() {
+        let mut t = PopupTracker::default();
+        t.ingest(
+            &Event::SpeakingState {
+                id: "a".into(),
+                speaking: true,
+            },
+            &cfg(),
+        );
+        assert!(t.is_speaking());
+        t.set_disconnected();
+        assert!(!t.is_speaking());
     }
 
     #[test]

--- a/crates/assistd/src/tray/popup/visibility.rs
+++ b/crates/assistd/src/tray/popup/visibility.rs
@@ -1,21 +1,4 @@
-//! Popup driver: a single tokio task that owns the [`PopupTracker`],
-//! the visibility state machine, and the `watch::Sender` the GUI
-//! thread reads from.
-//!
-//! Inputs:
-//! - daemon events (from the tray's subscribe loop), and a Disconnect
-//!   signal that re-uses the same mpsc for compactness;
-//! - explicit `Show` commands (tray-icon left-click + wake-on events);
-//! - explicit `Dismiss` commands (popup close button) which hide the
-//!   popup *and* fire a one-shot `InterruptTurn` IPC to abort the
-//!   current generation and stop any TTS playback;
-//! - GUI events (first paint after a show);
-//! - a 250 ms timer that drives the auto-hide check.
-//!
-//! The popup is sticky and does not self-dismiss on focus loss, so
-//! workspace switches and clicks into other windows leave it on screen.
-//! Dismissal comes from either the auto-hide timer or an explicit
-//! `Dismiss`.
+//! Popup driver task: visibility state machine plus event ingestion.
 
 use std::time::{Duration, Instant};
 
@@ -28,52 +11,19 @@ use uuid::Uuid;
 
 use super::state::{PopupState, PopupTracker};
 
-/// One input to the driver loop. Bundled into a single enum so the
-/// driver can select! over a single mpsc and a single ticker without
-/// fanning to many receivers. The `Event` variant is boxed because
-/// `assistd_ipc::Event` is ~230 bytes and dominates the enum size
-/// otherwise.
 #[derive(Debug)]
 pub enum DriverInput {
-    /// New IPC event from the daemon's broadcast bus.
     Event(Box<Event>),
-    /// IPC connection down — subscribe loop is in backoff or restart.
     Disconnected,
-    /// Tray-icon left-click or a wake-on event matched. The popup
-    /// should become visible (resetting the auto-hide timer).
     Show,
-    /// User-driven dismissal from the popup's close button. The driver
-    /// hides the popup and fires a fire-and-forget `InterruptTurn`
-    /// IPC, which cancels the in-flight LLM turn and drops any pending
-    /// TTS audio on the daemon side.
     Dismiss,
-    /// GUI thread finished its first paint after a Show. Kept as a
-    /// signal in case the driver ever needs to act on the
-    /// compositor-aware moment; `place_floating` handles the
-    /// map-time race against the compositor internally, so for now
-    /// the driver doesn't need to react.
     Mapped,
-    /// Cooperative shutdown.
     Shutdown,
 }
 
-/// Request sent to the placement worker. The worker holds the
-/// criteria + anchor; the request itself is a unit value because all
-/// the popup ever asks for is "place me now."
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PlaceRequest;
 
-/// Run the driver loop until a [`DriverInput::Shutdown`] arrives or
-/// all senders are dropped. Pushes a new [`PopupState`] onto the
-/// `watch` whenever the visible content changes; sends a single
-/// [`PlaceRequest`] onto `place_tx` when the popup becomes visible.
-/// One placement per wake is sufficient because
-/// [`assistd_wm::WindowManager::place_floating`] waits for and
-/// retries against the matching window-event internally.
-///
-/// `ipc` is used only on `DriverInput::Dismiss` to fire a one-shot
-/// `InterruptTurn` to the daemon. Failures (daemon down, socket
-/// missing) are logged and swallowed; the popup still hides.
 pub async fn run(
     state_tx: watch::Sender<PopupState>,
     mut rx: UnboundedReceiver<DriverInput>,
@@ -109,15 +59,10 @@ pub async fn run(
                         if visible {
                             last_activity = Instant::now();
                         }
-                        // Held-open → idle transition: restart the
-                        // auto-hide countdown from this instant so the
-                        // popup lingers for the full auto_hide_ms after
-                        // the agent finishes, regardless of how long
-                        // the busy stretch was. Same treatment for the
-                        // speaking → silent edge: TTS playback can
-                        // extend well past the turn's `Done`, and we
-                        // want the auto-hide window to start fresh
-                        // when the voice actually stops.
+                        // Restart the auto-hide countdown on each
+                        // held-open → idle edge (busy and speaking)
+                        // so the popup lingers for the full window
+                        // after the agent actually stops working.
                         let is_busy = tracker.is_busy();
                         let is_speaking = tracker.is_speaking();
                         if (was_busy && !is_busy) || (was_speaking && !is_speaking) {
@@ -149,13 +94,6 @@ pub async fn run(
                 if !visible {
                     continue;
                 }
-                // Pin the popup open while a turn is in flight — the
-                // gap between a ToolCall and its ToolResult is silent
-                // on the wire but the agent is still working, so an
-                // auto-hide here would dismiss the popup mid-tool-call.
-                // Same treatment while TTS is playing back: the user is
-                // listening to the response and shouldn't lose the
-                // activity surface mid-sentence.
                 if tracker.is_busy() || tracker.is_speaking() {
                     continue;
                 }
@@ -175,8 +113,6 @@ pub async fn run(
 
 fn push_with_visibility(tx: &watch::Sender<PopupState>, mut snap: PopupState, visible: bool) {
     snap.visible = visible;
-    // send_if_modified avoids waking the GUI thread when nothing the
-    // user can see actually changed.
     tx.send_if_modified(|cur| {
         if *cur != snap {
             *cur = snap;
@@ -187,9 +123,6 @@ fn push_with_visibility(tx: &watch::Sender<PopupState>, mut snap: PopupState, vi
     });
 }
 
-/// Fire-and-forget `InterruptTurn` IPC. Detached so the driver loop
-/// never blocks on a daemon that is slow to respond (or absent
-/// entirely — the popup still hides). Failures land at warn-level.
 fn spawn_interrupt(ipc: IpcClient) {
     tokio::spawn(async move {
         let req = Request::InterruptTurn {
@@ -221,11 +154,6 @@ mod tests {
         }
     }
 
-    /// IPC client pointed at a non-existent socket so tests never make
-    /// network/IPC calls. The driver only uses the client from a
-    /// `Dismiss` arm, which the existing tests don't exercise; failed
-    /// connect attempts on a path that doesn't exist are still cheap
-    /// and the tests aren't asserting on the result anyway.
     fn dummy_ipc() -> IpcClient {
         IpcClient::with_path("/tmp/assistd-popup-tests-nonexistent.sock")
     }
@@ -256,8 +184,6 @@ mod tests {
 
     #[tokio::test]
     async fn body_updates_while_visible_reset_the_auto_hide_timer() {
-        // Sanity check: incoming Events refresh last_activity, so a
-        // 1s auto-hide doesn't fire while events keep arriving.
         let (state_tx, mut state_rx) = watch::channel(PopupState::default());
         let (in_tx, in_rx) = mpsc::unbounded_channel();
         let (place_tx, _place_rx) = mpsc::unbounded_channel();
@@ -286,8 +212,6 @@ mod tests {
 
     #[tokio::test]
     async fn in_flight_turn_pins_popup_open_past_auto_hide() {
-        // While a turn is in flight, the popup must stay visible past
-        // auto_hide_ms — even when no events arrive — until Done.
         let (state_tx, mut state_rx) = watch::channel(PopupState::default());
         let (in_tx, in_rx) = mpsc::unbounded_channel();
         let (place_tx, _place_rx) = mpsc::unbounded_channel();
@@ -304,8 +228,6 @@ mod tests {
             .expect("send");
         let _ = drain_watch(&mut state_rx).await;
 
-        // Quiet stretch comfortably longer than auto_hide_ms (500ms);
-        // the in-flight turn must hold the popup open.
         tokio::time::sleep(Duration::from_millis(1500)).await;
         assert!(
             state_rx.borrow().visible,
@@ -317,8 +239,6 @@ mod tests {
             .expect("send");
         let _ = drain_watch(&mut state_rx).await;
 
-        // After Done, the auto-hide window starts fresh from this
-        // moment; wait it out and confirm the popup closes.
         tokio::time::sleep(Duration::from_millis(900)).await;
         assert!(
             !state_rx.borrow().visible,
@@ -331,9 +251,6 @@ mod tests {
 
     #[tokio::test]
     async fn listening_swaps_in_the_longer_auto_hide_window() {
-        // With listening active, auto-hide uses listen_auto_hide_ms
-        // instead of the shorter default — so the popup outlives the
-        // regular timeout but still dismisses eventually.
         let popup_cfg = TrayPopupConfig {
             auto_hide_ms: 500,
             listen_auto_hide_ms: 2000,
@@ -353,7 +270,6 @@ mod tests {
         in_tx.send(DriverInput::Show).expect("send");
         let _ = drain_watch(&mut state_rx).await;
 
-        // Past the short timeout, well under the listen-extended one.
         tokio::time::sleep(Duration::from_millis(900)).await;
         assert!(
             state_rx.borrow().visible,
@@ -366,10 +282,6 @@ mod tests {
 
     #[tokio::test]
     async fn speaking_pins_popup_past_done_then_auto_hides_after_silence() {
-        // After Done, TTS playback can run for seconds. While
-        // SpeakingState{true} is in flight, the popup must stay open
-        // past auto_hide_ms; once SpeakingState{false} arrives, the
-        // auto-hide countdown starts fresh from that instant.
         let (state_tx, mut state_rx) = watch::channel(PopupState::default());
         let (in_tx, in_rx) = mpsc::unbounded_channel();
         let (place_tx, _place_rx) = mpsc::unbounded_channel();
@@ -378,7 +290,6 @@ mod tests {
         in_tx.send(DriverInput::Show).expect("send");
         let _ = drain_watch(&mut state_rx).await;
 
-        // Turn starts, finishes, but TTS is mid-playback.
         in_tx
             .send(DriverInput::Event(Box::new(Event::LastDelta {
                 id: "a".into(),
@@ -397,14 +308,12 @@ mod tests {
             .expect("send");
         let _ = drain_watch(&mut state_rx).await;
 
-        // Past the short auto-hide; speaking should hold the popup.
         tokio::time::sleep(Duration::from_millis(900)).await;
         assert!(
             state_rx.borrow().visible,
             "popup should stay visible while TTS is playing"
         );
 
-        // Playback ends — auto-hide starts fresh from this moment.
         in_tx
             .send(DriverInput::Event(Box::new(Event::SpeakingState {
                 id: "a".into(),
@@ -424,8 +333,6 @@ mod tests {
 
     #[tokio::test]
     async fn tool_call_event_only_pushes_when_state_changed() {
-        // The driver's send_if_modified means watch only wakes when the
-        // visible snapshot actually differs.
         let (state_tx, mut state_rx) = watch::channel(PopupState::default());
         let (in_tx, in_rx) = mpsc::unbounded_channel();
         let (place_tx, _place_rx) = mpsc::unbounded_channel();

--- a/crates/assistd/src/tray/popup/visibility.rs
+++ b/crates/assistd/src/tray/popup/visibility.rs
@@ -68,6 +68,7 @@ pub async fn run(
     let mut visible = false;
     let mut last_activity = Instant::now();
     let mut was_busy = false;
+    let mut was_speaking = false;
     let auto_hide_default = Duration::from_millis(cfg.auto_hide_ms);
     let auto_hide_listening = Duration::from_millis(cfg.listen_auto_hide_ms);
     let mut ticker = interval(Duration::from_millis(250));
@@ -83,6 +84,7 @@ pub async fn run(
                     DriverInput::Disconnected => {
                         tracker.set_disconnected();
                         was_busy = false;
+                        was_speaking = false;
                         push_with_visibility(&state_tx, tracker.snapshot(&cfg), visible);
                     }
                     DriverInput::Event(ev) => {
@@ -94,12 +96,18 @@ pub async fn run(
                         // auto-hide countdown from this instant so the
                         // popup lingers for the full auto_hide_ms after
                         // the agent finishes, regardless of how long
-                        // the busy stretch was.
+                        // the busy stretch was. Same treatment for the
+                        // speaking → silent edge: TTS playback can
+                        // extend well past the turn's `Done`, and we
+                        // want the auto-hide window to start fresh
+                        // when the voice actually stops.
                         let is_busy = tracker.is_busy();
-                        if was_busy && !is_busy {
+                        let is_speaking = tracker.is_speaking();
+                        if (was_busy && !is_busy) || (was_speaking && !is_speaking) {
                             last_activity = Instant::now();
                         }
                         was_busy = is_busy;
+                        was_speaking = is_speaking;
                         push_with_visibility(&state_tx, snap, visible);
                     }
                     DriverInput::Show => {
@@ -127,7 +135,10 @@ pub async fn run(
                 // gap between a ToolCall and its ToolResult is silent
                 // on the wire but the agent is still working, so an
                 // auto-hide here would dismiss the popup mid-tool-call.
-                if tracker.is_busy() {
+                // Same treatment while TTS is playing back: the user is
+                // listening to the response and shouldn't lose the
+                // activity surface mid-sentence.
+                if tracker.is_busy() || tracker.is_speaking() {
                     continue;
                 }
                 let auto_hide = if tracker.is_listening() {
@@ -317,6 +328,64 @@ mod tests {
         assert!(
             state_rx.borrow().visible,
             "listening should extend the auto-hide window"
+        );
+
+        in_tx.send(DriverInput::Shutdown).expect("send");
+        handle.await.expect("driver join");
+    }
+
+    #[tokio::test]
+    async fn speaking_pins_popup_past_done_then_auto_hides_after_silence() {
+        // After Done, TTS playback can run for seconds. While
+        // SpeakingState{true} is in flight, the popup must stay open
+        // past auto_hide_ms; once SpeakingState{false} arrives, the
+        // auto-hide countdown starts fresh from that instant.
+        let (state_tx, mut state_rx) = watch::channel(PopupState::default());
+        let (in_tx, in_rx) = mpsc::unbounded_channel();
+        let (place_tx, _place_rx) = mpsc::unbounded_channel();
+        let handle = tokio::spawn(run(state_tx, in_rx, place_tx, cfg(500)));
+
+        in_tx.send(DriverInput::Show).expect("send");
+        let _ = drain_watch(&mut state_rx).await;
+
+        // Turn starts, finishes, but TTS is mid-playback.
+        in_tx
+            .send(DriverInput::Event(Box::new(Event::LastDelta {
+                id: "a".into(),
+                text: "hi".into(),
+            })))
+            .expect("send");
+        let _ = drain_watch(&mut state_rx).await;
+        in_tx
+            .send(DriverInput::Event(Box::new(Event::SpeakingState {
+                id: "a".into(),
+                speaking: true,
+            })))
+            .expect("send");
+        in_tx
+            .send(DriverInput::Event(Box::new(Event::Done { id: "a".into() })))
+            .expect("send");
+        let _ = drain_watch(&mut state_rx).await;
+
+        // Past the short auto-hide; speaking should hold the popup.
+        tokio::time::sleep(Duration::from_millis(900)).await;
+        assert!(
+            state_rx.borrow().visible,
+            "popup should stay visible while TTS is playing"
+        );
+
+        // Playback ends — auto-hide starts fresh from this moment.
+        in_tx
+            .send(DriverInput::Event(Box::new(Event::SpeakingState {
+                id: "a".into(),
+                speaking: false,
+            })))
+            .expect("send");
+        let _ = drain_watch(&mut state_rx).await;
+        tokio::time::sleep(Duration::from_millis(900)).await;
+        assert!(
+            !state_rx.borrow().visible,
+            "popup should auto-hide after TTS finishes"
         );
 
         in_tx.send(DriverInput::Shutdown).expect("send");

--- a/crates/assistd/src/tray/popup/visibility.rs
+++ b/crates/assistd/src/tray/popup/visibility.rs
@@ -6,16 +6,25 @@
 //! - daemon events (from the tray's subscribe loop), and a Disconnect
 //!   signal that re-uses the same mpsc for compactness;
 //! - explicit `Show` commands (tray-icon left-click + wake-on events);
-//! - GUI events (focus lost, first paint after a show);
+//! - explicit `Dismiss` commands (popup close button) which hide the
+//!   popup *and* fire a one-shot `InterruptTurn` IPC to abort the
+//!   current generation and stop any TTS playback;
+//! - GUI events (first paint after a show);
 //! - a 250 ms timer that drives the auto-hide check.
+//!
+//! The popup is sticky and does not self-dismiss on focus loss, so
+//! workspace switches and clicks into other windows leave it on screen.
+//! Dismissal comes from either the auto-hide timer or an explicit
+//! `Dismiss`.
 
 use std::time::{Duration, Instant};
 
 use assistd_config::TrayPopupConfig;
-use assistd_ipc::Event;
+use assistd_ipc::{Event, IpcClient, Request};
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use tokio::sync::watch;
 use tokio::time::interval;
+use uuid::Uuid;
 
 use super::state::{PopupState, PopupTracker};
 
@@ -33,8 +42,11 @@ pub enum DriverInput {
     /// Tray-icon left-click or a wake-on event matched. The popup
     /// should become visible (resetting the auto-hide timer).
     Show,
-    /// GUI thread reports focus lost — popup should hide.
-    FocusLost,
+    /// User-driven dismissal from the popup's close button. The driver
+    /// hides the popup and fires a fire-and-forget `InterruptTurn`
+    /// IPC, which cancels the in-flight LLM turn and drops any pending
+    /// TTS audio on the daemon side.
+    Dismiss,
     /// GUI thread finished its first paint after a Show. Kept as a
     /// signal in case the driver ever needs to act on the
     /// compositor-aware moment; `place_floating` handles the
@@ -58,11 +70,16 @@ pub struct PlaceRequest;
 /// One placement per wake is sufficient because
 /// [`assistd_wm::WindowManager::place_floating`] waits for and
 /// retries against the matching window-event internally.
+///
+/// `ipc` is used only on `DriverInput::Dismiss` to fire a one-shot
+/// `InterruptTurn` to the daemon. Failures (daemon down, socket
+/// missing) are logged and swallowed; the popup still hides.
 pub async fn run(
     state_tx: watch::Sender<PopupState>,
     mut rx: UnboundedReceiver<DriverInput>,
     place_tx: UnboundedSender<PlaceRequest>,
     cfg: TrayPopupConfig,
+    ipc: IpcClient,
 ) {
     let mut tracker = PopupTracker::default();
     let mut visible = false;
@@ -118,11 +135,12 @@ pub async fn run(
                             let _ = place_tx.send(PlaceRequest);
                         }
                     }
-                    DriverInput::FocusLost => {
+                    DriverInput::Dismiss => {
                         if visible {
                             visible = false;
                             push_with_visibility(&state_tx, tracker.snapshot(&cfg), visible);
                         }
+                        spawn_interrupt(ipc.clone());
                     }
                     DriverInput::Mapped => {}
                 }
@@ -169,6 +187,27 @@ fn push_with_visibility(tx: &watch::Sender<PopupState>, mut snap: PopupState, vi
     });
 }
 
+/// Fire-and-forget `InterruptTurn` IPC. Detached so the driver loop
+/// never blocks on a daemon that is slow to respond (or absent
+/// entirely — the popup still hides). Failures land at warn-level.
+fn spawn_interrupt(ipc: IpcClient) {
+    tokio::spawn(async move {
+        let req = Request::InterruptTurn {
+            id: Uuid::new_v4().to_string(),
+        };
+        match ipc.one_shot(req).await {
+            Ok(stream) => {
+                if let Err(e) = stream.collect().await {
+                    tracing::warn!(target: "tray", "popup dismiss: interrupt_turn stream: {e}");
+                }
+            }
+            Err(e) => {
+                tracing::warn!(target: "tray", "popup dismiss: interrupt_turn send failed: {e}");
+            }
+        }
+    });
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -182,6 +221,15 @@ mod tests {
         }
     }
 
+    /// IPC client pointed at a non-existent socket so tests never make
+    /// network/IPC calls. The driver only uses the client from a
+    /// `Dismiss` arm, which the existing tests don't exercise; failed
+    /// connect attempts on a path that doesn't exist are still cheap
+    /// and the tests aren't asserting on the result anyway.
+    fn dummy_ipc() -> IpcClient {
+        IpcClient::with_path("/tmp/assistd-popup-tests-nonexistent.sock")
+    }
+
     async fn drain_watch(rx: &mut watch::Receiver<PopupState>) -> PopupState {
         rx.changed().await.expect("watch sender alive");
         rx.borrow_and_update().clone()
@@ -193,7 +241,7 @@ mod tests {
         let (in_tx, in_rx) = mpsc::unbounded_channel();
         let (place_tx, mut place_rx) = mpsc::unbounded_channel();
 
-        let handle = tokio::spawn(run(state_tx, in_rx, place_tx, cfg(60_000)));
+        let handle = tokio::spawn(run(state_tx, in_rx, place_tx, cfg(60_000), dummy_ipc()));
         in_tx.send(DriverInput::Show).expect("send");
         let s = drain_watch(&mut state_rx).await;
         assert!(s.visible);
@@ -207,31 +255,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn focus_lost_hides_the_popup() {
-        let (state_tx, mut state_rx) = watch::channel(PopupState::default());
-        let (in_tx, in_rx) = mpsc::unbounded_channel();
-        let (place_tx, _place_rx) = mpsc::unbounded_channel();
-        let handle = tokio::spawn(run(state_tx, in_rx, place_tx, cfg(60_000)));
-
-        in_tx.send(DriverInput::Show).expect("send");
-        let visible_state = drain_watch(&mut state_rx).await;
-        assert!(visible_state.visible);
-        in_tx.send(DriverInput::FocusLost).expect("send");
-        let hidden_state = drain_watch(&mut state_rx).await;
-        assert!(!hidden_state.visible);
-
-        in_tx.send(DriverInput::Shutdown).expect("send");
-        handle.await.expect("driver join");
-    }
-
-    #[tokio::test]
     async fn body_updates_while_visible_reset_the_auto_hide_timer() {
         // Sanity check: incoming Events refresh last_activity, so a
         // 1s auto-hide doesn't fire while events keep arriving.
         let (state_tx, mut state_rx) = watch::channel(PopupState::default());
         let (in_tx, in_rx) = mpsc::unbounded_channel();
         let (place_tx, _place_rx) = mpsc::unbounded_channel();
-        let handle = tokio::spawn(run(state_tx, in_rx, place_tx, cfg(1_000)));
+        let handle = tokio::spawn(run(state_tx, in_rx, place_tx, cfg(1_000), dummy_ipc()));
 
         in_tx.send(DriverInput::Show).expect("send");
         let _ = drain_watch(&mut state_rx).await;
@@ -261,7 +291,7 @@ mod tests {
         let (state_tx, mut state_rx) = watch::channel(PopupState::default());
         let (in_tx, in_rx) = mpsc::unbounded_channel();
         let (place_tx, _place_rx) = mpsc::unbounded_channel();
-        let handle = tokio::spawn(run(state_tx, in_rx, place_tx, cfg(500)));
+        let handle = tokio::spawn(run(state_tx, in_rx, place_tx, cfg(500), dummy_ipc()));
 
         in_tx.send(DriverInput::Show).expect("send");
         let _ = drain_watch(&mut state_rx).await;
@@ -312,7 +342,7 @@ mod tests {
         let (state_tx, mut state_rx) = watch::channel(PopupState::default());
         let (in_tx, in_rx) = mpsc::unbounded_channel();
         let (place_tx, _place_rx) = mpsc::unbounded_channel();
-        let handle = tokio::spawn(run(state_tx, in_rx, place_tx, popup_cfg));
+        let handle = tokio::spawn(run(state_tx, in_rx, place_tx, popup_cfg, dummy_ipc()));
 
         in_tx
             .send(DriverInput::Event(Box::new(Event::ListenState {
@@ -343,7 +373,7 @@ mod tests {
         let (state_tx, mut state_rx) = watch::channel(PopupState::default());
         let (in_tx, in_rx) = mpsc::unbounded_channel();
         let (place_tx, _place_rx) = mpsc::unbounded_channel();
-        let handle = tokio::spawn(run(state_tx, in_rx, place_tx, cfg(500)));
+        let handle = tokio::spawn(run(state_tx, in_rx, place_tx, cfg(500), dummy_ipc()));
 
         in_tx.send(DriverInput::Show).expect("send");
         let _ = drain_watch(&mut state_rx).await;
@@ -399,7 +429,7 @@ mod tests {
         let (state_tx, mut state_rx) = watch::channel(PopupState::default());
         let (in_tx, in_rx) = mpsc::unbounded_channel();
         let (place_tx, _place_rx) = mpsc::unbounded_channel();
-        let handle = tokio::spawn(run(state_tx, in_rx, place_tx, cfg(60_000)));
+        let handle = tokio::spawn(run(state_tx, in_rx, place_tx, cfg(60_000), dummy_ipc()));
 
         in_tx
             .send(DriverInput::Event(Box::new(Event::ToolCall {

--- a/crates/assistd/src/tray/popup/window.rs
+++ b/crates/assistd/src/tray/popup/window.rs
@@ -3,19 +3,18 @@
 //! Renders two labels — body and footer — from the latest
 //! [`PopupState`] snapshot held in a `watch::Receiver`. The GUI
 //! thread owns the entire eframe event loop; it sends focus-lost and
-//! first-paint events back to the tokio-side driver via a `std`
-//! mpsc, and observes the `visible` flag on the watch to toggle the
-//! viewport between shown and hidden.
+//! first-paint events back to the tokio-side driver over the driver's
+//! `UnboundedSender`, and observes the `visible` flag on the watch to
+//! toggle the viewport between shown and hidden.
 //!
 //! A small tokio task ([`wake_egui_on_state_change`]) runs on the
 //! workspace runtime and calls `ctx.request_repaint()` whenever the
 //! watch updates, so content changes don't have to wait for a stray
 //! OS input event to wake the egui loop.
 
-use std::sync::mpsc::Sender;
-
 use eframe::egui::{self, Color32, FontFamily, FontId, RichText, ViewportBuilder, ViewportCommand};
 use tokio::runtime::Handle;
+use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::watch;
 
 use super::state::{PopupActivity, PopupState};
@@ -31,7 +30,7 @@ use super::visibility::DriverInput;
 /// runtime from inside the eframe creator closure.
 pub fn run(
     state_rx: watch::Receiver<PopupState>,
-    event_tx: Sender<DriverInput>,
+    event_tx: UnboundedSender<DriverInput>,
     app_id: &str,
     width: u32,
     height: u32,
@@ -115,7 +114,7 @@ async fn wake_egui_on_state_change(mut rx: watch::Receiver<PopupState>, ctx: egu
 /// renders the three labels.
 struct PopupApp {
     state_rx: watch::Receiver<PopupState>,
-    event_tx: Sender<DriverInput>,
+    event_tx: UnboundedSender<DriverInput>,
     last_visible: bool,
     /// True once the popup has organically gained input focus (i.e.
     /// the user clicked it). Until that happens, focus-lost events
@@ -138,7 +137,7 @@ struct PopupApp {
 }
 
 impl PopupApp {
-    fn new(state_rx: watch::Receiver<PopupState>, event_tx: Sender<DriverInput>) -> Self {
+    fn new(state_rx: watch::Receiver<PopupState>, event_tx: UnboundedSender<DriverInput>) -> Self {
         Self {
             state_rx,
             event_tx,

--- a/crates/assistd/src/tray/popup/window.rs
+++ b/crates/assistd/src/tray/popup/window.rs
@@ -1,22 +1,4 @@
 //! eframe-backed window for the tray popup.
-//!
-//! Renders two labels — body and footer — from the latest
-//! [`PopupState`] snapshot held in a `watch::Receiver`. The GUI
-//! thread owns the entire eframe event loop; it sends the first-paint
-//! Mapped event back to the tokio-side driver over the driver's
-//! `UnboundedSender`, and observes the `visible` flag on the watch to
-//! toggle the viewport between shown and hidden.
-//!
-//! The popup is intentionally a notification surface: it does not
-//! dismiss itself when input focus moves to another window, and the
-//! placement command (see `assistd_wm::criteria`) makes the window
-//! sticky so it persists across workspace switches. Dismissal is
-//! driven entirely by the driver's auto-hide timer.
-//!
-//! A small tokio task ([`wake_egui_on_state_change`]) runs on the
-//! workspace runtime and calls `ctx.request_repaint()` whenever the
-//! watch updates, so content changes don't have to wait for a stray
-//! OS input event to wake the egui loop.
 
 use eframe::egui::{self, Color32, FontFamily, FontId, RichText, ViewportBuilder, ViewportCommand};
 use tokio::runtime::Handle;
@@ -26,14 +8,6 @@ use tokio::sync::watch;
 use super::state::{PopupActivity, PopupState};
 use super::visibility::DriverInput;
 
-/// Run the eframe loop in the calling thread. Blocks until the
-/// viewport is closed (we close it ourselves on a `Shutdown` command
-/// from the driver via the `state.visible` channel; see
-/// [`PopupApp::logic`]).
-///
-/// `runtime` is captured before the GUI thread starts so the
-/// state-watch waker task can be spawned onto the workspace tokio
-/// runtime from inside the eframe creator closure.
 pub fn run(
     state_rx: watch::Receiver<PopupState>,
     event_tx: UnboundedSender<DriverInput>,
@@ -45,35 +19,21 @@ pub fn run(
 ) -> Result<(), eframe::Error> {
     let mut viewport = ViewportBuilder::default()
         .with_app_id(app_id)
-        // Explicitly set the X11 title — egui-winit 0.34 defaults it
-        // to "egui window" and only propagates with_app_id to the
-        // Wayland app_id, never to X11 WM_CLASS. Setting the title
-        // gives the i3 backend a deterministic `[title="..."]`
-        // criteria to match against.
+        // egui-winit only propagates app_id to Wayland; set the title
+        // explicitly so X11 WM_CLASS gives the i3 backend a stable
+        // `[title="..."]` to match against.
         .with_title(app_id)
         .with_decorations(false)
         .with_resizable(false)
         .with_inner_size([width as f32, height as f32])
         .with_visible(false);
     if let Some((x, y)) = initial_position {
-        // Pre-position the window so its first map lands at the
-        // configured corner. winit propagates this to X11's window
-        // attributes; i3 honours it for floating windows (which the
-        // for_window rule makes the popup at map time). Without this,
-        // i3's default-placement runs first and the popup briefly
-        // flashes in the centre before place_floating shoves it into
-        // place.
         viewport = viewport.with_position([x as f32, y as f32]);
     }
     let options = eframe::NativeOptions {
         viewport,
-        // The popup runs on a dedicated OS thread because the tray's
-        // tokio runtime owns the main thread (it has SIGINT/SIGTERM
-        // handlers and the ksni service). winit's default main-thread
-        // assertion is a portability hint, not a hard requirement — on
-        // Linux X11 and Wayland a worker-thread event loop works once
-        // we opt in. The error message that fires without these calls
-        // points users at exactly these methods.
+        // The tray runtime owns the main thread, so run the popup's
+        // winit loop on a worker thread instead.
         event_loop_builder: Some(Box::new(|builder| {
             use winit::platform::wayland::EventLoopBuilderExtWayland;
             use winit::platform::x11::EventLoopBuilderExtX11;
@@ -88,51 +48,28 @@ pub fn run(
         &app_id_owned,
         options,
         Box::new(move |cc| {
-            // Wake egui on every watch change. Without this the GUI
-            // thread sleeps between OS events, so a Show command or a
-            // new LastDelta wouldn't be observed until the user
-            // happened to move the mouse over the window.
             runtime.spawn(wake_egui_on_state_change(waker_rx, cc.egui_ctx.clone()));
             Ok(Box::new(PopupApp::new(state_rx, event_tx)))
         }),
     )
 }
 
-/// Forward `watch` change notifications to egui as repaint requests.
-/// When the watch sender is dropped (popup is shutting down) the loop
-/// exits and the final `ViewportCommand::Close` tells eframe's event
-/// loop to return — without this signal `eframe::run_native` would
-/// block the GUI thread forever and `gui_thread.join()` would hang on
-/// shutdown.
+/// Forward watch updates to egui as repaint requests; when the sender
+/// drops, close the viewport so `eframe::run_native` can return.
 async fn wake_egui_on_state_change(mut rx: watch::Receiver<PopupState>, ctx: egui::Context) {
     while rx.changed().await.is_ok() {
         ctx.request_repaint();
     }
     ctx.send_viewport_cmd(ViewportCommand::Close);
-    // Egui only processes viewport commands on the next frame, so
-    // poke the event loop once more so the close lands without
-    // waiting for unrelated input.
     ctx.request_repaint();
 }
 
-/// eframe `App` for the popup. Visibility transitions and the
-/// first-paint Mapped signal live in `logic`; `ui` only renders the
-/// three labels. The popup deliberately ignores focus changes — see
-/// the module-level comment for why.
 struct PopupApp {
     state_rx: watch::Receiver<PopupState>,
     event_tx: UnboundedSender<DriverInput>,
     last_visible: bool,
     awaiting_first_paint: bool,
-    /// True until `logic` runs for the first time. Used to force a
-    /// `Visible(false)` viewport command on startup so the popup never
-    /// flashes on screen — winit's `with_visible(false)` doesn't
-    /// reliably suppress the initial map on X11, and once mapped the
-    /// only thing that hides the window is an explicit
-    /// `ViewportCommand::Visible(false)`.
     first_frame: bool,
-    /// Cache of the most recently observed `PopupState`. `logic` runs
-    /// before `ui` and refreshes it; `ui` reads it.
     current: PopupState,
 }
 
@@ -227,11 +164,8 @@ impl eframe::App for PopupApp {
     }
 }
 
-/// Render the top-right close button. Returns the egui [`Response`] so
-/// the caller can detect clicks. Uses U+00D7 MULTIPLICATION SIGN (the
-/// Latin-1 "×") rather than U+2715 / U+2717: the bundled default eframe
-/// font (Ubuntu-Light) ships Latin-1 supplement but not Dingbats, so
-/// the dingbat "✕" rendered as the tofu fallback box.
+// U+00D7 MULTIPLICATION SIGN, not U+2715/2717: the default eframe font
+// covers Latin-1 supplement but not Dingbats.
 fn close_button(ui: &mut egui::Ui) -> egui::Response {
     let btn = egui::Button::new(
         RichText::new("\u{00D7}")
@@ -242,13 +176,8 @@ fn close_button(ui: &mut egui::Ui) -> egui::Response {
     ui.add(btn).on_hover_text("Close (interrupts the agent)")
 }
 
-/// Map [`PopupActivity`] to the one-line status header rendered above
-/// the body. Returns `None` when the popup should be header-less (the
-/// idle case — the body already conveys "last completed turn").
-///
-/// The leading marker is U+00B7 MIDDLE DOT (Latin-1 supplement) rather
-/// than U+25CF BLACK CIRCLE: the default eframe font doesn't cover
-/// Geometric Shapes, so the original "●" rendered as a tofu box.
+// Leading marker is U+00B7 MIDDLE DOT, not U+25CF BLACK CIRCLE: the
+// default eframe font doesn't cover Geometric Shapes.
 fn activity_label(activity: &PopupActivity) -> Option<(String, Color32)> {
     match activity {
         PopupActivity::Idle => None,

--- a/crates/assistd/src/tray/popup/window.rs
+++ b/crates/assistd/src/tray/popup/window.rs
@@ -2,10 +2,16 @@
 //!
 //! Renders two labels — body and footer — from the latest
 //! [`PopupState`] snapshot held in a `watch::Receiver`. The GUI
-//! thread owns the entire eframe event loop; it sends focus-lost and
-//! first-paint events back to the tokio-side driver over the driver's
+//! thread owns the entire eframe event loop; it sends the first-paint
+//! Mapped event back to the tokio-side driver over the driver's
 //! `UnboundedSender`, and observes the `visible` flag on the watch to
 //! toggle the viewport between shown and hidden.
+//!
+//! The popup is intentionally a notification surface: it does not
+//! dismiss itself when input focus moves to another window, and the
+//! placement command (see `assistd_wm::criteria`) makes the window
+//! sticky so it persists across workspace switches. Dismissal is
+//! driven entirely by the driver's auto-hide timer.
 //!
 //! A small tokio task ([`wake_egui_on_state_change`]) runs on the
 //! workspace runtime and calls `ctx.request_repaint()` whenever the
@@ -109,20 +115,14 @@ async fn wake_egui_on_state_change(mut rx: watch::Receiver<PopupState>, ctx: egu
     ctx.request_repaint();
 }
 
-/// eframe `App` for the popup. Visibility transitions, focus tracking,
-/// and the first-paint Mapped signal live in `logic`; `ui` only
-/// renders the three labels.
+/// eframe `App` for the popup. Visibility transitions and the
+/// first-paint Mapped signal live in `logic`; `ui` only renders the
+/// three labels. The popup deliberately ignores focus changes — see
+/// the module-level comment for why.
 struct PopupApp {
     state_rx: watch::Receiver<PopupState>,
     event_tx: UnboundedSender<DriverInput>,
     last_visible: bool,
-    /// True once the popup has organically gained input focus (i.e.
-    /// the user clicked it). Until that happens, focus-lost events
-    /// don't dismiss the popup — a notification-style window that
-    /// never grabbed focus has nothing to lose, and treating the
-    /// brief initial focus dance as dismissal would hide the popup
-    /// the moment the user resumes typing in their terminal.
-    has_been_focused: bool,
     awaiting_first_paint: bool,
     /// True until `logic` runs for the first time. Used to force a
     /// `Visible(false)` viewport command on startup so the popup never
@@ -142,7 +142,6 @@ impl PopupApp {
             state_rx,
             event_tx,
             last_visible: false,
-            has_been_focused: false,
             awaiting_first_paint: false,
             first_frame: true,
             current: PopupState::default(),
@@ -159,30 +158,12 @@ impl eframe::App for PopupApp {
             ctx.send_viewport_cmd(ViewportCommand::Visible(self.current.visible));
             if self.current.visible && visibility_changed {
                 self.awaiting_first_paint = true;
-                // Each new show starts the focus tracker over; the
-                // popup hasn't organically gained focus yet.
-                self.has_been_focused = false;
             }
             self.last_visible = self.current.visible;
             self.first_frame = false;
         }
 
         if self.current.visible {
-            // Default to false on unknown so we don't pretend to be
-            // focused before we've actually observed it. The popup
-            // never auto-grabs focus (no ViewportCommand::Focus on
-            // show) so users can keep typing in their terminal while
-            // it surfaces.
-            let focused = ctx.input(|i| i.viewport().focused.unwrap_or(false));
-            if focused {
-                self.has_been_focused = true;
-            } else if self.has_been_focused {
-                // We had focus, now we don't — treat as user-driven
-                // dismissal.
-                let _ = self.event_tx.send(DriverInput::FocusLost);
-                self.has_been_focused = false;
-            }
-
             if self.awaiting_first_paint {
                 self.awaiting_first_paint = false;
                 let _ = self.event_tx.send(DriverInput::Mapped);
@@ -197,14 +178,22 @@ impl eframe::App for PopupApp {
             return;
         }
         ui.vertical(|ui| {
-            if let Some((label, color)) = activity_label(&self.current.activity) {
-                ui.label(
-                    RichText::new(label)
-                        .color(color)
-                        .font(FontId::new(11.0, FontFamily::Proportional)),
-                );
-                ui.add_space(2.0);
-            }
+            ui.horizontal(|ui| {
+                let header = activity_label(&self.current.activity);
+                if let Some((label, color)) = header.as_ref() {
+                    ui.label(
+                        RichText::new(label)
+                            .color(*color)
+                            .font(FontId::new(11.0, FontFamily::Proportional)),
+                    );
+                }
+                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                    if close_button(ui).clicked() {
+                        let _ = self.event_tx.send(DriverInput::Dismiss);
+                    }
+                });
+            });
+            ui.add_space(2.0);
             if self.current.body.is_empty() {
                 ui.label(
                     RichText::new("(no reply yet)")
@@ -238,17 +227,38 @@ impl eframe::App for PopupApp {
     }
 }
 
+/// Render the top-right close button. Returns the egui [`Response`] so
+/// the caller can detect clicks. Uses U+00D7 MULTIPLICATION SIGN (the
+/// Latin-1 "×") rather than U+2715 / U+2717: the bundled default eframe
+/// font (Ubuntu-Light) ships Latin-1 supplement but not Dingbats, so
+/// the dingbat "✕" rendered as the tofu fallback box.
+fn close_button(ui: &mut egui::Ui) -> egui::Response {
+    let btn = egui::Button::new(
+        RichText::new("\u{00D7}")
+            .color(Color32::GRAY)
+            .font(FontId::new(14.0, FontFamily::Proportional)),
+    )
+    .frame(false);
+    ui.add(btn).on_hover_text("Close (interrupts the agent)")
+}
+
 /// Map [`PopupActivity`] to the one-line status header rendered above
 /// the body. Returns `None` when the popup should be header-less (the
 /// idle case — the body already conveys "last completed turn").
+///
+/// The leading marker is U+00B7 MIDDLE DOT (Latin-1 supplement) rather
+/// than U+25CF BLACK CIRCLE: the default eframe font doesn't cover
+/// Geometric Shapes, so the original "●" rendered as a tofu box.
 fn activity_label(activity: &PopupActivity) -> Option<(String, Color32)> {
     match activity {
         PopupActivity::Idle => None,
-        PopupActivity::Streaming => Some(("● replying…".into(), Color32::LIGHT_GREEN)),
-        PopupActivity::Thinking => Some(("● thinking…".into(), Color32::YELLOW)),
+        PopupActivity::Streaming => Some(("\u{00B7} replying…".into(), Color32::LIGHT_GREEN)),
+        PopupActivity::Thinking => Some(("\u{00B7} thinking…".into(), Color32::YELLOW)),
         PopupActivity::RunningTool { name } => {
-            Some((format!("● running {name}…"), Color32::LIGHT_BLUE))
+            Some((format!("\u{00B7} running {name}…"), Color32::LIGHT_BLUE))
         }
-        PopupActivity::Listening => Some(("● listening…".into(), Color32::from_rgb(255, 140, 0))),
+        PopupActivity::Listening => {
+            Some(("\u{00B7} listening…".into(), Color32::from_rgb(255, 140, 0)))
+        }
     }
 }

--- a/crates/assistd/src/tray/popup/wm_bridge.rs
+++ b/crates/assistd/src/tray/popup/wm_bridge.rs
@@ -1,9 +1,4 @@
 //! Window-manager glue for the tray popup.
-//!
-//! Starts the compositor backend via [`crate::wm_backend`] and drives a
-//! small placement worker that drains [`PlaceRequest`]s and issues
-//! [`WindowManager::place_floating`] calls. All errors are logged at
-//! warn; placement is best-effort.
 
 use std::sync::Arc;
 
@@ -16,26 +11,16 @@ use crate::wm_backend::{WmBackend, start_backend};
 
 use super::visibility::PlaceRequest;
 
-/// Pair returned by [`build_wm_backend`]: the trait object the
-/// placement worker calls, plus the supervisor handle the popup module
-/// drives on shutdown.
 pub struct WmBackendBundle {
     pub manager: Arc<dyn WindowManager>,
     pub handle: Option<WmHandle>,
 }
 
-/// Start the compositor backend for the tray popup, adapting
-/// [`crate::wm_backend::start_backend`]'s result into a
-/// [`WmBackendBundle`].
 pub async fn build_wm_backend(cfg: &Config, shutdown_rx: watch::Receiver<bool>) -> WmBackendBundle {
     let WmBackend { manager, handle } = start_backend(cfg, shutdown_rx).await;
     WmBackendBundle { manager, handle }
 }
 
-/// Drain [`PlaceRequest`]s and call `place_floating` for each. The
-/// criteria + anchor are fixed at spawn time (config doesn't change
-/// while the tray is running); the only thing each call carries is
-/// "please place me now."
 pub async fn place_worker(
     mut rx: UnboundedReceiver<PlaceRequest>,
     backend: Arc<dyn WindowManager>,
@@ -52,8 +37,6 @@ pub async fn place_worker(
     }
 }
 
-/// Build a [`PlacementAnchor`] from the user's [`TrayPopupConfig`]
-/// using the configured corner + offsets + width/height.
 pub fn anchor_from_config(cfg: &assistd_config::TrayPopupConfig) -> PlacementAnchor {
     PlacementAnchor {
         corner: map_anchor(cfg.anchor),
@@ -64,17 +47,10 @@ pub fn anchor_from_config(cfg: &assistd_config::TrayPopupConfig) -> PlacementAnc
     }
 }
 
-/// Construct a [`PlacementCriteria::AppId`] targeting the constant
-/// app_id the popup window sets. Centralised so the GUI and placement
-/// references stay in sync.
 pub fn popup_criteria() -> PlacementCriteria {
     PlacementCriteria::AppId(assistd_config::defaults::DEFAULT_TRAY_POPUP_APP_ID.to_string())
 }
 
-/// Map the i3/sway anchor enum that `assistd-wm` expects from the
-/// equivalent shape in `assistd-config`. Helper indirected through
-/// [`AnchorCorner`] so neither crate needs to depend on the other for
-/// this enum.
 pub fn map_anchor(corner: assistd_config::PopupAnchor) -> AnchorCorner {
     match corner {
         assistd_config::PopupAnchor::TopLeft => AnchorCorner::TopLeft,

--- a/crates/assistd/src/tray/popup/wm_bridge.rs
+++ b/crates/assistd/src/tray/popup/wm_bridge.rs
@@ -1,21 +1,18 @@
 //! Window-manager glue for the tray popup.
 //!
-//! Builds the appropriate backend at startup (using the same
-//! auto-detect / explicit-config logic the daemon uses, copied here
-//! because `wm_init.rs` is gated behind the `daemon` feature) and
-//! drives a small placement worker that drains [`PlaceRequest`]s and
-//! issues [`WindowManager::place_floating`] calls. All errors are
-//! logged at warn; placement is best-effort.
+//! Starts the compositor backend via [`crate::wm_backend`] and drives a
+//! small placement worker that drains [`PlaceRequest`]s and issues
+//! [`WindowManager::place_floating`] calls. All errors are logged at
+//! warn; placement is best-effort.
 
 use std::sync::Arc;
 
-use assistd_config::{CompositorType, Config, compositor::detect_from_env};
-use assistd_wm::{
-    AnchorCorner, I3Backend, NoWindowManager, PlacementAnchor, PlacementCriteria, SwayBackend,
-    WindowManager, WmHandle,
-};
+use assistd_config::Config;
+use assistd_wm::{AnchorCorner, PlacementAnchor, PlacementCriteria, WindowManager, WmHandle};
 use tokio::sync::mpsc::UnboundedReceiver;
 use tokio::sync::watch;
+
+use crate::wm_backend::{WmBackend, start_backend};
 
 use super::visibility::PlaceRequest;
 
@@ -27,77 +24,12 @@ pub struct WmBackendBundle {
     pub handle: Option<WmHandle>,
 }
 
-/// Detect (or read from config) the compositor and start the matching
-/// backend. Mirrors `crates/assistd/src/wm_init.rs` so the tray can
-/// construct a backend without depending on the `daemon` feature.
+/// Start the compositor backend for the tray popup, adapting
+/// [`crate::wm_backend::start_backend`]'s result into a
+/// [`WmBackendBundle`].
 pub async fn build_wm_backend(cfg: &Config, shutdown_rx: watch::Receiver<bool>) -> WmBackendBundle {
-    let resolved = match cfg.compositor.compositor_type {
-        CompositorType::Auto => match detect_from_env(
-            std::env::var_os("SWAYSOCK").is_some(),
-            std::env::var_os("I3SOCK").is_some(),
-            std::env::var_os("HYPRLAND_INSTANCE_SIGNATURE").is_some(),
-            std::env::var("XDG_CURRENT_DESKTOP").ok().as_deref(),
-        ) {
-            Some(c) => {
-                tracing::info!(target: "tray", "popup: auto-detected compositor = {:?}", c);
-                c
-            }
-            None => {
-                tracing::info!(
-                    target: "tray",
-                    "popup: no supported compositor detected; placement disabled"
-                );
-                CompositorType::Auto
-            }
-        },
-        explicit => explicit,
-    };
-
-    match resolved {
-        CompositorType::I3 => match I3Backend::start(shutdown_rx).await {
-            Ok(handle) => {
-                tracing::info!(target: "tray", "popup: i3 backend connected");
-                WmBackendBundle {
-                    manager: handle.backend.clone(),
-                    handle: Some(WmHandle::I3(handle)),
-                }
-            }
-            Err(e) => {
-                tracing::warn!(target: "tray", "popup: i3 backend unavailable ({e:#}); placement disabled");
-                WmBackendBundle {
-                    manager: Arc::new(NoWindowManager),
-                    handle: None,
-                }
-            }
-        },
-        CompositorType::Sway => match SwayBackend::start(shutdown_rx).await {
-            Ok(handle) => {
-                tracing::info!(target: "tray", "popup: sway backend connected");
-                WmBackendBundle {
-                    manager: handle.backend.clone(),
-                    handle: Some(WmHandle::Sway(handle)),
-                }
-            }
-            Err(e) => {
-                tracing::warn!(target: "tray", "popup: sway backend unavailable ({e:#}); placement disabled");
-                WmBackendBundle {
-                    manager: Arc::new(NoWindowManager),
-                    handle: None,
-                }
-            }
-        },
-        CompositorType::Hyprland => {
-            tracing::info!(target: "tray", "popup: hyprland backend not yet implemented; placement disabled");
-            WmBackendBundle {
-                manager: Arc::new(NoWindowManager),
-                handle: None,
-            }
-        }
-        CompositorType::Auto => WmBackendBundle {
-            manager: Arc::new(NoWindowManager),
-            handle: None,
-        },
-    }
+    let WmBackend { manager, handle } = start_backend(cfg, shutdown_rx).await;
+    WmBackendBundle { manager, handle }
 }
 
 /// Drain [`PlaceRequest`]s and call `place_floating` for each. The

--- a/crates/assistd/src/tray/subscribe.rs
+++ b/crates/assistd/src/tray/subscribe.rs
@@ -104,6 +104,7 @@ fn subscribe_filter() -> SubscribeFilter {
             EventKind::Error,
             EventKind::Presence,
             EventKind::ListenState,
+            EventKind::SpeakingState,
         ],
     }
 }
@@ -223,9 +224,12 @@ mod tests {
             assert!(f.kinds.contains(&k), "filter missing {k:?}");
         }
         // Popup-only needs: server-coalesced reply text + tool
-        // results. No-ops on TrayTracker; the popup tracker uses them.
+        // results + TTS playback boundaries. No-ops on TrayTracker; the
+        // popup tracker uses them to pin the window open while audio
+        // plays.
         assert!(f.kinds.contains(&EventKind::LastDelta));
         assert!(f.kinds.contains(&EventKind::ToolResult));
+        assert!(f.kinds.contains(&EventKind::SpeakingState));
     }
 
     #[test]

--- a/crates/assistd/src/tray/subscribe.rs
+++ b/crates/assistd/src/tray/subscribe.rs
@@ -1,14 +1,4 @@
 //! Long-lived passive subscription to the daemon's broadcast bus.
-//!
-//! Connects, seeds the current presence and listening state, then
-//! pumps events into the [`TrayItem`] through `Handle::update` for as
-//! long as the daemon is reachable. On any disconnect — clean EOF or
-//! I/O error — flips the tray to `Disconnected` and retries with
-//! exponential backoff (1, 2, 4, … s, capped at 60 s).
-//!
-//! When the popup feature is on, a [`PopupSink`](super::popup::PopupSink)
-//! also forwarded every event (plus `Disconnected` transitions) so the
-//! popup driver can update its content and apply its wake-on rules.
 
 use std::time::Duration;
 
@@ -23,16 +13,11 @@ use super::menu::TrayItem;
 #[cfg(feature = "tray-popup")]
 use super::popup::PopupSink;
 
-/// Optional popup hook handed to the subscribe loop. Cloned by the
-/// caller into [`run`]; `None` in builds without the popup feature
-/// (or when the popup is disabled in config).
 #[cfg(feature = "tray-popup")]
 pub type OptionalPopup = Option<PopupSink>;
 #[cfg(not(feature = "tray-popup"))]
 pub type OptionalPopup = Option<()>;
 
-/// Run the reconnect loop forever. Returns only if the ksni handle has
-/// shut down (signalling app exit).
 pub async fn run(handle: Handle<TrayItem>, ipc: IpcClient, popup: OptionalPopup) {
     let mut attempt: u32 = 0;
     loop {
@@ -61,11 +46,8 @@ pub async fn run(handle: Handle<TrayItem>, ipc: IpcClient, popup: OptionalPopup)
     }
 }
 
-/// Why a single subscribe attempt returned.
 enum ExitReason {
-    /// ksni told us the service is gone — quit the loop.
     ServiceShutdown,
-    /// The daemon closed cleanly; reconnect after the usual backoff.
     DaemonClosed,
 }
 
@@ -89,9 +71,6 @@ async fn try_once(
     pump_events(handle, stream, popup).await
 }
 
-/// Build the filter requested from the daemon. Extracted into a
-/// helper so a unit test can verify both tray-only and popup-relevant
-/// kinds are present.
 fn subscribe_filter() -> SubscribeFilter {
     SubscribeFilter {
         kinds: vec![
@@ -137,10 +116,6 @@ type PopupSinkRef = PopupSink;
 #[cfg(not(feature = "tray-popup"))]
 type PopupSinkRef = ();
 
-/// Subscribe is passive — it doesn't replay the daemon's current
-/// presence or listening state. Run a pair of one-shot probes against
-/// fresh connections so the tray icon reflects reality immediately
-/// after a reconnect.
 async fn seed_initial_state(
     handle: &Handle<TrayItem>,
     ipc: &IpcClient,
@@ -196,9 +171,6 @@ where
     handle.update(f).await
 }
 
-/// Exponential backoff capped at 60 s. Mirrors the shape used in
-/// `assistd-llm`'s llama-server supervisor without taking a dependency
-/// on it — the workspace's three-use rule says inline.
 fn backoff_delay(attempt: u32) -> Duration {
     const CAP_SECS: u64 = 60;
     let secs = 1u64.checked_shl(attempt).unwrap_or(CAP_SECS).min(CAP_SECS);
@@ -212,7 +184,6 @@ mod tests {
     #[test]
     fn subscribe_filter_lists_tray_and_popup_event_kinds() {
         let f = subscribe_filter();
-        // Tray-icon needs (presence priority machine).
         for k in [
             EventKind::Delta,
             EventKind::ToolCall,
@@ -223,10 +194,6 @@ mod tests {
         ] {
             assert!(f.kinds.contains(&k), "filter missing {k:?}");
         }
-        // Popup-only needs: server-coalesced reply text + tool
-        // results + TTS playback boundaries. No-ops on TrayTracker; the
-        // popup tracker uses them to pin the window open while audio
-        // plays.
         assert!(f.kinds.contains(&EventKind::LastDelta));
         assert!(f.kinds.contains(&EventKind::ToolResult));
         assert!(f.kinds.contains(&EventKind::SpeakingState));

--- a/crates/assistd/src/wm_backend.rs
+++ b/crates/assistd/src/wm_backend.rs
@@ -1,9 +1,4 @@
-//! Shared window-manager backend construction.
-//!
-//! The daemon ([`crate::wm_init`]) and the tray popup
-//! ([`crate::tray::popup`]) both resolve the configured compositor and
-//! start the matching `assistd-wm` backend. The logic lives here so the
-//! two feature-gated call sites can't drift.
+//! Shared window-manager backend construction for daemon and tray popup.
 
 use std::sync::Arc;
 
@@ -11,17 +6,12 @@ use assistd_config::{CompositorType, Config, compositor::detect_from_env};
 use assistd_wm::{I3Backend, NoWindowManager, SwayBackend, WindowManager, WmHandle};
 use tokio::sync::watch;
 
-/// A started window-manager backend: the trait object callers issue
-/// operations through, plus the supervisor handle used to shut it down.
-/// `handle` is `None` when no compositor backend connected, in which
-/// case `manager` is a [`NoWindowManager`] that rejects every operation.
 pub struct WmBackend {
     pub manager: Arc<dyn WindowManager>,
     pub handle: Option<WmHandle>,
 }
 
 impl WmBackend {
-    /// A disconnected backend: every window operation fails fast.
     fn disconnected() -> Self {
         Self {
             manager: Arc::new(NoWindowManager),
@@ -30,12 +20,8 @@ impl WmBackend {
     }
 }
 
-/// Resolve the configured compositor (explicit or auto-detected) and
-/// start the matching backend.
-///
-/// Falls back to a disconnected [`WmBackend`] when no supported
-/// compositor is found or the backend fails to connect, so callers can
-/// degrade gracefully instead of aborting startup.
+/// Resolve the configured compositor and start its backend, falling
+/// back to a disconnected [`WmBackend`] when none is available.
 pub async fn start_backend(config: &Config, shutdown_rx: watch::Receiver<bool>) -> WmBackend {
     let resolved = match config.compositor.compositor_type {
         CompositorType::Auto => match detect_from_env(

--- a/crates/assistd/src/wm_backend.rs
+++ b/crates/assistd/src/wm_backend.rs
@@ -1,0 +1,106 @@
+//! Shared window-manager backend construction.
+//!
+//! The daemon ([`crate::wm_init`]) and the tray popup
+//! ([`crate::tray::popup`]) both resolve the configured compositor and
+//! start the matching `assistd-wm` backend. The logic lives here so the
+//! two feature-gated call sites can't drift.
+
+use std::sync::Arc;
+
+use assistd_config::{CompositorType, Config, compositor::detect_from_env};
+use assistd_wm::{I3Backend, NoWindowManager, SwayBackend, WindowManager, WmHandle};
+use tokio::sync::watch;
+
+/// A started window-manager backend: the trait object callers issue
+/// operations through, plus the supervisor handle used to shut it down.
+/// `handle` is `None` when no compositor backend connected, in which
+/// case `manager` is a [`NoWindowManager`] that rejects every operation.
+pub struct WmBackend {
+    pub manager: Arc<dyn WindowManager>,
+    pub handle: Option<WmHandle>,
+}
+
+impl WmBackend {
+    /// A disconnected backend: every window operation fails fast.
+    fn disconnected() -> Self {
+        Self {
+            manager: Arc::new(NoWindowManager),
+            handle: None,
+        }
+    }
+}
+
+/// Resolve the configured compositor (explicit or auto-detected) and
+/// start the matching backend.
+///
+/// Falls back to a disconnected [`WmBackend`] when no supported
+/// compositor is found or the backend fails to connect, so callers can
+/// degrade gracefully instead of aborting startup.
+pub async fn start_backend(config: &Config, shutdown_rx: watch::Receiver<bool>) -> WmBackend {
+    let resolved = match config.compositor.compositor_type {
+        CompositorType::Auto => match detect_from_env(
+            std::env::var_os("SWAYSOCK").is_some(),
+            std::env::var_os("I3SOCK").is_some(),
+            std::env::var_os("HYPRLAND_INSTANCE_SIGNATURE").is_some(),
+            std::env::var("XDG_CURRENT_DESKTOP").ok().as_deref(),
+        ) {
+            Some(c) => {
+                tracing::info!(target: "assistd::wm", "auto-detected compositor = {c:?}");
+                c
+            }
+            None => {
+                tracing::info!(
+                    target: "assistd::wm",
+                    "auto-detect found no supported compositor \
+                     (no $SWAYSOCK/$I3SOCK/$HYPRLAND_INSTANCE_SIGNATURE/$XDG_CURRENT_DESKTOP); \
+                     window operations disabled"
+                );
+                CompositorType::Auto
+            }
+        },
+        explicit => explicit,
+    };
+
+    match resolved {
+        CompositorType::I3 => match I3Backend::start(shutdown_rx).await {
+            Ok(handle) => {
+                tracing::info!(target: "assistd::wm", "i3 backend connected");
+                WmBackend {
+                    manager: handle.backend.clone(),
+                    handle: Some(WmHandle::I3(handle)),
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    target: "assistd::wm",
+                    "i3 backend unavailable ({e:#}); window operations disabled"
+                );
+                WmBackend::disconnected()
+            }
+        },
+        CompositorType::Sway => match SwayBackend::start(shutdown_rx).await {
+            Ok(handle) => {
+                tracing::info!(target: "assistd::wm", "sway backend connected");
+                WmBackend {
+                    manager: handle.backend.clone(),
+                    handle: Some(WmHandle::Sway(handle)),
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    target: "assistd::wm",
+                    "sway backend unavailable ({e:#}); window operations disabled"
+                );
+                WmBackend::disconnected()
+            }
+        },
+        CompositorType::Hyprland => {
+            tracing::info!(
+                target: "assistd::wm",
+                "hyprland backend not yet implemented; window operations disabled"
+            );
+            WmBackend::disconnected()
+        }
+        CompositorType::Auto => WmBackend::disconnected(),
+    }
+}

--- a/crates/assistd/src/wm_init.rs
+++ b/crates/assistd/src/wm_init.rs
@@ -1,8 +1,4 @@
 //! Window-manager subsystem wiring for the daemon.
-//!
-//! Thin wrapper over [`crate::wm_backend::start_backend`]: exposes the
-//! started backend as an [`Arc`]`<dyn WindowManager>` for tools plus a
-//! [`WmHandle`] for shutdown.
 
 use std::sync::Arc;
 
@@ -12,16 +8,12 @@ use tokio::sync::watch;
 
 use crate::wm_backend::{WmBackend, start_backend};
 
-/// Live handles for the window-manager subsystem, returned by [`init`].
 pub struct WindowSubsystem {
-    /// Window-manager trait object (no-op when no backend is available).
     pub manager: Arc<dyn WindowManager>,
-    /// Backend handle used to shut down the WM connection at exit.
     pub handle: Option<WmHandle>,
 }
 
 impl WindowSubsystem {
-    /// Shut down the window-manager backend gracefully.
     pub async fn shutdown(self) {
         if let Some(h) = self.handle {
             h.shutdown().await;
@@ -29,10 +21,6 @@ impl WindowSubsystem {
     }
 }
 
-/// Detect and start the appropriate window-manager backend.
-///
-/// Falls back to a no-op backend when auto-detection finds no supported
-/// compositor or when the backend fails to connect.
 pub async fn init(config: &Config, shutdown_tx: &watch::Sender<bool>) -> WindowSubsystem {
     let WmBackend { manager, handle } = start_backend(config, shutdown_tx.subscribe()).await;
     WindowSubsystem { manager, handle }

--- a/crates/assistd/src/wm_init.rs
+++ b/crates/assistd/src/wm_init.rs
@@ -1,16 +1,16 @@
 //! Window-manager subsystem wiring for the daemon.
 //!
-//! Resolves the configured compositor (auto-detect or explicit), starts
-//! the matching backend from `assistd-wm`, and produces an
-//! [`Arc<dyn WindowManager>`] for tools plus a [`WmHandle`] for shutdown.
-//! Falls back to [`NoWindowManager`] when no backend is available.
+//! Thin wrapper over [`crate::wm_backend::start_backend`]: exposes the
+//! started backend as an [`Arc`]`<dyn WindowManager>` for tools plus a
+//! [`WmHandle`] for shutdown.
 
 use std::sync::Arc;
 
-use assistd_core::{CompositorType, Config, NoWindowManager, WindowManager};
-use assistd_wm::{I3Backend, SwayBackend, WmHandle};
+use assistd_core::{Config, WindowManager};
+use assistd_wm::WmHandle;
 use tokio::sync::watch;
-use tracing::info;
+
+use crate::wm_backend::{WmBackend, start_backend};
 
 /// Live handles for the window-manager subsystem, returned by [`init`].
 pub struct WindowSubsystem {
@@ -31,73 +31,9 @@ impl WindowSubsystem {
 
 /// Detect and start the appropriate window-manager backend.
 ///
-/// Falls back to a no-op [`NoWindowManager`] when auto-detection finds
-/// no supported compositor or when the backend fails to connect.
+/// Falls back to a no-op backend when auto-detection finds no supported
+/// compositor or when the backend fails to connect.
 pub async fn init(config: &Config, shutdown_tx: &watch::Sender<bool>) -> WindowSubsystem {
-    let resolved = match config.compositor.compositor_type {
-        CompositorType::Auto => match assistd_core::config::compositor::detect_from_env(
-            std::env::var_os("SWAYSOCK").is_some(),
-            std::env::var_os("I3SOCK").is_some(),
-            std::env::var_os("HYPRLAND_INSTANCE_SIGNATURE").is_some(),
-            std::env::var("XDG_CURRENT_DESKTOP").ok().as_deref(),
-        ) {
-            Some(c) => {
-                info!("wm: auto-detected compositor = {:?}", c);
-                c
-            }
-            None => {
-                info!(
-                    "wm: auto-detect found no supported compositor (no $SWAYSOCK/$I3SOCK/$HYPRLAND_INSTANCE_SIGNATURE/$XDG_CURRENT_DESKTOP); window ops disabled"
-                );
-                CompositorType::Auto
-            }
-        },
-        explicit => explicit,
-    };
-
-    match resolved {
-        CompositorType::I3 => match I3Backend::start(shutdown_tx.subscribe()).await {
-            Ok(handle) => {
-                info!("wm: i3 backend connected");
-                WindowSubsystem {
-                    manager: handle.backend.clone(),
-                    handle: Some(WmHandle::I3(handle)),
-                }
-            }
-            Err(e) => {
-                tracing::warn!("wm: i3 backend unavailable ({e:#}); window ops disabled");
-                WindowSubsystem {
-                    manager: Arc::new(NoWindowManager),
-                    handle: None,
-                }
-            }
-        },
-        CompositorType::Sway => match SwayBackend::start(shutdown_tx.subscribe()).await {
-            Ok(handle) => {
-                info!("wm: sway backend connected");
-                WindowSubsystem {
-                    manager: handle.backend.clone(),
-                    handle: Some(WmHandle::Sway(handle)),
-                }
-            }
-            Err(e) => {
-                tracing::warn!("wm: sway backend unavailable ({e:#}); window ops disabled");
-                WindowSubsystem {
-                    manager: Arc::new(NoWindowManager),
-                    handle: None,
-                }
-            }
-        },
-        CompositorType::Hyprland => {
-            info!("wm: hyprland backend not yet implemented; window ops disabled");
-            WindowSubsystem {
-                manager: Arc::new(NoWindowManager),
-                handle: None,
-            }
-        }
-        CompositorType::Auto => WindowSubsystem {
-            manager: Arc::new(NoWindowManager),
-            handle: None,
-        },
-    }
+    let WmBackend { manager, handle } = start_backend(config, shutdown_tx.subscribe()).await;
+    WindowSubsystem { manager, handle }
 }


### PR DESCRIPTION
Refinements to tray popup GUI:
- Persistence based on whether or not voice output is enabled (persisting for the duration of the voice output)
- Changed default status glyph, added 'x' glyph to close the popup
   - Added interruption state
- Changed workspace/terminal focus to include the popup when traversing workspaces or changing terminal focus