### PR TITLE
aur: pin assistd v1.0.0 source checksum

### DIFF
--- a/dist/aur/assistd/.SRCINFO
+++ b/dist/aur/assistd/.SRCINFO
@@ -32,6 +32,6 @@ pkgbase = assistd
 	options = !lto
 	backup = etc/assistd/config.toml
 	source = assistd-1.0.0.tar.gz::https://github.com/gnolruf/assistd/archive/refs/tags/v1.0.0.tar.gz
-	sha256sums = SKIP
+	sha256sums = 6253dc8fa36c66c0d883f89346176ad59e037ce97cc0a77a0c14e5fa80aec341
 
 pkgname = assistd

--- a/dist/aur/assistd/PKGBUILD
+++ b/dist/aur/assistd/PKGBUILD
@@ -42,8 +42,7 @@ makedepends=(
 backup=('etc/assistd/config.toml')
 install=assistd.install
 source=("$pkgname-$pkgver.tar.gz::$url/archive/refs/tags/v$pkgver.tar.gz")
-# TODO: replace SKIP with `updpkgsums` output once v$pkgver is tagged upstream.
-sha256sums=('SKIP')
+sha256sums=('6253dc8fa36c66c0d883f89346176ad59e037ce97cc0a77a0c14e5fa80aec341')
 
 prepare() {
   cd "$pkgname-$pkgver"


### PR DESCRIPTION
The tarball at archive/refs/tags/v1.0.0.tar.gz now exists, so replace the placeholder sha256sums=('SKIP') with the real hash and regenerate .SRCINFO.